### PR TITLE
Moved ReferenceCollection to Nevermore.Contracts

### DIFF
--- a/source/Nevermore.Contracts/ReferenceCollection.cs
+++ b/source/Nevermore.Contracts/ReferenceCollection.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Nevermore
+namespace Nevermore.Contracts
 {
     /// <summary>
     /// A case-insensitive collection of unique strings used for holding document ID's.

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Reflection;
+using Nevermore.Contracts;
 
 namespace Nevermore.Mapping
 {

--- a/source/Nevermore/Mapping/DatabaseTypeConverter.cs
+++ b/source/Nevermore/Mapping/DatabaseTypeConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
+using Nevermore.Contracts;
 
 namespace Nevermore.Mapping
 {

--- a/source/Nevermore/Mapping/ReferenceCollectionReaderWriter.cs
+++ b/source/Nevermore/Mapping/ReferenceCollectionReaderWriter.cs
@@ -1,6 +1,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Nevermore.Contracts;
 
 namespace Nevermore.Mapping
 {


### PR DESCRIPTION
This change was originally slated for the ODCM changes, but we're aiming to release the user changes in 3.X

Update is primarily so Octopus.Data can use ReferenceCollection in IUser.