### PR TITLE
Roll contracts dependency back to netstandard1.2

### DIFF
--- a/source/Nevermore.Contracts/Nevermore.Contracts.csproj
+++ b/source/Nevermore.Contracts/Nevermore.Contracts.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A JSON Document Store library for SQL Server</Description>
     <Authors>Octopus Deploy</Authors>
-    <TargetFrameworks>netstandard1.5;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.2;net451</TargetFrameworks>
     <AssemblyName>Nevermore.Contracts</AssemblyName>
     <PackageId>Nevermore.Contracts</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>


### PR DESCRIPTION
1.5 was causing issues with referencing the package in ODCM