### PR TITLE
Use a static ILog instance for perf

### DIFF
--- a/source/Nevermore/RelationalTransactionRegistry.cs
+++ b/source/Nevermore/RelationalTransactionRegistry.cs
@@ -9,7 +9,8 @@ namespace Nevermore
 {
     public class RelationalTransactionRegistry
     {
-        readonly ILog log = LogProvider.For<RelationalTransactionRegistry>();
+        // Getting a typed ILog causes JIT compilation - we should only do this once
+        static readonly ILog Log = LogProvider.For<RelationalTransactionRegistry>();
 
         readonly List<RelationalTransaction> transactions = new List<RelationalTransaction>();
         bool highNumberAlreadyLoggedAtError;
@@ -30,7 +31,7 @@ namespace Nevermore
                 transactions.Add(trn);
                 var numberOfTransactions = transactions.Count;
                 if (numberOfTransactions > MaxPoolSize * 0.8)
-                    log.Info("{numberOfTransactions} transactions active");
+                    Log.Info("{numberOfTransactions} transactions active");
 
                 if (numberOfTransactions >= MaxPoolSize || numberOfTransactions == (int)(MaxPoolSize * 0.9))
                     LogHighNumberOfTransactions(numberOfTransactions >= MaxPoolSize);
@@ -48,12 +49,12 @@ namespace Nevermore
             if (reachedMax && !highNumberAlreadyLoggedAtError)
             {
                 highNumberAlreadyLoggedAtError = true;
-                log.Error(BuildHighNumberOfTransactionsMessage());
+                Log.Error(BuildHighNumberOfTransactionsMessage());
                 return;
             }
 
-            if (log.IsDebugEnabled())
-                log.Debug(BuildHighNumberOfTransactionsMessage());
+            if (Log.IsDebugEnabled())
+                Log.Debug(BuildHighNumberOfTransactionsMessage());
         }
 
         string BuildHighNumberOfTransactionsMessage()

--- a/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
+++ b/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
@@ -8,7 +8,8 @@ namespace Nevermore.Transient
 {
     sealed class SqlDatabaseTransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
     {
-        private ILog log = LogProvider.For<SqlDatabaseTransientErrorDetectionStrategy>();
+        // Getting a typed ILog causes JIT compilation - we should only do this once
+        static readonly ILog Log = LogProvider.For<SqlDatabaseTransientErrorDetectionStrategy>();
 
         static readonly int[] SimpleTransientErrorCodes = { 20, 64, 233, 10053, 10054, 10060, 10928, 10929, 40143, 40197, 40540, 40613 };
 
@@ -32,7 +33,7 @@ namespace Nevermore.Transient
             var sqlConnectionErrors = sqlErrors.Where(e => e.Message.Contains("requires an open and available Connection") || e.Message.Contains("broken and recovery is not possible")).ToList();
             if (sqlConnectionErrors.Any())
             {
-                log.Info($"Connection error detected. SQL Error code(s) {string.Join(", ", sqlConnectionErrors.Select(e => e.Number))}");
+                Log.Info($"Connection error detected. SQL Error code(s) {string.Join(", ", sqlConnectionErrors.Select(e => e.Number))}");
             }
 
             // Otherwise it could be another simple transient error


### PR DESCRIPTION
Profiling shows a high JIT cost to creating a new typed-ILog instance per dependency. The logging framework itself is thread-safe so we should just use a static typed-ILog instance.