### PR TITLE
 Ability to compare to null in where expressions

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -16,7 +16,7 @@ namespace Nevermore.IntegrationTests
     public class IntegrationTestDatabase
     {
         readonly TextWriter output = Console.Out;
-        readonly string SqlInstance = "(local)\\SQLEXPRESS,1433";
+        readonly string SqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "(local)\\SQLEXPRESS,1433";
         readonly string TestDatabaseName;
         readonly string TestDatabaseConnectionString;
 

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -21,6 +21,8 @@ namespace Nevermore.IntegrationTests.Model
         public string Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+
+        public string Nickname { get; set; }
         public ReferenceCollection Roles { get; private set; }
 
         public string JSON { get; set; }
@@ -34,6 +36,7 @@ namespace Nevermore.IntegrationTests.Model
 
             Column(m => m.FirstName).WithMaxLength(20);
             Column(m => m.LastName);
+            Column(m => m.Nickname).Nullable();
             Column(m => m.Roles);
             Column(m => m.JSON);
         }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -10,6 +10,7 @@ namespace Nevermore.IntegrationTests.Model
         {
             Column(m => m.FirstName).WithMaxLength(20);
             Column(m => m.LastName);
+            Column(m => m.Nickname).Nullable();
             Column(m => m.Roles);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }

--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -1,4 +1,6 @@
-﻿using Nevermore.IntegrationTests.Model;
+﻿using System.Linq;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
 using NUnit.Framework;
 
 namespace Nevermore.IntegrationTests
@@ -29,5 +31,31 @@ namespace Nevermore.IntegrationTests
             }
         }
 
+        [Test]
+        public void WhereNullClause()
+        {
+            using (var t = Store.BeginTransaction())
+            {
+                foreach (var c in new []
+                {
+                    new Customer {FirstName = "Alice", LastName = "Apple", Nickname = null},
+                    new Customer {FirstName = "Bob", LastName = "Banana", Nickname = ""},
+                    new Customer {FirstName = "Charlie", LastName = "Cherry", Nickname = "Chazza"}
+                })
+                    t.Insert(c);
+                t.Commit();
+                
+                var customersNull = t.TableQuery<Customer>()
+                    .Where(c => c.Nickname == null)
+                    .ToList();
+                
+                var customersNotNull = t.TableQuery<Customer>()
+                    .Where(c => c.Nickname != null)
+                    .ToList();
+
+                customersNull.Select(c => c.FirstName).Should().BeEquivalentTo("Alice");
+                customersNotNull.Select(c => c.FirstName).Should().BeEquivalentTo("Bob", "Charlie");
+            }
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -63,7 +63,8 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
 
                 var c = customers.Single(p => p.Id == "Customers-01");
                 c.FirstName.Should().Be("Bob", "Type isn't serializing into column correctly");
-                c.JSON.Should().Be("{\"Nickname\":\"Bob the builder\",\"LuckyNumbers\":null,\"ApiKey\":null,\"Passphrases\":null}");
+                c.Nickname.Should().Be("Bob the builder", "Type isn't serializing into column correctly");
+                c.JSON.Should().Be("{\"LuckyNumbers\":null,\"ApiKey\":null,\"Passphrases\":null}");
             }
         }
 

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseComparisonTypeTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseComparisonTypeTests.cs
@@ -81,6 +81,23 @@ FROM dbo.[Foo]
 WHERE ([Int] <> @int)
 ORDER BY [Id]");
         }
-        
+
+        [Test]
+        public void IsNull()
+        {
+            NewQueryBuilder().builder.Where(f => f.String == null).DebugViewRawQuery()
+                .Should()
+                .Be(@"SELECT *
+FROM dbo.[Foo]
+WHERE ([String] is null)
+ORDER BY [Id]");
+            
+            NewQueryBuilder().builder.Where(f => f.String != null).DebugViewRawQuery()
+                .Should()
+                .Be(@"SELECT *
+FROM dbo.[Foo]
+WHERE ([String] is not null)
+ORDER BY [Id]");
+        }
     }
 }

--- a/source/Nevermore/AST/Where.cs
+++ b/source/Nevermore/AST/Where.cs
@@ -129,7 +129,7 @@ AND ", subClauses.Select(c => $"({c.GenerateSql()})"));
             this.parameterName = parameterName;
         }
 
-        public string GenerateSql() => $"{whereFieldReference.GenerateSql()} {GetQueryOperandSql()} @{parameterName}";
+        public string GenerateSql() => $"{whereFieldReference.GenerateSql()} {GetQueryOperandSql()} {parameterName}";
         public override string ToString() => GenerateSql();
 
         string GetQueryOperandSql()
@@ -154,5 +154,21 @@ AND ", subClauses.Select(c => $"({c.GenerateSql()})"));
                     throw new NotSupportedException("Operand " + operand + " is not supported!");
             }
         }
+    }
+
+    public class IsNullClause : IWhereClause
+    {
+        readonly IWhereFieldReference whereFieldReference;
+        readonly bool not;
+
+        public IsNullClause(IWhereFieldReference whereFieldReference, bool not = false)
+        {
+            this.whereFieldReference = whereFieldReference;
+            this.not = not;
+        }
+
+        string NotPart => not ? " not " : " ";
+
+        public string GenerateSql() => $"{whereFieldReference.GenerateSql()} is{NotPart}null";
     }
 }

--- a/source/Nevermore/AST/Where.cs
+++ b/source/Nevermore/AST/Where.cs
@@ -129,7 +129,7 @@ AND ", subClauses.Select(c => $"({c.GenerateSql()})"));
             this.parameterName = parameterName;
         }
 
-        public string GenerateSql() => $"{whereFieldReference.GenerateSql()} {GetQueryOperandSql()} {parameterName}";
+        public string GenerateSql() => $"{whereFieldReference.GenerateSql()} {GetQueryOperandSql()} @{parameterName}";
         public override string ToString() => GenerateSql();
 
         string GetQueryOperandSql()

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -113,7 +113,8 @@ namespace Nevermore
         /// <returns>The query builder that can be used to add parameters to the query, and then further modify the query, or execute the query</returns>
         IArrayParametersQueryBuilder<TRecord> WhereParameterised(string fieldName, ArraySqlOperand operand, IEnumerable<Parameter> parameterNames);
         
-        IQueryBuilder<TRecord> WhereNull(string fieldName, bool not);
+        IQueryBuilder<TRecord> WhereNull(string fieldName);
+        IQueryBuilder<TRecord> WhereNotNull(string fieldName);
 
         /// <summary>
         /// Adds an order by clause to the query, where the order by clause will be in the default order (ascending).

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -112,6 +112,8 @@ namespace Nevermore
         /// <param name="parameterNames">The parameters that will be included in the where clause. Requires data types if used as part of a Function or Stored Procedure</param>
         /// <returns>The query builder that can be used to add parameters to the query, and then further modify the query, or execute the query</returns>
         IArrayParametersQueryBuilder<TRecord> WhereParameterised(string fieldName, ArraySqlOperand operand, IEnumerable<Parameter> parameterNames);
+        
+        IQueryBuilder<TRecord> WhereNull(string fieldName, bool not);
 
         /// <summary>
         /// Adds an order by clause to the query, where the order by clause will be in the default order (ascending).

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -11,6 +11,7 @@ namespace Nevermore
         void AddWhere(UnaryWhereParameter whereParams);
         void AddWhere(BinaryWhereParameter whereParams);
         void AddWhere(ArrayWhereParameter whereParams);
+        void AddWhere(IsNullWhereParameter isNull);
         void AddWhere(string whereClause);
         void AddColumn(string columnName);
         void AddColumn(string columnName, string columnAlias);

--- a/source/Nevermore/IsNullWhereParameter.cs
+++ b/source/Nevermore/IsNullWhereParameter.cs
@@ -1,0 +1,16 @@
+﻿using Nevermore.AST;
+
+namespace Nevermore
+{
+    public class IsNullWhereParameter
+    {
+        public IsNullWhereParameter(string fieldName, bool not)
+        {
+            FieldName = fieldName;
+            Not = not;
+        }
+
+        public string FieldName { get; }
+        public bool Not { get; }
+    }
+}

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -44,9 +44,15 @@ namespace Nevermore
             return this;
         }
 
-        public IQueryBuilder<TRecord> WhereNull(string fieldName, bool not)
+        public IQueryBuilder<TRecord> WhereNull(string fieldName)
         {
-            selectBuilder.AddWhere(new IsNullWhereParameter(fieldName, not));
+            selectBuilder.AddWhere(new IsNullWhereParameter(fieldName, false));
+            return this;
+        }
+        
+        public IQueryBuilder<TRecord> WhereNotNull(string fieldName)
+        {
+            selectBuilder.AddWhere(new IsNullWhereParameter(fieldName, true));
             return this;
         }
 

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -44,6 +44,12 @@ namespace Nevermore
             return this;
         }
 
+        public IQueryBuilder<TRecord> WhereNull(string fieldName, bool not)
+        {
+            selectBuilder.AddWhere(new IsNullWhereParameter(fieldName, not));
+            return this;
+        }
+
         public IUnaryParameterQueryBuilder<TRecord> WhereParameterised(string fieldName, UnarySqlOperand operand, Parameter parameter)
         {
             var uniqueParameter = new UniqueParameter(uniqueParameterNameGenerator, parameter);

--- a/source/Nevermore/QueryBuilderWhereExtensions.cs
+++ b/source/Nevermore/QueryBuilderWhereExtensions.cs
@@ -39,6 +39,8 @@ namespace Nevermore
                 {
                     case ExpressionType.Equal:
                         return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.Equal, binExpr);
+                    case ExpressionType.NotEqual:
+                        return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.NotEqual, binExpr);
                     case ExpressionType.GreaterThan:
                         return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.GreaterThan, binExpr);
                     case ExpressionType.GreaterThanOrEqual:
@@ -47,8 +49,6 @@ namespace Nevermore
                         return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.LessThan, binExpr);
                     case ExpressionType.LessThanOrEqual:
                         return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.LessThanOrEqual, binExpr);
-                    case ExpressionType.NotEqual:
-                        return AddUnaryWhereClauseFromExpression(queryBuilder, UnarySqlOperand.NotEqual, binExpr);
                     case ExpressionType.AndAlso:
                         return AddLogicalAndOperatorWhereClauses(queryBuilder, binExpr);
                     default:
@@ -144,6 +144,9 @@ namespace Nevermore
 
             var value = GetValueFromExpression(binaryExpression.Right, property.PropertyType);
             var fieldName = property.Name;
+            
+            if (value == null && new[] {UnarySqlOperand.Equal, UnarySqlOperand.NotEqual}.Contains(operand))
+                return queryBuilder.WhereNull(fieldName, operand == UnarySqlOperand.NotEqual);
             return queryBuilder.Where(fieldName, operand, value);
         }
         
@@ -171,8 +174,7 @@ namespace Nevermore
         public static IQueryBuilder<TRecord> Where<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string fieldName,
             UnarySqlOperand operand, object value) where TRecord : class
         {
-            return queryBuilder.WhereParameterised(fieldName, operand, new Parameter(fieldName))
-                .ParameterValue(value);
+            return queryBuilder.WhereParameterised(fieldName, operand, new Parameter(fieldName)).ParameterValue(value);
         }
 
         /// <summary>

--- a/source/Nevermore/QueryBuilderWhereExtensions.cs
+++ b/source/Nevermore/QueryBuilderWhereExtensions.cs
@@ -146,7 +146,7 @@ namespace Nevermore
             var fieldName = property.Name;
             
             if (value == null && new[] {UnarySqlOperand.Equal, UnarySqlOperand.NotEqual}.Contains(operand))
-                return operand == UnarySqlOperand.NotEqual ? queryBuilder.WhereNotNull(fieldName) : queryBuilder.WhereNull(fieldName);
+                return operand == UnarySqlOperand.Equal ? queryBuilder.WhereNull(fieldName) : queryBuilder.WhereNotNull(fieldName);
             return queryBuilder.Where(fieldName, operand, value);
         }
         

--- a/source/Nevermore/QueryBuilderWhereExtensions.cs
+++ b/source/Nevermore/QueryBuilderWhereExtensions.cs
@@ -146,7 +146,7 @@ namespace Nevermore
             var fieldName = property.Name;
             
             if (value == null && new[] {UnarySqlOperand.Equal, UnarySqlOperand.NotEqual}.Contains(operand))
-                return queryBuilder.WhereNull(fieldName, operand == UnarySqlOperand.NotEqual);
+                return operand == UnarySqlOperand.NotEqual ? queryBuilder.WhereNotNull(fieldName) : queryBuilder.WhereNull(fieldName);
             return queryBuilder.Where(fieldName, operand, value);
         }
         

--- a/source/Nevermore/SelectBuilder.cs
+++ b/source/Nevermore/SelectBuilder.cs
@@ -277,6 +277,11 @@ namespace Nevermore
             WhereClauses.Add(new ArrayWhereClause(new WhereFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterNames));
         }
 
+        public virtual void AddWhere(IsNullWhereParameter isNull)
+        {
+            WhereClauses.Add(new IsNullClause(new WhereFieldReference(isNull.FieldName), isNull.Not));
+        }
+
         public void AddWhere(string whereClause)
         {
             WhereClauses.Add(new CustomWhereClause(whereClause));

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -312,7 +312,9 @@ namespace Nevermore
             return Builder.WhereParameterised(fieldName, operand, parameter);
         }
         
-        public IQueryBuilder<TRecord> WhereNull(string fieldName, bool not) => Builder.WhereNull(fieldName, not);
+        public IQueryBuilder<TRecord> WhereNull(string fieldName) => Builder.WhereNull(fieldName);
+        
+        public IQueryBuilder<TRecord> WhereNotNull(string fieldName) => Builder.WhereNotNull(fieldName);
 
         public IBinaryParametersQueryBuilder<TRecord> WhereParameterised(string fieldName, BinarySqlOperand operand,
             Parameter startValueParameter, Parameter endValueParameter)

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -311,6 +311,8 @@ namespace Nevermore
         {
             return Builder.WhereParameterised(fieldName, operand, parameter);
         }
+        
+        public IQueryBuilder<TRecord> WhereNull(string fieldName, bool not) => Builder.WhereNull(fieldName, not);
 
         public IBinaryParametersQueryBuilder<TRecord> WhereParameterised(string fieldName, BinarySqlOperand operand,
             Parameter startValueParameter, Parameter endValueParameter)


### PR DESCRIPTION
Added ability to compare to null in where expressions
e.g. `t.TableQuery<Customer>().Where(c => c.Nickname == null)`