### PR TITLE
Change subtype handling

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -77,7 +77,9 @@ namespace Nevermore.IntegrationTests
                 new ProductMap<Product>(),
                 new SpecialProductMap(),
                 new ProductToTestSerializationMap(),
-                new LineItemMap()
+                new LineItemMap(),
+                new MachineMap(),
+                new MachineToTestSerializationMap()
             });
             Store = BuildRelationalStore(TestDatabaseConnectionString, 0.01);
         }
@@ -99,6 +101,7 @@ namespace Nevermore.IntegrationTests
             };
             jsonSerializerSettings.Converters.Add(new ProductConverter(Mappings));
             jsonSerializerSettings.Converters.Add(new BrandConverter(Mappings));
+            jsonSerializerSettings.Converters.Add(new EndpointConverter());
 
             return new RelationalStore(connectionString ?? TestDatabaseConnectionString, TestDatabaseName, sqlCommandFactory, Mappings, jsonSerializerSettings, new EmptyRelatedDocumentStore());
         }
@@ -122,7 +125,8 @@ namespace Nevermore.IntegrationTests
                 new CustomerMap(),
                 new SpecialProductMap(),
                 new LineItemMap(),
-                new BrandMap()
+                new BrandMap(),
+                new MachineMap()
             };
 
             Mappings.Install(mappings);

--- a/source/Nevermore.IntegrationTests/Model/Brand.cs
+++ b/source/Nevermore.IntegrationTests/Model/Brand.cs
@@ -1,0 +1,27 @@
+﻿using Nevermore.Contracts;
+using Newtonsoft.Json;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public abstract class Brand : IDocument
+    {
+        public string Id { get; protected set; }
+        public string Name { get; set; }
+
+        public abstract string Type { get; }
+
+        public string Description { get; set; }
+    }
+
+    public class BrandA : Brand
+    {
+        public const string BrandType = "BrandA";
+        public override string Type => BrandType;
+    }
+
+    public class BrandB : Brand
+    {
+        public const string BrandType = "BrandB";
+        public override string Type => BrandType;
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/BrandMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/BrandMap.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using Nevermore.Contracts;
+using Nevermore.Mapping;
+using Nevermore.Serialization;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class BrandMap : DocumentMap<Brand>
+    {
+        public BrandMap()
+        {
+            Column(m => m.Name);
+        }
+    }
+
+    public class BrandConverter : InheritedClassConverter<Brand>
+    {
+        readonly Dictionary<string, Type> derivedTypeMappings = new Dictionary<string, Type>
+        {
+            {BrandA.BrandType, typeof(BrandA)},
+            {BrandB.BrandType, typeof(BrandB)}
+        };
+
+        public BrandConverter(RelationalMappings relationalMappings) : base(relationalMappings)
+        {
+        }
+
+        protected override IDictionary<string, Type> DerivedTypeMappings => derivedTypeMappings;
+        protected override string TypeDesignatingPropertyName => "Type";
+    }
+
+    public class BrandToTestSerialization : IDocument
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+
+        public string JSON { get; set; }
+    }
+
+    public class BrandToTestSerializationMap : DocumentMap<BrandToTestSerialization>
+    {
+        public BrandToTestSerializationMap()
+        {
+            TableName = "Brand";
+            Column(x => x.Name);
+            Column(x => x.JSON);
+        }
+    }
+
+}

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using Nevermore.Contracts;
 using Nevermore.Mapping;
 
 namespace Nevermore.IntegrationTests.Model
@@ -11,6 +12,29 @@ namespace Nevermore.IntegrationTests.Model
             Column(m => m.LastName);
             Column(m => m.Roles);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
+        }
+    }
+
+    public class CustomerToTestSerialization : IId
+    {
+        public string Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public ReferenceCollection Roles { get; private set; }
+
+        public string JSON { get; set; }
+    }
+
+    public class CustomerToTestSerializationMap : DocumentMap<CustomerToTestSerialization>
+    {
+        public CustomerToTestSerializationMap()
+        {
+            TableName = "Customer";
+
+            Column(m => m.FirstName).WithMaxLength(20);
+            Column(m => m.LastName);
+            Column(m => m.Roles);
+            Column(m => m.JSON);
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/Machine.cs
+++ b/source/Nevermore.IntegrationTests/Model/Machine.cs
@@ -1,0 +1,29 @@
+﻿using Nevermore.Contracts;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class Machine : IDocument
+    {
+        public string Id { get; protected set; }
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+        public Endpoint Endpoint { get; set; }
+    }
+
+    public abstract class Endpoint
+    {
+        public string Name { get; set; }
+
+        public abstract string Type { get; }
+    }
+
+    public class PassiveTentacleEndpoint : Endpoint
+    {
+        public override string Type => "PassiveTentacle";
+    }
+    public class ActiveTentacleEndpoint : Endpoint
+    {
+        public override string Type => "ActiveTentacle";
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MachineMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MachineMap.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Nevermore.Contracts;
+using Nevermore.Mapping;
+using Nevermore.Serialization;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MachineMap : DocumentMap<Machine>
+    {
+        public MachineMap()
+        {
+            Column(x => x.Name);
+        }
+    }
+
+    public class EndpointConverter : InheritedClassConverter<Endpoint>
+    {
+        readonly Dictionary<string, Type> derivedTypeMappings = new Dictionary<string, Type>
+        {
+            {"PassiveTentacle", typeof(PassiveTentacleEndpoint)},
+            {"ActiveTentacle", typeof(ActiveTentacleEndpoint)}
+        };
+
+        protected override IDictionary<string, Type> DerivedTypeMappings => derivedTypeMappings;
+        protected override string TypeDesignatingPropertyName => "Type";
+    }
+
+    public class MachineToTestSerialization : IDocument
+    {
+        public string Id { get; protected set; }
+        public string Name { get; set; }
+
+        public string JSON { get; set; }
+    }
+
+    public class MachineToTestSerializationMap : DocumentMap<MachineToTestSerialization>
+    {
+        public MachineToTestSerializationMap()
+        {
+            TableName = "Machine";
+            Column(x => x.Name);
+            Column(x => x.JSON);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/ProductMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/ProductMap.cs
@@ -1,34 +1,63 @@
 using System;
 using System.Collections.Generic;
-using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using Nevermore.Contracts;
 using Nevermore.Mapping;
+using Nevermore.Serialization;
 
 namespace Nevermore.IntegrationTests.Model
 {
     public class ProductMap<TProduct> : DocumentMap<TProduct> where TProduct : Product
     {
-        static readonly Dictionary<ProductType, Type> SubTypeMappings = new Dictionary<ProductType, Type>
-        {
-            {ProductType.Special, typeof(SpecialProduct)},
-            {ProductType.Dodgy, typeof(DodgyProduct)},
-            {ProductType.Normal, typeof(Product)}
-        };
-
         public ProductMap()
         {
-
             Column(m => m.Name);
-            TypeDiscriminatorColumn(m => m.Type, SubTypeMappings);
+            Column(m => m.Type);
         }
     }
 
-        public class SpecialProductMap : ProductMap<SpecialProduct>
+    public class SpecialProductMap : ProductMap<SpecialProduct>
     {
-
         public SpecialProductMap()
         {
             TableName = typeof(Product).Name;
             Column(m => m.BonusMaterial).IsNullable = true;
         }
+    }
+
+    public class ProductToTestSerialization : IDocument
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+     
+        public string Type { get; set; }
+        public string JSON { get; set; }
+    }
+
+    public class ProductToTestSerializationMap : DocumentMap<ProductToTestSerialization>
+    {
+        public ProductToTestSerializationMap()
+        {
+            TableName = "Product";
+            Column(x => x.Name);
+            Column(x => x.Type);
+            Column(x => x.JSON);
+        }
+    }
+
+    public class ProductConverter : InheritedClassConverter<Product, ProductType>
+    {
+        readonly Dictionary<ProductType, Type> derivedTypeMappings = new Dictionary<ProductType, Type>
+        {
+            {ProductType.Dodgy, typeof(DodgyProduct)},
+            {ProductType.Special, typeof(SpecialProduct)},
+            {ProductType.Normal, typeof(Product)}
+        };
+
+        public ProductConverter(RelationalMappings relationalMappings) : base(relationalMappings)
+        {
+        }
+
+        protected override IDictionary<ProductType, Type> DerivedTypeMappings => derivedTypeMappings;
+        protected override string TypeDesignatingPropertyName => "Type";
     }
 }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -1,7 +1,5 @@
 ﻿using System.Linq;
 using FluentAssertions;
-using Nevermore.Contracts;
-using Nevermore;
 using Nevermore.IntegrationTests.Model;
 using NUnit.Framework;
 
@@ -45,9 +43,54 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 trn.LoadStream<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
             }
         }
+        
+        [Test]
+        public void StoreNonInheritedTypesSerializesCorrectly()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var customer = new Customer
+                {
+                    FirstName = "Bob",
+                    LastName = "Tester",
+                    Nickname = "Bob the builder",
+                    Id = "Customers-01"
+                };
+
+                trn.Insert<Customer>(customer);
+
+                var customers = trn.TableQuery<CustomerToTestSerialization>().ToList();
+
+                var c = customers.Single(p => p.Id == "Customers-01");
+                c.FirstName.Should().Be("Bob", "Type isn't serializing into column correctly");
+                c.JSON.Should().Be("{\"Nickname\":\"Bob the builder\",\"LuckyNumbers\":null,\"ApiKey\":null,\"Passphrases\":null}");
+            }
+        }
 
         [Test]
-        public void StoreAndLoadInheritedTypes()
+        public void StoreEnumInheritedTypesSerializesCorrectlyForNormalProduct()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var originalNormal = new Product()
+                {
+                    Name = "Unicorn Dust",
+                    Id = "UD-01",
+                    Price = 11.1m,
+                };
+
+                trn.Insert(originalNormal);
+
+                var allProducts = trn.TableQuery<ProductToTestSerialization>().ToList();
+
+                var special = allProducts.Single(p => p.Id == "UD-01");
+                special.Type.Should().Be("Normal", "Type isn't serializing into column correctly");
+                special.JSON.Should().Be("{\"Price\":11.1,\"Type\":0}");
+            }
+        }
+
+        [Test]
+        public void StoreEnumInheritedTypesSerializesCorrectlyForSpecialProduct()
         {
             using (var trn = Store.BeginTransaction())
             {
@@ -70,14 +113,93 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 trn.Insert<SpecialProduct>(originalSpecial);
                 trn.Insert<DodgyProduct>(originalDud);
 
+                var allProducts = trn.TableQuery<ProductToTestSerialization>().ToList();
+
+                var special = allProducts.Single(p => p.Id == "UD-01");
+                special.Type.Should().Be("Special", "Type isn't serializing into column correctly");
+                special.JSON.Should().Be("{\"Price\":11.1,\"Type\":1}");
+            }
+        }
+
+        [Test]
+        public void StoreAndLoadEnumInheritedTypes()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var originalNormal = new Product
+                {
+                    Name = "Norm",
+                    Id = "NL-01",
+                    Price = 15.5m
+                };
+
+                var originalSpecial = new SpecialProduct
+                {
+                    Name = "Unicorn Dust",
+                    BonusMaterial = "Directors Commentary",
+                    Id = "UD-01",
+                    Price = 11.1m
+                };
+
+                var originalDud = new DodgyProduct
+                {
+                    Id = "DO-01",
+                    Name = "Something",
+                    Price = 12.3m,
+                    Tax = 15m
+                };
+
+                trn.Insert(originalNormal);
+                trn.Insert<SpecialProduct>(originalSpecial);
+                trn.Insert<DodgyProduct>(originalDud);
+
                 var allProducts = trn.TableQuery<Product>().ToList();
                 Assert.True(allProducts.Exists(p =>
-                    p is SpecialProduct sp && sp.BonusMaterial == originalSpecial.BonusMaterial));
-                Assert.True(allProducts.Exists(p => p is DodgyProduct dp && dp.Tax == originalDud.Tax));
+                    p is SpecialProduct sp && sp.BonusMaterial == originalSpecial.BonusMaterial), "Special product didn't load correctly");
+                Assert.True(allProducts.Exists(p => p is DodgyProduct dp && dp.Tax == originalDud.Tax), "Dodgy product didn't load correctly");
 
                 var onlySpecial = trn.TableQuery<SpecialProduct>().ToList();
                 onlySpecial.Count.Should().Be(1);
                 onlySpecial[0].BonusMaterial.Should().Be(originalSpecial.BonusMaterial);
+            }
+        }
+
+        [Test]
+        public void StoreStringInheritedTypesSerializeCorrectly()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
+                var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
+
+                trn.Insert<Brand>(brandA);
+                trn.Insert<Brand>(brandB);
+                trn.Commit();
+
+                var allBrands = trn.TableQuery<BrandToTestSerialization>().ToList();
+
+                allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
+                var brandToTestSerialization = allBrands.Single(x => x.Name == "Brand A");
+                brandToTestSerialization.JSON.Should().Be("{\"Type\":\"BrandA\",\"Description\":\"Details for Brand A.\"}");
+            }
+        }
+
+        [Test]
+        public void StoreAndLoadStringInheritedTypes()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
+                var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
+
+                trn.Insert<Brand>(brandA);
+                trn.Insert<Brand>(brandB);
+                trn.Commit();
+
+                var allBrands = trn.TableQuery<Brand>().ToList();
+
+                allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
+                allBrands.Single(x => x.Name == "Brand A").Should().BeOfType<BrandA>();
             }
         }
     }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -202,5 +202,43 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 allBrands.Single(x => x.Name == "Brand A").Should().BeOfType<BrandA>();
             }
         }
+
+        [Test]
+        public void StoreStringInheritedTypesThatArePropertiesSerializeCorrectly()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var machineA = new Machine { Name = "Machine A", Description = "Details for Machine A.", Endpoint = new PassiveTentacleEndpoint { Name = "Quiet tentacle" }};
+                var machineB = new Machine { Name = "Machine B", Description = "Details for Machine B.", Endpoint = new ActiveTentacleEndpoint { Name = "Noisy tentacle" } };
+
+                trn.Insert(machineA);
+                trn.Insert(machineB);
+                trn.Commit();
+
+                var allMachines = trn.TableQuery<MachineToTestSerialization>().ToList();
+
+                allMachines.SingleOrDefault(x => x.Name == "Machine A").Should().NotBeNull("Didn't retrieve BrandA");
+                allMachines.Single(x => x.Name == "Machine A").JSON.Should().Be("{\"Description\":\"Details for Machine A.\",\"Endpoint\":{\"Type\":\"PassiveTentacle\",\"Name\":\"Quiet tentacle\"}}");
+            }
+        }
+
+        [Test]
+        public void StoreAndLoadStringInheritedTypesThatAreProperties()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var machineA = new Machine { Name = "Machine A", Description = "Details for Machine A.", Endpoint = new PassiveTentacleEndpoint { Name = "Quiet tentacle" }};
+                var machineB = new Machine { Name = "Machine B", Description = "Details for Machine B.", Endpoint = new ActiveTentacleEndpoint { Name = "Noisy tentacle" } };
+
+                trn.Insert(machineA);
+                trn.Insert(machineB);
+                trn.Commit();
+
+                var allMachines = trn.TableQuery<Machine>().ToList();
+
+                allMachines.SingleOrDefault(x => x.Name == "Machine A").Should().NotBeNull("Didn't retrieve Machine A");
+                allMachines.Single(x => x.Name == "Machine A").Endpoint.Should().BeOfType<PassiveTentacleEndpoint>();
+            }
+        }
     }
 }

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -13,13 +13,6 @@ namespace Nevermore.Mapping
             InitializeDefault(typeof (TDocument));
         }
 
-        protected ColumnMapping TypeDiscriminatorColumn<T>(Expression<Func<TDocument, T>> property, Dictionary<T, Type> typeBuilder) where T : struct
-        {
-            var col = this.Column(property);
-            InstanceTypeResolver = new SubTypedResolver<TDocument, T>(col, typeBuilder);
-            return col;
-        }
-
         protected ColumnMapping Column<T>(Expression<Func<TDocument, T>> property)
         {
             var column = new ColumnMapping(GetPropertyInfo(property));

--- a/source/Nevermore/Mapping/InstanceTypeResolver.cs
+++ b/source/Nevermore/Mapping/InstanceTypeResolver.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Data;
+
+namespace Nevermore.Mapping
+{
+    public abstract class InstanceTypeResolver
+    {
+        public abstract Type GetTypeFromInstance(object instance);
+        public abstract Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal);
+    }
+}

--- a/source/Nevermore/Mapping/RelationalMappings.cs
+++ b/source/Nevermore/Mapping/RelationalMappings.cs
@@ -24,7 +24,18 @@ namespace Nevermore.Mapping
 
         public bool TryGet(Type type, out DocumentMap map)
         {
-            return mappings.TryGetValue(type, out map);
+            DocumentMap mapping = null;
+
+            // Walk up the inheritance chain until we find a mapping
+            var currentType = type;
+            while (currentType != null && !mappings.TryGetValue(currentType, out mapping))
+            {
+                currentType = currentType.GetTypeInfo().BaseType;
+            }
+
+            map = mapping;
+
+            return mapping != null;
         }
 
         public DocumentMap Get(object instance)
@@ -38,16 +49,7 @@ namespace Nevermore.Mapping
         
         public DocumentMap Get(Type type)
         {
-            DocumentMap mapping = null;
-
-            // Walk up the inheritance chain until we find a mapping
-            var currentType = type;
-            while (currentType != null && !mappings.TryGetValue(currentType, out mapping))
-            {
-                currentType = currentType.GetTypeInfo().BaseType;
-            }
-
-            if (mapping == null)
+            if (!TryGet(type, out var mapping))
             {
                 throw new KeyNotFoundException(string.Format("A mapping for the type '{0}' has not been defined", type.Name));
             }

--- a/source/Nevermore/Mapping/StandardTypeResolver.cs
+++ b/source/Nevermore/Mapping/StandardTypeResolver.cs
@@ -3,12 +3,6 @@ using System.Data;
 
 namespace Nevermore.Mapping
 {
-    public abstract class InstanceTypeResolver
-    {
-        public abstract Type GetTypeFromInstance(object instance);
-        public abstract Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal);
-    }
-
     public class StandardTypeResolver : InstanceTypeResolver
     {
         readonly DocumentMap mapper;

--- a/source/Nevermore/Mapping/SubTypedResolver.cs
+++ b/source/Nevermore/Mapping/SubTypedResolver.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Reflection;
 
 namespace Nevermore.Mapping
 {
@@ -28,67 +26,6 @@ namespace Nevermore.Mapping
         public override Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal)
         {
             return (reader) => mapper.Type;
-        }
-    }
-
-    public class SubTypedResolver<TDocument, TProperty> : InstanceTypeResolver where TProperty : struct
-    {
-        readonly ColumnMapping column;
-        readonly Dictionary<TProperty, Type> typeBuilder;
-
-        public SubTypedResolver(ColumnMapping column, Dictionary<TProperty, Type> typeBuilder)
-        {
-            if (!typeof(TProperty).GetTypeInfo().IsEnum)
-            {
-                throw new InvalidOperationException($"The type discriminator for column {column.ColumnName} on object {typeof(TDocument).Name} must deserialize to an enum property");
-            }
-
-            this.column = column;
-
-
-            this.typeBuilder = typeBuilder;
-        }
-
-        public override Type GetTypeFromInstance(object instance)
-        {
-            var discriminator = (TProperty)column.ReaderWriter.Read(instance);
-            if (!typeBuilder.ContainsKey(discriminator))
-            {
-                throw new InvalidOperationException($"Unable to map provided enum {discriminator} to a sub type.");
-
-            }
-
-            return typeBuilder[discriminator];
-        }
-
-        public override Func<IDataReader, Type> TypeResolverFromReader(Func<string, int> columnOrdinal)
-        {
-            var colIndex = columnOrdinal(column.ColumnName);
-            return reader => GetType(reader[colIndex].ToString());
-        }
-
-        Type GetType(string value)
-        {
-            if (string.IsNullOrEmpty(value))
-                return typeof(TDocument);
-
-            TProperty discriminator;
-            try
-            {
-                discriminator = (TProperty)Enum.Parse(column.Property.PropertyType, value, true);
-            }
-            catch (ArgumentException)
-            {
-                throw new InvalidOperationException($"Unable to map provided enum {value} to a sub type.");
-            }
-
-            if (!typeBuilder.ContainsKey(discriminator))
-            {
-                throw new InvalidOperationException($"Unable to map provided enum {value} to a sub type.");
-
-            }
-
-            return typeBuilder[discriminator];
         }
     }
 }

--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
-using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -465,7 +463,7 @@ namespace Nevermore
                             instance = (T) Activator.CreateInstance(instanceType);
                         }
 
-                        var specificMapping = mappings.Get(instanceType);
+                        var specificMapping = mappings.Get(instance.GetType());
                         var columnIndexes = specificMapping.IndexedColumns.ToDictionary(c => c, c => GetOrdinal(reader, c.ColumnName));
 
                         foreach (var index in columnIndexes)
@@ -664,7 +662,7 @@ namespace Nevermore
                 var instanceType = mapping.InstanceTypeResolver.TypeResolverFromReader((colName) => GetOrdinal(reader, GetColumnName(prefix, colName)))(reader);
 
                 var instance = JsonConvert.DeserializeObject(json, instanceType, jsonSerializerSettings);
-                foreach (var column in mappings.Get(instanceType).IndexedColumns)
+                foreach (var column in mappings.Get(instance.GetType()).IndexedColumns)
                 {
                     column.ReaderWriter.Write(instance, reader[GetColumnName(prefix, column.ColumnName)]);
                 }

--- a/source/Nevermore/Serialization/InheritedClassConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverter.cs
@@ -120,7 +120,7 @@ namespace Nevermore.Serialization
         {
             if (!DerivedTypeMappings.ContainsKey(derivedType))
             {
-                throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} does not map to a known type");
+                throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} `{derivedType}` does not map to a known type");
             }
 
             var typeInfo = DerivedTypeMappings[derivedType].GetTypeInfo();

--- a/source/Nevermore/Serialization/InheritedClassConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverter.cs
@@ -1,93 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Nevermore.Mapping;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Nevermore.Serialization
 {
-    public abstract class InheritedClassConverter<TDocument, TDiscriminator> : JsonConverter
+    public abstract class InheritedClassConverter<TDocument, TDiscriminator> : InheritedClassConverterBase<TDocument, TDiscriminator>
+        where TDiscriminator : struct
     {
-        protected readonly RelationalMappings RelationalMappings;
-
-        protected InheritedClassConverter(RelationalMappings relationalMappings = null)
+        protected InheritedClassConverter(RelationalMappings relationalMappings = null) : base(relationalMappings)
         {
-            RelationalMappings = relationalMappings;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            writer.WriteStartObject();
-
-            DocumentMap map = null;
-            RelationalMappings?.TryGet(value.GetType(), out map);
-
-            var documentType = value.GetType().GetTypeInfo();
-
-            foreach (var property in documentType
-                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
-                .Where(p => p.Name == TypeDesignatingPropertyName || 
-                            (p.CanRead && (map == null || (p.Name != map.IdColumn.Property.Name && map.IndexedColumns.All(c => p.Name != c.Property.Name))))))
-            {
-                writer.WritePropertyName(property.Name);
-                serializer.Serialize(writer, property.GetValue(value, null));
-            }
-
-            WriteTypeProperty(writer, value, serializer);
-
-            writer.WriteEndObject();
-        }
-
-        protected virtual void WriteTypeProperty(JsonWriter writer, object value, JsonSerializer serializer)
-        { }
-
-        protected virtual Type DefaultType { get; } = null;
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            if (reader.TokenType == JsonToken.Null)
-                return null;
-
-            var jo = JObject.Load(reader);
-            var designatingProperty = jo.GetValue(TypeDesignatingPropertyName);
-            TypeInfo typeInfo;
-            if (designatingProperty == null)
-            {
-                if (DefaultType == null)
-                {
-                    throw new Exception($"Unable to determine type to deserialize. Missing property `{TypeDesignatingPropertyName}`");
-                }
-                typeInfo = DefaultType.GetTypeInfo();
-            }
-            else
-            {
-                var derivedType = designatingProperty.ToObject<string>();
-                typeInfo = GetTypeInfoFromDerivedType(derivedType);
-            }
-
-            var ctor = typeInfo.GetConstructors(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault();
-            if (ctor == null)
-            {
-                throw new Exception($"Type {typeInfo.Name} must have a public constructor");
-            }
-
-            var args = ctor.GetParameters().Select(p =>
-                jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))?.ToObject(p.ParameterType, serializer)).ToArray();
-            var instance = ctor.Invoke(args);
-            foreach (var prop in typeInfo
-                .GetProperties(BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.Instance)
-                .Where(p => p.CanWrite))
-            {
-                var val = jo.GetValue(prop.Name);
-                if (val != null)
-                    prop.SetValue(instance, val.ToObject(prop.PropertyType, serializer), null);
-            }
-            return instance;
-        }
-
-        protected virtual TypeInfo GetTypeInfoFromDerivedType(string derivedType)
+        protected override TypeInfo GetTypeInfoFromDerivedType(string derivedType)
         {
             var enumType = (TDiscriminator) Enum.Parse(typeof(TDiscriminator), derivedType);
             if (!DerivedTypeMappings.ContainsKey(enumType))
@@ -99,18 +23,9 @@ namespace Nevermore.Serialization
             var typeInfo = DerivedTypeMappings[enumType].GetTypeInfo();
             return typeInfo;
         }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return typeof(TDocument).GetTypeInfo().IsAssignableFrom(objectType);
-        }
-
-        protected abstract IDictionary<TDiscriminator, Type> DerivedTypeMappings { get; }
-
-        protected abstract string TypeDesignatingPropertyName { get; }
     }
 
-    public abstract class InheritedClassConverter<TModel> : InheritedClassConverter<TModel, string>
+    public abstract class InheritedClassConverter<TModel> : InheritedClassConverterBase<TModel, string>
     {
         protected InheritedClassConverter(RelationalMappings relationalMappings = null) : base(relationalMappings)
         {

--- a/source/Nevermore/Serialization/InheritedClassConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverter.cs
@@ -67,7 +67,12 @@ namespace Nevermore.Serialization
                 typeInfo = GetTypeInfoFromDerivedType(derivedType);
             }
 
-            var ctor = typeInfo.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Single();
+            var ctor = typeInfo.GetConstructors(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault();
+            if (ctor == null)
+            {
+                throw new Exception($"Type {typeInfo.Name} must have a public constructor");
+            }
+
             var args = ctor.GetParameters().Select(p =>
                 jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))
                     .ToObject(p.ParameterType, serializer)).ToArray();

--- a/source/Nevermore/Serialization/InheritedClassConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverter.cs
@@ -10,11 +10,11 @@ namespace Nevermore.Serialization
 {
     public abstract class InheritedClassConverter<TDocument, TDiscriminator> : JsonConverter
     {
-        readonly RelationalMappings relationalMappings;
+        protected readonly RelationalMappings RelationalMappings;
 
         protected InheritedClassConverter(RelationalMappings relationalMappings = null)
         {
-            this.relationalMappings = relationalMappings;
+            RelationalMappings = relationalMappings;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
@@ -22,7 +22,7 @@ namespace Nevermore.Serialization
             writer.WriteStartObject();
 
             DocumentMap map = null;
-            relationalMappings?.TryGet(value.GetType(), out map);
+            RelationalMappings?.TryGet(value.GetType(), out map);
 
             var documentType = value.GetType().GetTypeInfo();
 
@@ -74,8 +74,7 @@ namespace Nevermore.Serialization
             }
 
             var args = ctor.GetParameters().Select(p =>
-                jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))
-                    .ToObject(p.ParameterType, serializer)).ToArray();
+                jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))?.ToObject(p.ParameterType, serializer)).ToArray();
             var instance = ctor.Invoke(args);
             foreach (var prop in typeInfo
                 .GetProperties(BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.Instance)

--- a/source/Nevermore/Serialization/InheritedClassConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverter.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nevermore.Mapping;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nevermore.Serialization
+{
+    public abstract class InheritedClassConverter<TDocument, TDiscriminator> : JsonConverter
+    {
+        readonly RelationalMappings relationalMappings;
+
+        protected InheritedClassConverter(RelationalMappings relationalMappings)
+        {
+            this.relationalMappings = relationalMappings;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            var documentType = value.GetType().GetTypeInfo();
+
+            var map = relationalMappings.Get(documentType);
+
+            foreach (var property in documentType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
+                .Where(p => p.Name == TypeDesignatingPropertyName || 
+                            (p.CanRead && p.Name != map.IdColumn.Property.Name && map.IndexedColumns.All(c => p.Name != c.Property.Name))))
+            {
+                writer.WritePropertyName(property.Name);
+                serializer.Serialize(writer, property.GetValue(value, null));
+            }
+
+            WriteTypeProperty(writer, value, serializer);
+
+            writer.WriteEndObject();
+        }
+
+        protected virtual void WriteTypeProperty(JsonWriter writer, object value, JsonSerializer serializer)
+        { }
+
+        protected virtual Type DefaultType { get; } = null;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var jo = JObject.Load(reader);
+            var designatingProperty = jo.GetValue(TypeDesignatingPropertyName);
+            TypeInfo typeInfo;
+            if (designatingProperty == null)
+            {
+                if (DefaultType == null)
+                {
+                    throw new Exception($"Unable to determine type to deserialize. Missing property `{TypeDesignatingPropertyName}`");
+                }
+                typeInfo = DefaultType.GetTypeInfo();
+            }
+            else
+            {
+                var derivedType = designatingProperty.ToObject<string>();
+                typeInfo = GetTypeInfoFromDerivedType(derivedType);
+            }
+
+            var ctor = typeInfo.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Single();
+            var args = ctor.GetParameters().Select(p =>
+                jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))
+                    .ToObject(p.ParameterType, serializer)).ToArray();
+            var instance = ctor.Invoke(args);
+            foreach (var prop in typeInfo
+                .GetProperties(BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.Instance)
+                .Where(p => p.CanWrite))
+            {
+                var val = jo.GetValue(prop.Name);
+                if (val != null)
+                    prop.SetValue(instance, val.ToObject(prop.PropertyType, serializer), null);
+            }
+            return instance;
+        }
+
+        protected virtual TypeInfo GetTypeInfoFromDerivedType(string derivedType)
+        {
+            var enumType = (TDiscriminator) Enum.Parse(typeof(TDiscriminator), derivedType);
+            if (!DerivedTypeMappings.ContainsKey(enumType))
+            {
+                throw new Exception(
+                    $"Unable to determine type to deserialize. {TypeDesignatingPropertyName} `{enumType}` does not map to a known type");
+            }
+
+            var typeInfo = DerivedTypeMappings[enumType].GetTypeInfo();
+            return typeInfo;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(TDocument).GetTypeInfo().IsAssignableFrom(objectType);
+        }
+
+        protected abstract IDictionary<TDiscriminator, Type> DerivedTypeMappings { get; }
+
+        protected abstract string TypeDesignatingPropertyName { get; }
+    }
+
+    public abstract class InheritedClassConverter<TModel> : InheritedClassConverter<TModel, string>
+    {
+        protected InheritedClassConverter(RelationalMappings relationalMappings) : base(relationalMappings)
+        {
+        }
+
+        protected override TypeInfo GetTypeInfoFromDerivedType(string derivedType)
+        {
+            if (!DerivedTypeMappings.ContainsKey(derivedType))
+            {
+                throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} does not map to a known type");
+            }
+
+            var typeInfo = DerivedTypeMappings[derivedType].GetTypeInfo();
+            return typeInfo;
+        }
+    }
+}

--- a/source/Nevermore/Serialization/InheritedClassConverterBase.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverterBase.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Nevermore.Mapping;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Nevermore.Serialization
+{
+    public abstract class InheritedClassConverterBase<TDocument, TDiscriminator> : JsonConverter
+    {
+        protected readonly RelationalMappings RelationalMappings;
+
+        protected InheritedClassConverterBase(RelationalMappings relationalMappings = null)
+        {
+            RelationalMappings = relationalMappings;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+
+            DocumentMap map = null;
+            RelationalMappings?.TryGet(value.GetType(), out map);
+
+            var documentType = value.GetType().GetTypeInfo();
+
+            foreach (var property in documentType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty)
+                .Where(p => p.Name == TypeDesignatingPropertyName ||
+                            (p.CanRead && (map == null || (p.Name != map.IdColumn.Property.Name && map.IndexedColumns.All(c => p.Name != c.Property.Name))))))
+            {
+                writer.WritePropertyName(property.Name);
+                serializer.Serialize(writer, property.GetValue(value, null));
+            }
+
+            WriteTypeProperty(writer, value, serializer);
+
+            writer.WriteEndObject();
+        }
+
+        protected virtual void WriteTypeProperty(JsonWriter writer, object value, JsonSerializer serializer)
+        { }
+
+        protected virtual Type DefaultType { get; } = null;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var jo = JObject.Load(reader);
+            var designatingProperty = jo.GetValue(TypeDesignatingPropertyName);
+            TypeInfo typeInfo;
+            if (designatingProperty == null)
+            {
+                if (DefaultType == null)
+                {
+                    throw new Exception($"Unable to determine type to deserialize. Missing property `{TypeDesignatingPropertyName}`");
+                }
+                typeInfo = DefaultType.GetTypeInfo();
+            }
+            else
+            {
+                var derivedType = designatingProperty.ToObject<string>();
+                typeInfo = GetTypeInfoFromDerivedType(derivedType);
+            }
+
+            var ctor = typeInfo.GetConstructors(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault();
+            if (ctor == null)
+            {
+                throw new Exception($"Type {typeInfo.Name} must have a public constructor");
+            }
+
+            var args = ctor.GetParameters().Select(p =>
+                jo.GetValue(char.ToUpper(p.Name[0]) + p.Name.Substring(1))?.ToObject(p.ParameterType, serializer)).ToArray();
+            var instance = ctor.Invoke(args);
+            foreach (var prop in typeInfo
+                .GetProperties(BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.Instance)
+                .Where(p => p.CanWrite))
+            {
+                var val = jo.GetValue(prop.Name);
+                if (val != null)
+                    prop.SetValue(instance, val.ToObject(prop.PropertyType, serializer), null);
+            }
+            return instance;
+        }
+
+        protected abstract TypeInfo GetTypeInfoFromDerivedType(string derivedType);
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(TDocument).GetTypeInfo().IsAssignableFrom(objectType);
+        }
+
+        protected abstract IDictionary<TDiscriminator, Type> DerivedTypeMappings { get; }
+
+        protected abstract string TypeDesignatingPropertyName { get; }
+    }
+}


### PR DESCRIPTION
We can now support using a JSON converter to handle subtyping the same way we do in the API. This means the type namespaces won't be serialized into the DB and we are not going to break if we move types to different namespaces/assemblies.

Added tests to ensure the serialization is correct, and to guard against it accidentally changing in the future.