### PR TITLE
Store the table name instead of the document type

### DIFF
--- a/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
@@ -18,21 +18,21 @@ namespace Nevermore.IntegrationTests
             new RelatedDocumentRow
             {
                 Id = "ExistingOrder-1",
-                Type = "Order",
+                Table = "Order",
                 RelatedDocumentId = "Product-1",
                 RelatedDocumentType = "Product"
             },
             new RelatedDocumentRow
             {
                 Id = "ExistingOrder-1",
-                Type = "Order",
+                Table = "Order",
                 RelatedDocumentId = "Product-2",
                 RelatedDocumentType = "Product"
             },
             new RelatedDocumentRow
             {
                 Id = "ExistingOrder-2",
-                Type = "Order",
+                Table = "Order",
                 RelatedDocumentId = "Product-1",
                 RelatedDocumentType = "Product"
             }
@@ -46,7 +46,7 @@ namespace Nevermore.IntegrationTests
             using (var trn = Store.BeginTransaction())
             {
                 foreach (var item in StartingRecords)
-                    trn.ExecuteNonQuery($"INSERT INTO [{DocumentMap.DefaultRelatedDocumentTableName}] VALUES ('{item.Id}', '{item.Type}', '{item.RelatedDocumentId}', '{item.RelatedDocumentType}')");
+                    trn.ExecuteNonQuery($"INSERT INTO [{DocumentMap.DefaultRelatedDocumentTableName}] VALUES ('{item.Id}', '{item.Table}', '{item.RelatedDocumentId}', '{item.RelatedDocumentType}')");
 
                 trn.Commit();
             }
@@ -127,7 +127,7 @@ namespace Nevermore.IntegrationTests
             var expected = referenceIds.Select(r => new RelatedDocumentRow()
             {
                 Id = orderId,
-                Type = "Order",
+                Table = "Order",
                 RelatedDocumentId = r,
                 RelatedDocumentType = "Product"
             });
@@ -248,9 +248,9 @@ namespace Nevermore.IntegrationTests
                     => new RelatedDocumentRow
                     {
                         Id = (string) reader[map.IdColumnName],
-                        Type = (string) reader[map.IdTypeColumnName],
+                        Table = (string) reader[map.IdTableColumnName],
                         RelatedDocumentId = (string) reader[map.RelatedDocumentIdColumnName],
-                        RelatedDocumentType = (string) reader[map.RelatedDocumentTypeColumnName],
+                        RelatedDocumentType = (string) reader[map.RelatedDocumentTableColumnName],
                     };
 
             using (var trn = Store.BeginTransaction())
@@ -267,7 +267,7 @@ namespace Nevermore.IntegrationTests
         public class RelatedDocumentRow : IEquatable<RelatedDocumentRow>
         {
             public string Id { get; set; }
-            public string Type { get; set; }
+            public string Table { get; set; }
             public string RelatedDocumentId { get; set; }
             public string RelatedDocumentType { get; set; }
 
@@ -275,7 +275,7 @@ namespace Nevermore.IntegrationTests
             {
                 if (ReferenceEquals(null, other)) return false;
                 if (ReferenceEquals(this, other)) return true;
-                var eq = string.Equals(Id, other.Id) && string.Equals(Type, other.Type) && string.Equals(RelatedDocumentId, other.RelatedDocumentId) && string.Equals(RelatedDocumentType, other.RelatedDocumentType);
+                var eq = string.Equals(Id, other.Id) && string.Equals(Table, other.Table) && string.Equals(RelatedDocumentId, other.RelatedDocumentId) && string.Equals(RelatedDocumentType, other.RelatedDocumentType);
                 return eq;
             }
 
@@ -292,7 +292,7 @@ namespace Nevermore.IntegrationTests
                 unchecked
                 {
                     var hashCode = Id.GetHashCode();
-                    hashCode = (hashCode * 397) ^ Type.GetHashCode();
+                    hashCode = (hashCode * 397) ^ Table.GetHashCode();
                     hashCode = (hashCode * 397) ^ RelatedDocumentId.GetHashCode();
                     hashCode = (hashCode * 397) ^ RelatedDocumentType.GetHashCode();
                     return hashCode;

--- a/source/Nevermore.IntegrationTests/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SchemaGenerator.cs
@@ -36,9 +36,9 @@ namespace Nevermore.IntegrationTests
                 result.AppendLine($"IF NOT EXISTS (SELECT name from sys.tables WHERE name = '{refTblName}')");
                 result.AppendLine($"    CREATE TABLE [{refTblName}] (");
                 result.AppendLine($"        [{referencedDocumentMap.IdColumnName}] nvarchar(50) NOT NULL,");
-                result.AppendLine($"        [{referencedDocumentMap.IdTypeColumnName}] nvarchar(50) NOT NULL,");
+                result.AppendLine($"        [{referencedDocumentMap.IdTableColumnName}] nvarchar(50) NOT NULL,");
                 result.AppendLine($"        [{referencedDocumentMap.RelatedDocumentIdColumnName}] nvarchar(50) NOT NULL,");
-                result.AppendLine($"        [{referencedDocumentMap.RelatedDocumentTypeColumnName}] nvarchar(50) NOT NULL ");
+                result.AppendLine($"        [{referencedDocumentMap.RelatedDocumentTableColumnName}] nvarchar(50) NOT NULL ");
                 result.AppendLine("    )");
             }
         }

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
@@ -1,2 +1,2 @@
-DELETE FROM [TestDocument] WHERE [Id] = @Id
+DELETE FROM [TestDocumentTbl] WHERE [Id] = @Id
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
@@ -1,2 +1,3 @@
-DELETE FROM [TestDocumentTbl] WHERE [Id] = @Id
+DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
@@ -1,11 +1,5 @@
-DECLARE @Ids as TABLE (Id nvarchar(400))
-
-INSERT INTO @Ids
-SELECT [Id]
-FROM [TestDocumentTbl]
-WHERE [Id] = @Id
-
-DELETE FROM [RelatedDocument] WHERE [Id] in (SELECT Id FROM @Ids)
-DELETE FROM [TestDocumentTbl] WHERE [Id] in (SELECT Id FROM @Ids)
+DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [RelatedDocument] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [OtherRelatedTable] WITH (ROWLOCK) WHERE [Id] = @Id
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
@@ -2,10 +2,10 @@ DECLARE @Ids as TABLE (Id nvarchar(400))
 
 INSERT INTO @Ids
 SELECT [Id]
-FROM [TestDocument]
+FROM [TestDocumentTbl]
 WHERE [Id] = @Id
 
 DELETE FROM [RelatedDocument] WHERE [Id] in (SELECT Id FROM @Ids)
-DELETE FROM [TestDocument] WHERE [Id] in (SELECT Id FROM @Ids)
+DELETE FROM [TestDocumentTbl] WHERE [Id] in (SELECT Id FROM @Ids)
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
@@ -1,11 +1,4 @@
-DECLARE @Ids as TABLE (Id nvarchar(400))
-
-INSERT INTO @Ids
-SELECT [Id]
-FROM [TestDocumentTbl]
-WHERE [Id] = @Id
-
-DELETE FROM [RelatedDocument] WHERE [Id] in (SELECT Id FROM @Ids)
-DELETE FROM [TestDocumentTbl] WHERE [Id] in (SELECT Id FROM @Ids)
+DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [RelatedDocument] WITH (ROWLOCK) WHERE [Id] = @Id
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
@@ -2,10 +2,10 @@ DECLARE @Ids as TABLE (Id nvarchar(400))
 
 INSERT INTO @Ids
 SELECT [Id]
-FROM [TestDocument]
+FROM [TestDocumentTbl]
 WHERE [Id] = @Id
 
 DELETE FROM [RelatedDocument] WHERE [Id] in (SELECT Id FROM @Ids)
-DELETE FROM [TestDocument] WHERE [Id] in (SELECT Id FROM @Ids)
+DELETE FROM [TestDocumentTbl] WHERE [Id] in (SELECT Id FROM @Ids)
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
@@ -1,2 +1,2 @@
-DELETE FROM [TestDocument] WHERE [Id] = @Id
+DELETE FROM [TestDocumentTbl] WHERE [Id] = @Id
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
@@ -1,2 +1,3 @@
-DELETE FROM [TestDocumentTbl] WHERE [Id] = @Id
+DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByWhere.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByWhere.approved.txt
@@ -1,2 +1,2 @@
-DELETE FROM [TestDocument] 
+DELETE FROM [TestDocumentTbl] 
 WHERE [Foo] > @1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,12 +1,12 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@0__AColumn, @0__Id, @0__JSON)
 ,(@1__AColumn, @1__Id, @1__JSON)
 ,(@2__AColumn, @2__Id, @2__JSON)
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType]) VALUES
-(@0__Id, 'TestDocument', @relateddocument_0, 'Other')
-,(@0__Id, 'TestDocument', @relateddocument_1, 'Other')
-,(@2__Id, 'TestDocument', @relateddocument_2, 'Other')
-,(@2__Id, 'TestDocument', @relateddocument_3, 'Other')
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
+(@0__Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
+,(@0__Id, 'TestDocumentTbl', @relateddocument_1, 'OtherTbl')
+,(@2__Id, 'TestDocumentTbl', @relateddocument_2, 'OtherTbl')
+,(@2__Id, 'TestDocumentTbl', @relateddocument_3, 'OtherTbl')
 
 @0__Id=New-Id-1
 @0__JSON={"Id":null,"AColumn":"Doc1"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
@@ -3,8 +3,6 @@ INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES
 INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
 ,(@Id, 'TestDocumentTbl', @relateddocument_1, 'OtherTbl')
-,(@Id, 'TestDocumentTbl', @relateddocument_2, 'OtherTbl')
-,(@Id, 'TestDocumentTbl', @relateddocument_3, 'OtherTbl')
 INSERT INTO [OtherRelatedTable] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @otherrelatedtable_0, 'OtherTbl')
 ,(@Id, 'TestDocumentTbl', @otherrelatedtable_1, 'OtherTbl')
@@ -14,7 +12,5 @@ INSERT INTO [OtherRelatedTable] ([Id], [Table], [RelatedDocumentId], [RelatedDoc
 @AColumn=Doc1
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2
-@relateddocument_2=Rel-2
-@relateddocument_3=Rel-2
 @otherrelatedtable_0=Rel-3-Other
 @otherrelatedtable_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
@@ -1,13 +1,13 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType]) VALUES
-(@Id, 'TestDocument', @relateddocument_0, 'Other')
-,(@Id, 'TestDocument', @relateddocument_1, 'Other')
-,(@Id, 'TestDocument', @relateddocument_2, 'Other')
-,(@Id, 'TestDocument', @relateddocument_3, 'Other')
-INSERT INTO [OtherRelatedTable] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType]) VALUES
-(@Id, 'TestDocument', @otherrelatedtable_0, 'Other')
-,(@Id, 'TestDocument', @otherrelatedtable_1, 'Other')
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
+(@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
+,(@Id, 'TestDocumentTbl', @relateddocument_1, 'OtherTbl')
+,(@Id, 'TestDocumentTbl', @relateddocument_2, 'OtherTbl')
+,(@Id, 'TestDocumentTbl', @relateddocument_3, 'OtherTbl')
+INSERT INTO [OtherRelatedTable] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
+(@Id, 'TestDocumentTbl', @otherrelatedtable_0, 'OtherTbl')
+,(@Id, 'TestDocumentTbl', @otherrelatedtable_1, 'OtherTbl')
 
 @Id=New-Id-1
 @JSON={"Id":null,"AColumn":"Doc1"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@0__AColumn, @0__Id, @0__JSON)
 ,(@1__AColumn, @1__Id, @1__JSON)
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
 
 @Id=SuppliedId

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,8 +1,8 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType]) VALUES
-(@Id, 'TestDocument', @relateddocument_0, 'Other')
-,(@Id, 'TestDocument', @relateddocument_1, 'Other')
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
+(@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
+,(@Id, 'TestDocumentTbl', @relateddocument_1, 'OtherTbl')
 
 @Id=New-Id
 @JSON={"Id":null,"AColumn":"AValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
@@ -1,7 +1,7 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType]) VALUES
-(@Id, 'TestDocument', @relateddocument_0, 'Other')
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
+(@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
 
 @Id=New-Id
 @JSON={"Id":null,"AColumn":"AValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn) VALUES 
+INSERT INTO dbo.[TestDocumentTbl]  (AColumn) VALUES 
 (@AColumn)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocument]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
 @JSON={"Id":"Doc-1","AColumn":"AValue","NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocument] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE dbo.[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
 @JSON={"Id":"Doc-1","AColumn":"AValue","NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
@@ -1,27 +1,27 @@
-UPDATE dbo.[TestDocument]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DECLARE @references as TABLE (Reference nvarchar(400), ReferenceTable nvarchar(400))
 
 DELETE FROM @references
 
-INSERT INTO @references VALUES (@relateddocument_0, 'Other'), (@relateddocument_1, 'Other'), (@relateddocument_2, 'Other'), (@relateddocument_3, 'Other')
+INSERT INTO @references VALUES (@relateddocument_0, 'OtherTbl'), (@relateddocument_1, 'OtherTbl'), (@relateddocument_2, 'OtherTbl'), (@relateddocument_3, 'OtherTbl')
 
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
     AND [RelatedDocumentId] not in (SELECT Reference FROM @references)
 
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType])
-SELECT @Id, 'TestDocument', Reference, ReferenceTable FROM @references t
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable])
+SELECT @Id, 'TestDocumentTbl', Reference, ReferenceTable FROM @references t
 WHERE NOT EXISTS (SELECT null FROM [RelatedDocument] r WHERE r.[Id] = @Id AND r.[RelatedDocumentId] = t.Reference )
 
 DELETE FROM @references
 
-INSERT INTO @references VALUES (@otherrelatedtable_0, 'Other'), (@otherrelatedtable_1, 'Other')
+INSERT INTO @references VALUES (@otherrelatedtable_0, 'OtherTbl'), (@otherrelatedtable_1, 'OtherTbl')
 
 DELETE FROM [OtherRelatedTable] WHERE [Id] = @Id
     AND [RelatedDocumentId] not in (SELECT Reference FROM @references)
 
-INSERT INTO [OtherRelatedTable] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType])
-SELECT @Id, 'TestDocument', Reference, ReferenceTable FROM @references t
+INSERT INTO [OtherRelatedTable] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable])
+SELECT @Id, 'TestDocumentTbl', Reference, ReferenceTable FROM @references t
 WHERE NOT EXISTS (SELECT null FROM [OtherRelatedTable] r WHERE r.[Id] = @Id AND r.[RelatedDocumentId] = t.Reference )
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
@@ -4,7 +4,7 @@ DECLARE @references as TABLE (Reference nvarchar(400), ReferenceTable nvarchar(4
 
 DELETE FROM @references
 
-INSERT INTO @references VALUES (@relateddocument_0, 'OtherTbl'), (@relateddocument_1, 'OtherTbl'), (@relateddocument_2, 'OtherTbl'), (@relateddocument_3, 'OtherTbl')
+INSERT INTO @references VALUES (@relateddocument_0, 'OtherTbl'), (@relateddocument_1, 'OtherTbl')
 
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
     AND [RelatedDocumentId] not in (SELECT Reference FROM @references)
@@ -29,7 +29,5 @@ WHERE NOT EXISTS (SELECT null FROM [OtherRelatedTable] r WHERE r.[Id] = @Id AND 
 @AColumn=Doc1
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2
-@relateddocument_2=Rel-2
-@relateddocument_3=Rel-2
 @otherrelatedtable_0=Rel-3-Other
 @otherrelatedtable_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocument]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
@@ -1,16 +1,16 @@
-UPDATE dbo.[TestDocument]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DECLARE @references as TABLE (Reference nvarchar(400), ReferenceTable nvarchar(400))
 
 DELETE FROM @references
 
-INSERT INTO @references VALUES (@relateddocument_0, 'Other')
+INSERT INTO @references VALUES (@relateddocument_0, 'OtherTbl')
 
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
     AND [RelatedDocumentId] not in (SELECT Reference FROM @references)
 
-INSERT INTO [RelatedDocument] ([Id], [Type], [RelatedDocumentId], [RelatedDocumentType])
-SELECT @Id, 'TestDocument', Reference, ReferenceTable FROM @references t
+INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable])
+SELECT @Id, 'TestDocumentTbl', Reference, ReferenceTable FROM @references t
 WHERE NOT EXISTS (SELECT null FROM [RelatedDocument] r WHERE r.[Id] = @Id AND r.[RelatedDocumentId] = t.Reference )
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -386,7 +386,7 @@ namespace Nevermore.Tests.Util
         {
             public TestDocumentMap()
             {
-                TableName = "TestDocument";
+                TableName = "TestDocumentTbl";
                 Column(t => t.AColumn);
             }
         }
@@ -395,7 +395,7 @@ namespace Nevermore.Tests.Util
         {
             public TestDocumentWithRelatedDocumentsMap()
             {
-                TableName = "TestDocument";
+                TableName = "TestDocumentTbl";
                 Column(t => t.AColumn);
                 RelatedDocuments(t => t.RelatedDocumentIds);
             }
@@ -405,7 +405,7 @@ namespace Nevermore.Tests.Util
         {
             public TestDocumentWithMultipleRelatedDocumentsMap()
             {
-                TableName = "TestDocument";
+                TableName = "TestDocumentTbl";
                 Column(t => t.AColumn);
                 RelatedDocuments(t => t.RelatedDocumentIds1);
                 RelatedDocuments(t => t.RelatedDocumentIds2);

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -330,7 +330,7 @@ namespace Nevermore.Tests.Util
         [Test]
         public void DeleteByDocumentWithManyRelatedTables()
         {
-            var result = builder.CreateDelete<TestDocumentWithRelatedDocuments>("Doc-1");
+            var result = builder.CreateDelete<TestDocumentWithMultipleRelatedDocuments>("Doc-1");
 
             this.Assent(Format(result));
         }

--- a/source/Nevermore/IRelationalStore.cs
+++ b/source/Nevermore/IRelationalStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using System.Text;
+using Nevermore.Mapping;
 
 namespace Nevermore
 {
@@ -11,5 +12,7 @@ namespace Nevermore
         IRelationalTransaction BeginTransaction(RetriableOperation retriableOperation = RetriableOperation.Delete | RetriableOperation.Select, string name = null);
         IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel, RetriableOperation retriableOperation = RetriableOperation.Delete | RetriableOperation.Select, string name = null);
         void WriteCurrentTransactions(StringBuilder sb);
+        DocumentMap GetMappingFor<T>();
+        DocumentMap GetMappingFor(Type type);
     }
 }

--- a/source/Nevermore/Mapping/RelatedDocumentsMapping.cs
+++ b/source/Nevermore/Mapping/RelatedDocumentsMapping.cs
@@ -17,9 +17,9 @@ namespace Nevermore.Mapping
 
         public string TableName { get; }
         public string IdColumnName => "Id";
-        public string IdTypeColumnName => "Type";
+        public string IdTableColumnName => "Table";
         public string RelatedDocumentIdColumnName => "RelatedDocumentId";
-        public string RelatedDocumentTypeColumnName => "RelatedDocumentType";
+        public string RelatedDocumentTableColumnName => "RelatedDocumentTable";
 
         public IPropertyReaderWriter<IEnumerable<(string id, Type type)>> ReaderWriter { get; }
     }

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -79,6 +79,8 @@ namespace Nevermore
         public int MaxPoolSize => registry.Value.MaxPoolSize;
 
         public void WriteCurrentTransactions(StringBuilder sb) => registry.Value.WriteCurrentTransactions(sb);
+        public DocumentMap GetMappingFor(Type type) => mappings.Get(type);
+        public DocumentMap GetMappingFor<T>() => mappings.Get(typeof(T));
 
         public void Reset()
         {

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -305,7 +305,7 @@ namespace Nevermore.Util
                     from relId in m.ReaderWriter.Read(i.document) ?? new (string id, Type type)[0]
                     let relatedTableName = mappings.Get(relId.type).TableName
                     select (parentIdVariable: i.idVariable, relatedDocumentId: relId.id, relatedTableName: relatedTableName)
-                ).ToArray()
+                ).Distinct().ToArray()
                 select new RelatedDocumentTableData
                 {
                     TableName = g.Key,


### PR DESCRIPTION
A previous change changed the `IdTypeColumnName` to store the table name instead of the type and I didn't rename the column correctly at that time, which was misleading. After implementing in Octopus, it turns out determining the real `RelatedDocumentType` is tricky and not really required, just storing the table name is sufficient.