### PR TITLE
Use flag for object init to preserve backwards compat

### DIFF
--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;net451;netstandard2.0</TargetFrameworks>

--- a/source/Nevermore/ObjectInitialisationOptions.cs
+++ b/source/Nevermore/ObjectInitialisationOptions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Nevermore
+{
+    [Flags]
+    public enum ObjectInitialisationOptions
+    {
+        None = 0,
+        UseNonPublicConstructors = 1
+    }
+}

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -23,6 +23,7 @@ namespace Nevermore
         readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings();
         private readonly IRelatedDocumentStore relatedDocumentStore;
         readonly IKeyAllocator keyAllocator;
+        readonly ObjectInitialisationOptions objectInitialisationOptions;
 
         public RelationalStore(
             string connectionString,
@@ -31,7 +32,8 @@ namespace Nevermore
             RelationalMappings mappings,
             JsonSerializerSettings jsonSettings,
             IRelatedDocumentStore relatedDocumentStore,
-            int keyBlockSize = 20)
+            int keyBlockSize = 20,
+            ObjectInitialisationOptions objectInitialisationOptions = ObjectInitialisationOptions.None)
             : this(
                 () => connectionString,
                 applicationName,
@@ -39,7 +41,8 @@ namespace Nevermore
                 mappings,
                 jsonSettings,
                 relatedDocumentStore,
-                keyBlockSize
+                keyBlockSize,
+                objectInitialisationOptions
             )
         {
 
@@ -55,6 +58,7 @@ namespace Nevermore
         /// <param name="jsonSettings"></param>
         /// <param name="relatedDocumentStore">If you don't have releated documents use the EmptyRelatedDocumentStore</param>
         /// <param name="keyBlockSize">Block size for the KeyAllocator</param>
+        /// <param name="objectInitialisationOptions"></param>
         public RelationalStore(
             Func<string> connectionString,
             string applicationName,
@@ -62,7 +66,8 @@ namespace Nevermore
             RelationalMappings mappings,
             JsonSerializerSettings jsonSettings,
             IRelatedDocumentStore relatedDocumentStore,
-            int keyBlockSize = 20)
+            int keyBlockSize = 20,
+            ObjectInitialisationOptions objectInitialisationOptions = ObjectInitialisationOptions.None)
         {
             this.registry = new Lazy<RelationalTransactionRegistry>(
                 () => SetConnectionStringOptions(connectionString(), applicationName)
@@ -73,6 +78,7 @@ namespace Nevermore
 
             this.jsonSettings = jsonSettings;
             this.relatedDocumentStore = relatedDocumentStore;
+            this.objectInitialisationOptions = objectInitialisationOptions;
         }
 
         public string ConnectionString => registry.Value.ConnectionString;
@@ -97,7 +103,7 @@ namespace Nevermore
             RetriableOperation retriableOperation = RetriableOperation.Delete | RetriableOperation.Select, string name = null)
         {
             return new RelationalTransaction(registry.Value, retriableOperation, isolationLevel, sqlCommandFactory,
-                jsonSettings, mappings, keyAllocator, relatedDocumentStore, name);
+                jsonSettings, mappings, keyAllocator, relatedDocumentStore, name, objectInitialisationOptions);
         }
 
         static RelationalTransactionRegistry SetConnectionStringOptions(string connectionString, string applicationName)

--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -38,6 +38,7 @@ namespace Nevermore
         readonly ITableAliasGenerator tableAliasGenerator = new TableAliasGenerator();
         readonly IUniqueParameterNameGenerator uniqueParameterNameGenerator = new UniqueParameterNameGenerator();
         readonly DataModificationQueryBuilder dataModificationQueryBuilder;
+        readonly ObjectInitialisationOptions objectInitialisationOptions;
 
         // To help track deadlocks
         readonly List<string> commandTrace = new List<string>();
@@ -53,7 +54,8 @@ namespace Nevermore
             RelationalMappings mappings,
             IKeyAllocator keyAllocator,
             IRelatedDocumentStore relatedDocumentStore,
-            string name = null
+            string name = null,
+            ObjectInitialisationOptions objectInitialisationOptions = ObjectInitialisationOptions.None
         )
         {
             this.registry = registry;
@@ -461,7 +463,7 @@ namespace Nevermore
                         }
                         else
                         {
-                            instance = (T) Activator.CreateInstance(instanceType, true);
+                            instance = (T) Activator.CreateInstance(instanceType, objectInitialisationOptions.HasFlag(ObjectInitialisationOptions.UseNonPublicConstructors));
                         }
 
                         var specificMapping = mappings.Get(instance.GetType());


### PR DESCRIPTION
Instead of always using non-public constructors, pass a flag that will determine if non-public constructors can be used.  This maintains backwards compatability.