### PR TITLE
Normalize spaces in parameter names

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -602,6 +602,33 @@ namespace Nevermore.Tests.QueryBuilderFixture
         }
 
         [Fact]
+        public void ShouldGetCorrectSqlQueryForWhereInUsingWhereList()
+        {
+            var matches = new List<State>
+            {
+                State.Queued,
+                State.Running
+            };
+            const string expectedSql = "SELECT * FROM dbo.[Project] WHERE ([State] IN (@queued, @running)) ORDER BY [Id]";
+            var queryBuilder = new QueryBuilder<IDocument>(transaction, "Project")
+                .Where("State", SqlOperand.In, matches);
+
+            queryBuilder.DebugViewRawQuery().Should().Be(expectedSql);
+        }
+
+        [Fact]
+        public void ShouldGetCorrectSqlQueryForWhereInWithSpaces()
+        {
+            const string expectedSql = "SELECT * FROM dbo.[Project] WHERE ([Foo] IN (@bar_1, @bar_2)) ORDER BY [Id]";
+
+            var queryBuilder = new QueryBuilder<IDocument>(transaction, "Project")
+                .Where("Foo", SqlOperand.In, new[] { "Bar 1", "Bar 2" });
+
+            queryBuilder.DebugViewRawQuery().Should().Be(expectedSql);
+        }
+
+
+        [Fact]
         public void ShouldGetCorrectSqlQueryForWhereInExtension()
         {
             const string expectedSql = "SELECT COUNT(*) FROM dbo.[TodoItem] WHERE ([Title] IN (@nevermore, @octofront))";

--- a/source/Nevermore/SqlQueryGenerator.cs
+++ b/source/Nevermore/SqlQueryGenerator.cs
@@ -204,7 +204,10 @@ WHERE {innerColumnSelector} IN
         // https://blogs.msdn.microsoft.com/debuggingtoolbox/2008/04/02/comparing-regex-replace-string-replace-and-stringbuilder-replace-which-has-better-performance/
         static string Normalise(string value)
         {
-            return value.Replace('-', '_').ToLower();
+            return value
+                .Replace('-', '_')
+                .Replace(' ', '_')
+                .ToLower();
         }
 
         public void AddWhere(WhereParameter whereParams, object startValue, object endValue)


### PR DESCRIPTION
IN queries will add parameter names with spaces  eg `@foo 1` which will break the query.  This normalizes spaces in parameter names.