### PR TITLE
allow subclasses from column data, as well as JSON

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -68,10 +68,12 @@ namespace Nevermore.IntegrationTests
         void InitializeStore()
         {
             Mappings = new RelationalMappings();
+
             Mappings.Install(new List<DocumentMap>()
             {
                 new CustomerMap(),
-                new ProductMap(),
+                new ProductMap<Product>(),
+                new SpecialProductMap(),
                 new LineItemMap()
             });
             Store = BuildRelationalStore(TestDatabaseConnectionString, 0.01);
@@ -95,10 +97,14 @@ namespace Nevermore.IntegrationTests
             var output = new StringBuilder();
             SchemaGenerator.WriteTableSchema(new CustomerMap(), null, output);
 
+            // needed for products, but not to generate the table
+            Mappings.Install(new List<DocumentMap>() { new ProductMap<Product>() });
+
+            // needed to generate the table
             var mappings = new DocumentMap[]
             {
                 new CustomerMap(),
-                new ProductMap(),
+                new SpecialProductMap(),
                 new LineItemMap()
             };
 

--- a/source/Nevermore.IntegrationTests/Model/ProductMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/ProductMap.cs
@@ -5,7 +5,7 @@ using Nevermore.Mapping;
 
 namespace Nevermore.IntegrationTests.Model
 {
-    public class ProductMap : DocumentMap<Product>
+    public class ProductMap<TProduct> : DocumentMap<TProduct> where TProduct : Product
     {
         static readonly Dictionary<ProductType, Type> SubTypeMappings = new Dictionary<ProductType, Type>
         {
@@ -16,9 +16,19 @@ namespace Nevermore.IntegrationTests.Model
 
         public ProductMap()
         {
-            
+
             Column(m => m.Name);
             TypeDiscriminatorColumn(m => m.Type, SubTypeMappings);
+        }
+    }
+
+        public class SpecialProductMap : ProductMap<SpecialProduct>
+    {
+
+        public SpecialProductMap()
+        {
+            TableName = typeof(Product).Name;
+            Column(m => m.BonusMaterial).IsNullable = true;
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -121,7 +121,7 @@ namespace Nevermore.IntegrationTests
 
             using (var transaction = Store.BeginTransaction())
             {
-                var lines = transaction.ExecuteReaderWithProjection("SELECT line.Id as line_id, line.Name as line_name, line.PurchaseDate as line_PurchaseDate, line.ProductId as line_productid, line.JSON as line_json, prod.Id as prod_id, prod.Name as prod_name, prod.JSON as prod_json, prod.Type as prod_type from LineItem line inner join Product prod on prod.Id = line.ProductId", new CommandParameters(), map => new
+                var lines = transaction.ExecuteReaderWithProjection("SELECT line.Id as line_id, line.Name as line_name, line.PurchaseDate as line_PurchaseDate, line.ProductId as line_productid, line.JSON as line_json, prod.Id as prod_id, prod.Name as prod_name, prod.BonusMaterial as prod_bonusmaterial, prod.JSON as prod_json, prod.Type as prod_type from LineItem line inner join Product prod on prod.Id = line.ProductId", new CommandParameters(), map => new
                 {
                     LineItem = map.Map<LineItem>("line"),
                     Product = map.Map<Product>("prod")

--- a/source/Nevermore/Mapping/SubTypedResolver.cs
+++ b/source/Nevermore/Mapping/SubTypedResolver.cs
@@ -64,10 +64,7 @@ namespace Nevermore.Mapping
         public override Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal)
         {
             var colIndex = columnOrdinal(column.ColumnName);
-            return reader => GetType(
-                0 <= colIndex && colIndex < reader.FieldCount 
-                ? reader[colIndex].ToString() 
-                : "");
+            return reader => GetType(reader[colIndex].ToString());
         }
 
         Type GetType(string value)

--- a/source/Nevermore/Mapping/SubTypedResolver.cs
+++ b/source/Nevermore/Mapping/SubTypedResolver.cs
@@ -64,7 +64,10 @@ namespace Nevermore.Mapping
         public override Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal)
         {
             var colIndex = columnOrdinal(column.ColumnName);
-            return reader => GetType(reader[colIndex].ToString());
+            return reader => GetType(
+                0 <= colIndex && colIndex < reader.FieldCount 
+                ? reader[colIndex].ToString() 
+                : "");
         }
 
         Type GetType(string value)


### PR DESCRIPTION
Means that subtype mappings can pull from different columns as well as JSON, so allowing document hierarchies that pull from different bits of the table as well as different bits of JSON.

 