### PR TITLE
Forward MaxPoolSize for use in Octopus Server.

### DIFF
--- a/source/Nevermore/IRelationalStore.cs
+++ b/source/Nevermore/IRelationalStore.cs
@@ -6,6 +6,7 @@ namespace Nevermore
     public interface IRelationalStore
     {
         string ConnectionString { get; }
+        int MaxPoolSize { get; }
         IRelationalTransaction BeginTransaction(RetriableOperation retriableOperation = RetriableOperation.Delete | RetriableOperation.Select, string name = null);
         IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel, RetriableOperation retriableOperation = RetriableOperation.Delete | RetriableOperation.Select, string name = null);
     }

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -75,6 +75,7 @@ namespace Nevermore
         }
 
         public string ConnectionString => registry.Value.ConnectionString;
+        public int MaxPoolSize => registry.Value.MaxPoolSize;
 
         public void Reset()
         {

--- a/source/Nevermore/RelationalTransactionRegistry.cs
+++ b/source/Nevermore/RelationalTransactionRegistry.cs
@@ -12,16 +12,15 @@ namespace Nevermore
         readonly ILog log = LogProvider.For<RelationalTransactionRegistry>();
 
         readonly List<RelationalTransaction> transactions = new List<RelationalTransaction>();
-        readonly int maxPoolSize;
 
         public RelationalTransactionRegistry(SqlConnectionStringBuilder connectionString)
         {
             ConnectionString = connectionString.ToString();
-            maxPoolSize = connectionString.MaxPoolSize;
+            MaxPoolSize = connectionString.MaxPoolSize;
         }
 
         public string ConnectionString { get; }
-
+        public int MaxPoolSize { get; }
 
         public void Add(RelationalTransaction trn)
         {
@@ -29,9 +28,9 @@ namespace Nevermore
             {
                 transactions.Add(trn);
                 var numberOfTransactions = transactions.Count;
-                if (numberOfTransactions > maxPoolSize * 0.8)
+                if (numberOfTransactions > MaxPoolSize * 0.8)
                     log.Debug("{numberOfTransactions} transactions active");
-                if (numberOfTransactions == maxPoolSize || numberOfTransactions == (int)(maxPoolSize * 0.9))
+                if (numberOfTransactions == MaxPoolSize || numberOfTransactions == (int)(MaxPoolSize * 0.9))
                     LogHighNumberOfTransactions();
             }
         }


### PR DESCRIPTION
This will allow us to limit `ClusterWideMutex` to 20% of the SQL Connection Pool (for example)