### PR TITLE
Moved Load* methods on IQueryExecutor to extension methods, to make i…

### DIFF
--- a/source/Nevermore/IQueryExecutor.cs
+++ b/source/Nevermore/IQueryExecutor.cs
@@ -83,49 +83,7 @@ namespace Nevermore
         /// <returns>A builder to further customize the query</returns>
         IDeleteQueryBuilder<TDocument> DeleteQuery<TDocument>() where TDocument : class, IId;
 
-        /// <summary>
-        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="id">The <c>Id</c> of the document to find.</param>
-        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        TDocument Load<TDocument>(string id) where TDocument : class, IId;
-
-        /// <summary>
-        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-        /// the results may contain less items than the number of ID's queried for).
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="ids">A collection of ID's to query by.</param>
-        /// <returns>The documents.</returns>
-        TDocument[] Load<TDocument>(IEnumerable<string> ids) where TDocument : class, IId;
-
-        /// <summary>
-        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-        /// the results may contain less items than the number of ID's queried for).
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="ids">A collection of ID's to query by.</param>
-        /// <returns>The documents as a lazy loaded stream.</returns>
-        IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class, IId;
-
-        /// <summary>
-        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="id">The <c>Id</c> of the document to find.</param>
-        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        TDocument LoadRequired<TDocument>(string id) where TDocument : class, IId;
-
-        /// <summary>
-        /// Loads a set of documents by their ID's. If any of the documents are not found, a
-        /// <see cref="ResourceNotFoundException" /> will be thrown.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="ids">A collection of ID's to query by.</param>
-        /// <returns>The documents.</returns>
-        TDocument[] LoadRequired<TDocument>(IEnumerable<string> ids) where TDocument : class, IId;
-
+        
         /// <summary>
         /// Immediately inserts a new item into the default table for the document type. The item will have an automatically
         /// assigned ID, and that ID value will be visible in the <code>Id</code> property of the object as soon as

--- a/source/Nevermore/QueryExecutorExtensions.cs
+++ b/source/Nevermore/QueryExecutorExtensions.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
 using Nevermore.Contracts;
 
 namespace Nevermore
@@ -15,6 +19,103 @@ namespace Nevermore
                 // AsType creates an instance `QueryBuilder` without actually modifying the query itself.
                 // This allows any changes to the query (eg by calling `queryBuild.Where(...)`) to modify the state of the query builder itself
                 .AsType<TDocument>();
+        }
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="queryExecutor">The query executor to use</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure]
+        public static T Load<T>(this IQueryExecutor queryExecutor, string id) where T : class, IId
+        {
+            return queryExecutor.TableQuery<T>()
+                .Where("[Id] = @id")
+                .Parameter("id", id)
+                .First();
+        }
+        
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="queryExecutor">The query executor to use</param>
+        /// <returns>The documents.</returns>
+        [Pure]
+        public static T[] Load<T>(this IQueryExecutor queryExecutor, IEnumerable<string> ids) where T : class, IId
+            => queryExecutor.LoadStream<T>(ids).ToArray();
+        
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="queryExecutor">The query executor to use</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure]
+        public static IEnumerable<T> LoadStream<T>(this IQueryExecutor queryExecutor, IEnumerable<string> ids) where T : class, IId
+        {
+            var blocks = ids
+                .Distinct()
+                .Select((id, index) => (id: id, index: index))
+                .GroupBy(x => x.index / 500, y => y.id)
+                .ToArray();
+
+            foreach (var block in blocks)
+            {
+                var results = queryExecutor.TableQuery<T>()
+                    .Where("[Id] IN @ids")
+                    .Parameter("ids", block.ToArray())
+                    .Stream();
+
+                foreach (var result in results)
+                    yield return result;
+            }
+        }
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="queryExecutor">The query executor to use</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure]
+        public static T LoadRequired<T>(this IQueryExecutor queryExecutor, string id) where T : class, IId
+        {
+            var result = queryExecutor.Load<T>(id);
+            if (result == null)
+                throw new ResourceNotFoundException(id);
+            return result;
+        }
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="queryExecutor">The query executor to use</param>
+        /// <returns>The documents.</returns>
+        [Pure]
+        public static T[] LoadRequired<T>(this IQueryExecutor queryExecutor, IEnumerable<string> ids) where T : class, IId
+        {
+            var allIds = ids.ToArray();
+            var results = queryExecutor.TableQuery<T>()
+                .Where("[Id] IN @ids")
+                .Parameter("ids", allIds)
+                .Stream().ToArray();
+
+            var items = allIds.Zip(results, Tuple.Create);
+            foreach (var pair in items)
+                if (pair.Item2 == null)
+                    throw new ResourceNotFoundException(pair.Item1);
+            return results;
         }
     }
 }


### PR DESCRIPTION
…t easier for users to provide their own implementation of IQueryExecutor

In `spaces` in Octopus, we are providing our own implementation of IQueryExecutor, which for the most part delegates to the Nevermore implementation.

When we are applying permissions for loading data, we *always* need to provide an in-memory filtering implementation of the permission such that documents loaded with `.Load(IEnumerable<string> ids)` or similar methods can be filtered out in memory. This is because the sql filtering logic that we normally apply for there restrictions is hooked in as part of the `TableQuery` call, but if we need to delegate to Nevermore's implementation of `Load(...)` then we bypass this hook and don't apply any sql filtering for these calls.

By moving these methods to extension methods, they automatically get our custom sql filtering logic applied, plus we also don't have to implement them.

This allows our restrictions to optionally not specify an in-memory filter and rely on the sql filter alone. This is useful because we can switch on whether a specific type requires in-memory filtering and use this to decide whether that type can be included in a join (for example).