### PR TITLE
Add support for serializing nested mapped objects

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -83,7 +83,7 @@ namespace Nevermore.IntegrationTests
                 ? (ISqlCommandFactory)new ChaosSqlCommandFactory(new SqlCommandFactory(), chaosFactor)
                 : new SqlCommandFactory();
 
-            return new RelationalStore(connectionString ?? TestDatabaseConnectionString, TestDatabaseName, sqlCommandFactory, Mappings, new JsonSerializerSettings(), new EmptyRelatedDocumentStore());
+            return new RelationalStore(connectionString ?? TestDatabaseConnectionString, TestDatabaseName, sqlCommandFactory, Mappings, new JsonSerializerSettings { ContractResolver = new RelationalJsonContractResolver(Mappings)}, new EmptyRelatedDocumentStore());
         }
 
         void InstallSchema()

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -18,5 +18,7 @@ namespace Nevermore.IntegrationTests.Model
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }
         public string[] Passphrases { get; set; }
+
+        public Customer ParentCustomer { get; set; }
     }
 }

--- a/source/Nevermore/RelationalJsonContractResolver.cs
+++ b/source/Nevermore/RelationalJsonContractResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Nevermore.Mapping;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -8,32 +9,19 @@ namespace Nevermore
 {
     public class RelationalJsonContractResolver : DefaultContractResolver
     {
-        private RelationalMappings mappings;
+        public RelationalJsonContractResolver()
+        {
+        }
 
+        [Obsolete("Using this is no longer necessary, call the default constructor")]
         public RelationalJsonContractResolver(RelationalMappings mappings)
         {
-            this.mappings = mappings;
         }
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
-            DocumentMap map;
-            mappings.TryGet(member.DeclaringType, out map);
-
             var property = base.CreateProperty(member, memberSerialization);
-
-            // ID properties are stored as columns
-            if (property.PropertyName == "Id" && map != null)
-            {
-                property.Ignored = true;
-            }
-
-            // Indexed properties are stored as columns
-            if (map != null && map.IndexedColumns.Any(c => c.Property != null && c.Property.Name == member.Name))
-            {
-                property.Ignored = true;
-            }
-
+            
             if (!property.Writable)
             {
                 var property2 = member as PropertyInfo;


### PR DESCRIPTION
In Octofront we have a class called `Discount`. It's a document, stored in a table that defines what discounts are available.

We also use the same class when we apply a discount, by adding it to an `Order` (`Order.Discounts` collection). 

In Nevermore, properties like the Id and those which are mapped to a table column are hidden from the serialized JSON - we don't want values to be written once to the table column, and then again in the JSON. 

This was acheived in `RelationalJsonContractResolver` by excluding properties that are Id's or marked as indexed. Unfortunately, the contract resolver applies in situations where the type is being serialized as the root of the graph, as well as when it is a nested object deep in the graph. 

In our case, it meant properties on the Discount that was applied to an Order wouldn't be serialized if they were also indexed. 

I've fixed it by serializing everything, but then having `RelationalTransaction` remove the properties (on the root object only) before writing them to the database.

Some side effects to be aware of:

 - Serialization when inserting/updating new objects could be slightly slower (since we now create a JObject graph on the way). Perhaps a smarter way would be a `JsonWriter` wrapper that ignores property writes for indexed columns?
 - If a property is both indexed and given a custom property name with `[JsonProperty]` it will still appear in the JSON. 