### PR TITLE
Fix a couple problems when using InnerJoin and LeftHashJoin

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoinsWithParameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoinsWithParameter.approved.txt
@@ -1,0 +1,19 @@
+SELECT ALIAS_GENERATED_2.*
+FROM (
+    SELECT *
+    FROM dbo.[Orders]
+    WHERE ([CustomerId] = @customerid_0)
+) ALIAS_GENERATED_2
+INNER JOIN (
+    SELECT *
+    FROM dbo.[Customers]
+    WHERE ([Name] = @name_1)
+) ALIAS_GENERATED_1
+ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_GENERATED_1.[Id]
+INNER JOIN (
+    SELECT *
+    FROM dbo.[Accounts]
+    WHERE ([Name] = @name_2)
+) ALIAS_GENERATED_3
+ON ALIAS_GENERATED_2.[AccountId] = ALIAS_GENERATED_3.[Id]
+ORDER BY ALIAS_GENERATED_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsSubQueryWithPrameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsSubQueryWithPrameter.approved.txt
@@ -1,0 +1,15 @@
+SELECT ALIAS_Orders_2.*
+FROM dbo.[Orders] ALIAS_Orders_2
+LEFT HASH JOIN (
+    SELECT *
+    FROM dbo.[Account]
+    WHERE ([Name] = @name_0)
+) ALIAS_GENERATED_1
+ON ALIAS_Orders_2.[AccountId] = ALIAS_GENERATED_1.[Id]
+LEFT HASH JOIN (
+    SELECT *
+    FROM dbo.[Company]
+    WHERE ([Name] = @name_1)
+) ALIAS_GENERATED_3
+ON ALIAS_Orders_2.[CompanyId] = ALIAS_GENERATED_3.[CompanyId]
+ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsWithTableAndSubQueryWithPrameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsWithTableAndSubQueryWithPrameter.approved.txt
@@ -1,0 +1,11 @@
+SELECT ALIAS_Orders_2.*
+FROM dbo.[Orders] ALIAS_Orders_2
+LEFT HASH JOIN dbo.[Account] ALIAS_Account_1
+ON ALIAS_Orders_2.[AccountId] = ALIAS_Account_1.[Id]
+LEFT HASH JOIN (
+    SELECT *
+    FROM dbo.[Company]
+    WHERE ([Name] = @name_0)
+) ALIAS_GENERATED_3
+ON ALIAS_Orders_2.[CompanyId] = ALIAS_GENERATED_3.[CompanyId]
+ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -1075,6 +1075,36 @@ ORDER BY [Title] DESC";
         }
 
         [Fact]
+        public void ShouldGenerateWithMultipleLeftHashJoinsSubQueryWithPrameter()
+        {
+            var account = CreateQueryBuilder<IDocument>("Account").Where("Name", UnarySqlOperand.Equal, "Octopus 1");
+            var company = CreateQueryBuilder<IDocument>("Company").Where("Name", UnarySqlOperand.Equal, "Octopus 2");
+            var actual = CreateQueryBuilder<IDocument>("Orders")
+                .LeftHashJoin(account.Subquery())
+                .On("AccountId", JoinOperand.Equal, "Id")
+                .LeftHashJoin(company.Subquery())
+                .On("CompanyId", JoinOperand.Equal, "CompanyId")
+                .DebugViewRawQuery();
+
+            this.Assent(actual);
+        }
+
+        [Fact]
+        public void ShouldGenerateWithMultipleLeftHashJoinsWithTableAndSubQueryWithPrameter()
+        {
+            var account = CreateQueryBuilder<IDocument>("Account");
+            var company = CreateQueryBuilder<IDocument>("Company").Where("Name", UnarySqlOperand.Equal, "Octopus");
+            var actual = CreateQueryBuilder<IDocument>("Orders")
+                .LeftHashJoin(account)
+                .On("AccountId", JoinOperand.Equal, "Id")
+                .LeftHashJoin(company.Subquery())
+                .On("CompanyId", JoinOperand.Equal, "CompanyId")
+                .DebugViewRawQuery();
+
+            this.Assent(actual);
+        }
+
+        [Fact]
         public void ShouldGenerateMultipleJoinTypes()
         {
             var customers = CreateQueryBuilder<Customer>("Customers")

--- a/source/Nevermore/QueryBuilderJoinExtensions.cs
+++ b/source/Nevermore/QueryBuilderJoinExtensions.cs
@@ -42,14 +42,34 @@ namespace Nevermore
         /// Adds a left hash join to the query.
         /// The query that has been built up so far in the left hand side query builder may be converted to a subquery to capture more complex modifications, such as where clauses.
         /// </summary>
-        /// <typeparam name="TRecord">The record type of the query builder</typeparam>
+        /// <typeparam name="TRecordLeft">The record type of the left hand side query builder</typeparam>
+        /// <typeparam name="TRecordRight">The record type of the right hand side query builder</typeparam>
         /// <param name="queryBuilder">The query builder which represents the left hand side of the join</param>
-        /// <param name="source">The source which represents the right hand side of the join</param>
+        /// <param name="rightHandQueryBuilder">The query builder which represents the right hand side of the join</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        public static IJoinSourceQueryBuilder<TRecord> LeftHashJoin<TRecord>(this IQueryBuilder<TRecord> queryBuilder,
-            IAliasedSelectSource source) where TRecord : class
+        public static IJoinSourceQueryBuilder<TRecordLeft> LeftHashJoin<TRecordLeft, TRecordRight>(this IQueryBuilder<TRecordLeft> queryBuilder,
+            ITableSourceQueryBuilder<TRecordRight> rightHandQueryBuilder)
+            where TRecordLeft : class
+            where TRecordRight : class
         {
-            return queryBuilder.Join(source, JoinType.LeftHashJoin, queryBuilder.ParameterValues, queryBuilder.Parameters, queryBuilder.ParameterDefaults);
+            return queryBuilder.Join(rightHandQueryBuilder.AsAliasedSource(), JoinType.LeftHashJoin, rightHandQueryBuilder.ParameterValues, rightHandQueryBuilder.Parameters, rightHandQueryBuilder.ParameterDefaults);
+        }
+
+        /// <summary>
+        /// Adds a left hash join to the query.
+        /// The query that has been built up so far in the left hand side query builder may be converted to a subquery to capture more complex modifications, such as where clauses.
+        /// </summary>
+        /// <typeparam name="TRecordLeft">The record type of the left hand side query builder</typeparam>
+        /// <typeparam name="TRecordRight">The record type of the right hand side query builder</typeparam>
+        /// <param name="queryBuilder">The query builder which represents the left hand side of the join</param>
+        /// <param name="rightHandQueryBuilder">The query builder which represents the right hand side of the join</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        public static IJoinSourceQueryBuilder<TRecordLeft> LeftHashJoin<TRecordLeft, TRecordRight>(this IQueryBuilder<TRecordLeft> queryBuilder,
+            ISubquerySourceBuilder<TRecordRight> rightHandQueryBuilder)
+            where TRecordLeft : class
+            where TRecordRight : class
+        {
+            return queryBuilder.Join(rightHandQueryBuilder.AsSource(), JoinType.LeftHashJoin, rightHandQueryBuilder.ParameterValues, rightHandQueryBuilder.Parameters, rightHandQueryBuilder.ParameterDefaults);
         }
     }
 }

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -100,6 +100,11 @@ namespace Nevermore
             clauses = new List<JoinClause>();
             joinSource = source;
             type = joinType;
+
+            ParamValues.AddRange(parameterValues);
+            Params.AddRange(parameters);
+            ParamDefaults.AddRange(parameterDefaults);
+
             return this;
         }
 

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -101,9 +101,16 @@ namespace Nevermore
             joinSource = source;
             type = joinType;
 
-            ParamValues.AddRange(parameterValues);
-            Params.AddRange(parameters);
-            ParamDefaults.AddRange(parameterDefaults);
+            var commandParameterValues = new CommandParameterValues(ParamValues, parameterValues);
+            var combinedParameters = new Parameters(Params, parameters);
+            var combinedParameterDefaults = new ParameterDefaults(ParamDefaults, parameterDefaults);
+
+            ParamValues.Clear();
+            ParamValues.AddRange(commandParameterValues);
+            Params.Clear();
+            Params.AddRange(combinedParameters);
+            ParamDefaults.Clear();
+            ParamDefaults.AddRange(combinedParameterDefaults);
 
             return this;
         }


### PR DESCRIPTION
## Problem
- Parameters from the subsequence `InnerJoin` source are ignored if a query has more than 1 `InnerJoin` clauses
- `LeftHashJoin` pass the same parameters from itself rather than from the right hand side query

## Solution for problem 1
- Add the parameters into the query builder from the right hand side query

## Solution for problem 2
LeftHashJoin in the version prior this PR took `IAliasedSelectSource` as the right hand side for join. In this case we lose the ability to pass its parameters to form a new `IQueryBuilder`, thought that sometimes we might not have any parameter. As we updated the `JoinSourceQueryBuilder` in solution 1, it accidentally trigger a bug where `LeftHashJoin` pass the parameters from itself to form a new `IQueryBuilder`. So using `IAliasedSelectSource` is very error prone as it only works if the left hand side query has no parameter.

In order to make it a bit more flexible, `LeftHashJoin` in this PR uses the same approach as `InnerJoin` which takes `ISubquerySourceBuilder` or `ITableSourceQueryBuilder` as input parameters, so that we can pass its parameters down to form a new `IQueryBuilder`
