### PR TITLE
Provide ability to set a non-default command timeout

### DIFF
--- a/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommandFactory.cs
+++ b/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommandFactory.cs
@@ -14,9 +14,9 @@ namespace Nevermore.IntegrationTests.Chaos
             this.chaosFactor = chaosFactor;
         }
 
-        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null)
+        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null, int? commandTimeoutSeconds = null)
         {
-            return new ChaosSqlCommand(wrappedFactory.CreateCommand(connection, transaction, statement, args), chaosFactor);
+            return new ChaosSqlCommand(wrappedFactory.CreateCommand(connection, transaction, statement, args, mapping, commandTimeoutSeconds), chaosFactor);
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.xproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.xproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/source/Nevermore/IRelationalTransaction.cs
+++ b/source/Nevermore/IRelationalTransaction.cs
@@ -14,8 +14,9 @@ namespace Nevermore
         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
         /// <returns>A scalar value.</returns>
-        TResult ExecuteScalar<TResult>(string query, CommandParameters args = null);
+        TResult ExecuteScalar<TResult>(string query, CommandParameters args = null, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Executes a query that returns a data reader, and allows you to manually read the fields.
@@ -44,10 +45,20 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
         /// <returns>A stream of resulting documents.</returns>
-        IEnumerable<TDocument> ExecuteReader<TDocument>(string query, CommandParameters args);
+        IEnumerable<TDocument> ExecuteReader<TDocument>(string query, CommandParameters args, int? commandTimeoutSeconds = null);
 
-        IEnumerable<TDocument> ExecuteReaderWithProjection<TDocument>(string query, CommandParameters args, Func<IProjectionMapper, TDocument> projectionMapper);
+        /// <summary>
+        /// Executes a query that returns strongly typed documents using a custom mapper function.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        IEnumerable<TDocument> ExecuteReaderWithProjection<TDocument>(string query, CommandParameters args, Func<IProjectionMapper, TDocument> projectionMapper, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Executes a delete query (bypasses the usual OctopusModelDeletionRules checks). Only use this if you are 100% certain you can 
@@ -55,14 +66,16 @@ namespace Nevermore
         /// </summary>
         /// <param name="query">The SQL query to execute. Example: <c>DELETE FROM [Event]...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-        void ExecuteRawDeleteQuery(string query, CommandParameters args);
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        void ExecuteRawDeleteQuery(string query, CommandParameters args, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Executes a query that returns no results.
         /// </summary>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-        void ExecuteNonQuery(string query, CommandParameters args = null);
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        void ExecuteNonQuery(string query, CommandParameters args = null, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Creates a query that returns strongly typed documents.
@@ -140,7 +153,8 @@ namespace Nevermore
         /// <param name="instance">The document instance to insert.</param>
         /// <param name="customAssignedId">The ID to assign to the document.</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts multiple items into a specific table.
@@ -158,14 +172,16 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being updated.</typeparam>
         /// <param name="instance">The document to update.</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        void Update<TDocument>(TDocument instance, string tableHint = null) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        void Update<TDocument>(TDocument instance, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="instance">The document to delete.</param>
-        void Delete<TDocument>(TDocument instance) where TDocument : class;
+        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        void Delete<TDocument>(TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class;
 
         /// <summary>
         /// Commits the current pending transaction.

--- a/source/Nevermore/ISqlCommandFactory.cs
+++ b/source/Nevermore/ISqlCommandFactory.cs
@@ -6,6 +6,6 @@ namespace Nevermore
 {
     public interface ISqlCommandFactory
     {
-        IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null);
+        IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null, int? commandTimeoutSeconds = null);
     }
 }

--- a/source/Nevermore/SqlCommandFactory.cs
+++ b/source/Nevermore/SqlCommandFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using Nevermore.Mapping;
 
@@ -7,20 +8,16 @@ namespace Nevermore
     {
         public static readonly int DefaultCommandTimeoutSeconds = 60;
 
-        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null)
+        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameters args, DocumentMap mapping = null, int? commandTimeoutSeconds = null)
         {
             var command = connection.CreateCommand();
 
             try
             {
-                command.CommandTimeout = DefaultCommandTimeoutSeconds;
+                command.CommandTimeout = commandTimeoutSeconds ?? DefaultCommandTimeoutSeconds;
                 command.CommandText = statement;
                 command.Transaction = transaction;
-
-                if (args != null)
-                {
-                    args.ContributeTo(command, mapping);
-                }
+                args?.ContributeTo(command, mapping);
                 return command;
             }
             catch


### PR DESCRIPTION
The reason I'm considering this is so `ClusterWideMutex` can provide a custom (shorter) command timeout. The default of 60s doesn't provide a very good feedback cycle. This probably won't matter for many situations, but the `ClusterWideMutex` is a very special case where we expect other processes to lock on that exact record, and some of those processes could be long-running.

What would also be lovely is if we could provide cooperative cancellation support... this gets a bit harder because we'd need to use `CancellationToken.Register` and then dispose of the returned `CancellationTokenRegistration` once the `IDbCommand` has completed. This would require a signature and slight behaviour change of the `ISqlCommandFactory`.