### PR TITLE
Expose pipe delimiting logic so that it can be used elsewhere (e.g. w…

### DIFF
--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -7,13 +7,13 @@ namespace Nevermore.IntegrationTests.Model
     {
         public Customer()
         {
-            Roles = new HashSet<string>();
+            Roles = new ReferenceCollection();
         }
 
         public string Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public HashSet<string> Roles { get; private set; }
+        public ReferenceCollection Roles { get; private set; }
         public string Nickname { get; set; }
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -9,13 +9,7 @@ namespace Nevermore.IntegrationTests.Model
         {
             Column(m => m.FirstName).WithMaxLength(20);
             Column(m => m.LastName);
-            Column(m => m.Roles, map =>
-            {
-                map.ReaderWriter = new HashSetReaderWriter(map.ReaderWriter);
-                map.DbType = DbType.String;
-                map.MaxLength = int.MaxValue;
-            });
-
+            Column(m => m.Roles);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -1,18 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Text;
 using Nevermore.IntegrationTests.Model;
-using Nevermore.Mapping;
 using NUnit.Framework;
 
 namespace Nevermore.IntegrationTests
 {
     public class RelationalStoreFixture : FixtureWithRelationalStore
     {
-
-
         [Test]
         public void ShouldGenerateIdsUnlessExplicitlyAssigned()
         {
@@ -164,58 +158,4 @@ namespace Nevermore.IntegrationTests
             }
         }
     }
-
-    public class HashSetReaderWriter : PropertyReaderWriterDecorator
-    {
-        public HashSetReaderWriter(IPropertyReaderWriter<object> original)
-            : base(original)
-        {
-        }
-
-        public override object Read(object target)
-        {
-            var value = base.Read(target) as HashSet<string>;
-            if (value == null || value.Count == 0)
-                return "";
-
-            var items = new StringBuilder();
-            items.Append("|");
-            foreach (var item in value)
-            {
-                items.Append(item);
-                items.Append("|");
-            }
-            return items.ToString();
-        }
-
-        public override void Write(object target, object value)
-        {
-            var valueAsString = (value ?? string.Empty).ToString().Split('|');
-
-            var collection = base.Read(target) as HashSet<string>;
-            if (collection == null)
-            {
-                base.Write(target, collection = new HashSet<string>());
-            }
-
-            collection.ReplaceAll(valueAsString.Where(v => !string.IsNullOrWhiteSpace(v)));
-        }
-
-    }
-
-    public static class HashSetExtensions
-    {
-        public static void ReplaceAll(this HashSet<string> collection, IEnumerable<string> newItems)
-        {
-            collection.Clear();
-
-            if (newItems == null) return;
-
-            foreach (var item in newItems)
-            {
-                collection.Add(item);
-            }
-        }
-    }
-
 }

--- a/source/Nevermore/Mapping/ReferenceCollectionReaderWriter.cs
+++ b/source/Nevermore/Mapping/ReferenceCollectionReaderWriter.cs
@@ -1,4 +1,5 @@
 
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Nevermore.Mapping
@@ -15,20 +16,28 @@ namespace Nevermore.Mapping
             if (value == null || value.Count == 0)
                 return "";
 
-            return $"|{string.Join("|", value)}| ";
+            return UnParse(value);
         }
 
         public override void Write(object target, object value)
         {
-            var valueAsString = (value ?? string.Empty).ToString().Split('|');
-
             var collection = base.Read(target) as ReferenceCollection;
             if (collection == null)
             {
                 base.Write(target, collection = new ReferenceCollection());
             }
 
-            collection.ReplaceAll(valueAsString.Where(item => !string.IsNullOrWhiteSpace(item)));
+            collection.ReplaceAll(Parse(value?.ToString()));
+        }
+
+        public static IEnumerable<string> Parse(string value)
+        {
+            return (value ?? string.Empty).Split('|').Where(item => !string.IsNullOrWhiteSpace(item));
+        }
+
+        public static string UnParse(IEnumerable<string> items)
+        {
+            return $"|{string.Join("|", items)}| ";
         }
     }
 }


### PR DESCRIPTION
…hen trying to access the raw columns in db update scripts).

Also didnt seem like the HashSetReaderWriter is really needed since its covered by the existing one for referencecollections