### PR TITLE
Fixing pagination query performance issues

### DIFF
--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.xproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.xproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/source/Nevermore.Tests/Nevermore.Tests.xproj
+++ b/source/Nevermore.Tests/Nevermore.Tests.xproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
@@ -5,5 +5,4 @@ WHERE [Id] IN
  SELECT [Id]
  FROM (SELECT t1.[Id], Row_Number() over (ORDER BY t1.[Foo]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1) RS
  WHERE RowNum >= @_minrow AND RowNum <= @_maxrow
- ORDER BY RowNum
 )

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
@@ -1,4 +1,9 @@
 SELECT *
-FROM (SELECT t1.*, Row_Number() over (ORDER BY t1.[Foo]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1) RS
-WHERE RowNum >= @_minrow And RowNum <= @_maxrow
-ORDER BY RowNum
+FROM dbo.[Orders]
+WHERE [Id] IN
+(
+ SELECT [Id]
+ FROM (SELECT t1.[Id], Row_Number() over (ORDER BY t1.[Foo]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1) RS
+ WHERE RowNum >= @_minrow AND RowNum <= @_maxrow
+ ORDER BY RowNum
+)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
@@ -1,5 +1,10 @@
 SELECT *
-FROM (SELECT t1.*, Row_Number() over (ORDER BY t1.[Id]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1
+FROM dbo.[Orders]
+WHERE [Id] IN
+(
+ SELECT [Id]
+ FROM (SELECT t1.[Id], Row_Number() over (ORDER BY t1.[Id]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1
 INNER JOIN (SELECT * FROM dbo.[Customers]) t2 ON t1.[CustomerId] = t2.[Id]) RS
-WHERE RowNum >= @_minrow And RowNum <= @_maxrow
-ORDER BY RowNum
+ WHERE RowNum >= @_minrow AND RowNum <= @_maxrow
+ ORDER BY RowNum
+)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
@@ -6,5 +6,4 @@ WHERE [Id] IN
  FROM (SELECT t1.[Id], Row_Number() over (ORDER BY t1.[Id]) as RowNum FROM (SELECT * FROM dbo.[Orders] WHERE ([Price] > 5)) t1
 INNER JOIN (SELECT * FROM dbo.[Customers]) t2 ON t1.[CustomerId] = t2.[Id]) RS
  WHERE RowNum >= @_minrow AND RowNum <= @_maxrow
- ORDER BY RowNum
 )

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -198,12 +198,10 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
             this.Assent(actual);
         }
-
-
+        
         [Test]
         public void ShouldGeneratePaginateForJoin()
         {
-
             var leftQueryBuilder = new QueryBuilder<IDocument>(transaction, "Orders", tableAliasGenerator)
                 .Where("[Price] > 5");
             var rightQueryBuilder = new QueryBuilder<IDocument>(transaction, "Customers");
@@ -230,8 +228,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
             Assert.AreEqual(expected, actual);
         }
-
-
+        
         [Test]
         public void ShouldGenerateTopForJoin()
         {

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -223,9 +223,7 @@ namespace Nevermore
         {
             return QueryGenerator.SelectQuery();
         }
-
-    
-
+        
         public IQueryBuilder<TRecord> NoLock()
         {
             Hint("NOLOCK");

--- a/source/Nevermore/SqlQueryGenerator.cs
+++ b/source/Nevermore/SqlQueryGenerator.cs
@@ -128,7 +128,6 @@ WHERE {innerColumnSelector} IN
  SELECT {innerColumnSelector}
  FROM ({select}) RS
  WHERE RowNum >= @_minrow AND RowNum <= @_maxrow
- ORDER BY RowNum
 )";
             return paginatedQuery;
         }


### PR DESCRIPTION
This fixes an issue in the pagination query that was previously using wildcards when it should be selecting on [Id] and using a subquery to improve performance (this was previously fixed in 3.4, but when we migrated to Nevermore this must have gotten lost in the merge).