### PR TITLE
Added ReadOnly option for columns

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -140,6 +140,8 @@ namespace Nevermore.IntegrationTests
 
                 transaction.ExecuteScalar<int>(output.ToString());
 
+                transaction.ExecuteScalar<int>($"alter table [{nameof(Customer)}] add [RowVersion] rowversion");
+
                 transaction.Commit();
             }
         }

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -18,5 +18,6 @@ namespace Nevermore.IntegrationTests.Model
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }
         public string[] Passphrases { get; set; }
+        public byte[] RowVersion { get; set; }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -12,6 +12,7 @@ namespace Nevermore.IntegrationTests.Model
             Column(m => m.LastName);
             Column(m => m.Nickname).Nullable();
             Column(m => m.Roles);
+            Column(m => m.RowVersion).ReadOnly();
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }
@@ -24,7 +25,6 @@ namespace Nevermore.IntegrationTests.Model
 
         public string Nickname { get; set; }
         public ReferenceCollection Roles { get; private set; }
-
         public string JSON { get; set; }
     }
 

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -198,5 +198,18 @@ namespace Nevermore.IntegrationTests
                 ex.Message.Should().Be("Customers must have a unique name");
             }
         }
+
+        [Test]
+        public void ShouldHanldeRowVersionColumn()
+        {
+            using (var transaction = Store.BeginTransaction())
+            {
+                var customer1 = new Customer {FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
+                transaction.Insert(customer1); // customer has a RowVersion column, but would have an error when inserting if the ReadOnly mapping was ignored
+                var dbCustomer = transaction.TableQuery<Customer>().Where(c => c.Id == customer1.Id).ToList().Single();
+                dbCustomer.RowVersion.Length.Should().Be(8);
+                dbCustomer.RowVersion.All(v => v == 0).Should().BeFalse();
+            }
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -200,7 +200,7 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
-        public void ShouldHanldeRowVersionColumn()
+        public void ShouldHandleRowVersionColumn()
         {
             using (var transaction = Store.BeginTransaction())
             {

--- a/source/Nevermore.IntegrationTests/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SchemaGenerator.cs
@@ -14,7 +14,7 @@ namespace Nevermore.IntegrationTests
             result.AppendLine("CREATE TABLE [" + tableName + "] (");
             result.AppendFormat("  [Id] NVARCHAR(50) NOT NULL CONSTRAINT [PK_{0}_Id] PRIMARY KEY CLUSTERED, ", tableName).AppendLine();
 
-            foreach (var column in mapping.IndexedColumns)
+            foreach (var column in mapping.WritableIndexedColumns())
             {
                 result.AppendFormat("  [{0}] {1} {2}, ", column.ColumnName, GetDatabaseType(column).ToUpperInvariant(), column.IsNullable ? "NULL" : "NOT NULL").AppendLine();
             }

--- a/source/Nevermore.Tests/Nevermore.Tests.csproj
+++ b/source/Nevermore.Tests/Nevermore.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.9" />
-    <PackageReference Include="Assent" Version="0.8.0" />
+    <PackageReference Include="Assent" Version="1.3.1" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
@@ -1,6 +1,6 @@
 INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
 
-@Id=New-Id
-@JSON={}
+@Id=Doc-1
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
@@ -9,13 +9,13 @@ INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocum
 ,(@2__Id, 'TestDocumentTbl', @relateddocument_3, 'OtherTbl')
 
 @0__Id=New-Id-1
-@0__JSON={"Id":null,"AColumn":"Doc1"}
+@0__JSON={}
 @0__AColumn=Doc1
 @1__Id=New-Id-2
-@1__JSON={"Id":null,"AColumn":"Doc2"}
+@1__JSON={}
 @1__AColumn=Doc2
 @2__Id=New-Id-3
-@2__JSON={"Id":null,"AColumn":"Doc1"}
+@2__JSON={}
 @2__AColumn=Doc1
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
@@ -8,7 +8,7 @@ INSERT INTO [OtherRelatedTable] ([Id], [Table], [RelatedDocumentId], [RelatedDoc
 ,(@Id, 'TestDocumentTbl', @otherrelatedtable_1, 'OtherTbl')
 
 @Id=New-Id-1
-@JSON={"Id":null,"AColumn":"Doc1"}
+@JSON={}
 @AColumn=Doc1
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
@@ -3,8 +3,8 @@ INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES
 ,(@1__AColumn, @1__Id, @1__JSON)
 
 @0__Id=New-Id-1
-@0__JSON={"Id":null,"AColumn":"AValue1","NotMapped":"NonMappedValue"}
+@0__JSON={"NotMapped":"NonMappedValue"}
 @0__AColumn=AValue1
 @1__Id=New-Id-2
-@1__JSON={"Id":null,"AColumn":"AValue2","NotMapped":"NonMappedValue"}
+@1__JSON={"NotMapped":"NonMappedValue"}
 @1__AColumn=AValue2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
@@ -2,5 +2,5 @@ INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES
 (@AColumn, @Id, @JSON)
 
 @Id=New-Id
-@JSON={"Id":null,"AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
@@ -2,5 +2,5 @@ INSERT INTO dbo.[TestDocumentTbl]  (AColumn, Id, JSON) VALUES
 (@AColumn, @Id, @JSON)
 
 @Id=SuppliedId
-@JSON={"Id":"SuppliedId","AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
@@ -5,7 +5,7 @@ INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocum
 ,(@Id, 'TestDocumentTbl', @relateddocument_1, 'OtherTbl')
 
 @Id=New-Id
-@JSON={"Id":null,"AColumn":"AValue"}
+@JSON={}
 @AColumn=AValue
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
@@ -4,6 +4,6 @@ INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocum
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')
 
 @Id=New-Id
-@JSON={"Id":null,"AColumn":"AValue"}
+@JSON={}
 @AColumn=AValue
 @relateddocument_0=Rel-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
@@ -2,5 +2,5 @@ INSERT INTO dbo.[AltTableName] WITH (NOLOCK) (AColumn, Id, JSON) VALUES
 (@AColumn, @Id, @JSON)
 
 @Id=New-Id
-@JSON={"Id":null,"AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
@@ -2,5 +2,5 @@ INSERT INTO dbo.[TestDocumentTbl]  (AColumn) VALUES
 (@AColumn)
 
 @Id=New-Id
-@JSON={"Id":null,"AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
@@ -1,4 +1,4 @@
 UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
-@JSON={"Id":"Doc-1","AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
@@ -1,4 +1,4 @@
 UPDATE dbo.[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
-@JSON={"Id":"Doc-1","AColumn":"AValue","NotMapped":"NonMappedValue"}
+@JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
@@ -25,7 +25,7 @@ SELECT @Id, 'TestDocumentTbl', Reference, ReferenceTable FROM @references t
 WHERE NOT EXISTS (SELECT null FROM [OtherRelatedTable] r WHERE r.[Id] = @Id AND r.[RelatedDocumentId] = t.Reference )
 
 @Id=Doc-1
-@JSON={"Id":"Doc-1","AColumn":"Doc1"}
+@JSON={}
 @AColumn=Doc1
 @relateddocument_0=Rel-1
 @relateddocument_1=Rel-2

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
@@ -3,5 +3,5 @@ UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
 
 @Id=Doc-1
-@JSON={"Id":"Doc-1","AColumn":"AValue"}
+@JSON={}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
@@ -14,6 +14,6 @@ SELECT @Id, 'TestDocumentTbl', Reference, ReferenceTable FROM @references t
 WHERE NOT EXISTS (SELECT null FROM [RelatedDocument] r WHERE r.[Id] = @Id AND r.[RelatedDocumentId] = t.Reference )
 
 @Id=Doc-1
-@JSON={"Id":"Doc-1","AColumn":"AValue"}
+@JSON={}
 @AColumn=AValue
 @relateddocument_0=Rel-1

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -21,7 +21,7 @@ namespace Nevermore.Mapping
         DbType? dbType;
         int maxLength;
 
-        public ColumnMapping(string columnName, DbType dbType, IPropertyReaderWriter<object> readerWriter)
+        public ColumnMapping(string columnName, DbType dbType, IPropertyReaderWriter<object> readerWriter, bool readOnly = false)
         {
             if (columnName == null)
                 throw new ArgumentNullException("columnName");
@@ -31,6 +31,7 @@ namespace Nevermore.Mapping
             this.dbType = dbType;
             ColumnName = columnName;
             ReaderWriter = readerWriter;
+            IsReadOnly = readOnly;
         }
 
         public ColumnMapping(PropertyInfo property)
@@ -103,6 +104,7 @@ namespace Nevermore.Mapping
 
         public PropertyInfo Property { get; private set; }
         public IPropertyReaderWriter<object> ReaderWriter { get; set; }
+        public bool IsReadOnly { get; set; }
 
         public ColumnMapping Nullable()
         {
@@ -113,6 +115,12 @@ namespace Nevermore.Mapping
         public ColumnMapping WithMaxLength(int max)
         {
             maxLength = max;
+            return this;
+        }
+
+        public ColumnMapping ReadOnly()
+        {
+            IsReadOnly = true;
             return this;
         }
     }

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -27,7 +27,7 @@ namespace Nevermore.Mapping
             return column;
         }
 
-        protected ColumnMapping VirtualColumn<TProperty>(string name, DbType databaseType, Func<TDocument, TProperty> reader, Action<TDocument, TProperty> writer = null, int? maxLength = null, bool nullable = false)
+        protected ColumnMapping VirtualColumn<TProperty>(string name, DbType databaseType, Func<TDocument, TProperty> reader, Action<TDocument, TProperty> writer = null, int? maxLength = null, bool nullable = false, bool readOnly = false)
         {
             var column = new ColumnMapping(name, databaseType, new DelegateReaderWriter<TDocument, TProperty>(reader, writer));
             IndexedColumns.Add(column);
@@ -36,6 +36,7 @@ namespace Nevermore.Mapping
                 column.MaxLength = maxLength.Value;
             }
             column.IsNullable = nullable;
+            column.IsReadOnly = readOnly;
             return column;
         }
 


### PR DESCRIPTION
For some columns, the database itself calculates values, and Nevermore should be able to be configured to read a column but not include in insert/update statements. RowVersion and SQL Calculated Columns are examples of this. 

For example, in a derived class of  `DocumentMap` , this configures the RowVersion column to be read from the database and not updated/inserted:
```
Column(m => m.RowVersion).ReadOnly();
```