### PR TITLE
Add more options to specify command timeouts and add missing timing log messages

### DIFF
--- a/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommandFactory.cs
+++ b/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommandFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using Nevermore.Mapping;
 
@@ -14,9 +15,9 @@ namespace Nevermore.IntegrationTests.Chaos
             this.chaosFactor = chaosFactor;
         }
 
-        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, int? commandTimeoutSeconds = null)
+        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, TimeSpan? commandTimeout = null)
         {
-            return new ChaosSqlCommand(wrappedFactory.CreateCommand(connection, transaction, statement, args, mapping, commandTimeoutSeconds), chaosFactor);
+            return new ChaosSqlCommand(wrappedFactory.CreateCommand(connection, transaction, statement, args, mapping, commandTimeout), chaosFactor);
         }
     }
 }

--- a/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
@@ -17,7 +17,7 @@ namespace Nevermore.Tests.Delete
             transaction = Substitute.For<IRelationalTransaction>();
         }
 
-        IDeleteQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(Action<Type, Where, CommandParameterValues, int?> executeDelete) where TDocument : class
+        IDeleteQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(Action<Type, Where, CommandParameterValues, TimeSpan?> executeDelete) where TDocument : class
         {
             return new DeleteQueryBuilder<TDocument>(new UniqueParameterNameGenerator(), executeDelete, Enumerable.Empty<IWhereClause>(), new CommandParameterValues());
         }
@@ -27,7 +27,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
 
-            void ExecuteDelete(Type _, Where where, CommandParameterValues __, int? ___) => actual = where.GenerateSql().Trim();
+            void ExecuteDelete(Type _, Where where, CommandParameterValues __, TimeSpan? ___) => actual = where.GenerateSql().Trim();
 
             CreateQueryBuilder<IDocument>(ExecuteDelete)
                 .Where("[Price] > 5")
@@ -41,7 +41,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -61,7 +61,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -82,7 +82,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -103,7 +103,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -122,7 +122,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -142,7 +142,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;
@@ -162,7 +162,7 @@ namespace Nevermore.Tests.Delete
         {
             string actual = null;
             CommandParameterValues values = null;
-            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, int? ___)
+            void ExecuteDelete(Type _, Where where, CommandParameterValues cmdValue, TimeSpan? ___)
             {
                 actual = @where.GenerateSql().Trim();
                 values = cmdValue;

--- a/source/Nevermore/DeleteQueryBuilder.cs
+++ b/source/Nevermore/DeleteQueryBuilder.cs
@@ -11,13 +11,13 @@ namespace Nevermore
     internal class DeleteQueryBuilder<TRecord> : IDeleteQueryBuilder<TRecord> where TRecord : class
     {
         readonly IUniqueParameterNameGenerator uniqueParameterNameGenerator;
-        readonly Action<Type, Where, CommandParameterValues, int?> executeDelete;
+        readonly Action<Type, Where, CommandParameterValues, TimeSpan?> executeDelete;
         readonly IEnumerable<IWhereClause> whereClauses;
         readonly CommandParameterValues parameterValues;
 
         public DeleteQueryBuilder(
             IUniqueParameterNameGenerator uniqueParameterNameGenerator, 
-            Action<Type, Where, CommandParameterValues, int?> executeDelete, 
+            Action<Type, Where, CommandParameterValues, TimeSpan?> executeDelete, 
             IEnumerable<IWhereClause> whereClauses, 
             CommandParameterValues parameterValues)
         {
@@ -97,12 +97,12 @@ namespace Nevermore
             return new DeleteQueryBuilder<TNewRecord>(uniqueParameterNameGenerator, executeDelete, whereClauses, parameterValues);
         }
 
-        public void Delete(int? commandTimeoutSeconds = null)
+        public void Delete(TimeSpan? commandTimeout = null)
         {
             var whereClausesList = whereClauses.ToList();
             var where = whereClausesList.Any() ? new Where(new AndClause(whereClausesList)) : new Where();
 
-            executeDelete(typeof(TRecord), where, parameterValues, commandTimeoutSeconds);
+            executeDelete(typeof(TRecord), where, parameterValues, commandTimeout);
         }
     }
 }

--- a/source/Nevermore/ICompleteQuery.cs
+++ b/source/Nevermore/ICompleteQuery.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace Nevermore
+{
+    public interface ICompleteQuery<TRecord> where TRecord : class
+    {
+        /// <summary>
+        /// Executes the query, and counts the number of rows.
+        /// Any order by clauses will be ignored
+        /// </summary>
+        /// <returns>The number of rows in the result set</returns>
+        int Count();
+
+        /// <summary>
+        /// Executes the query and determines if there are any rows
+        /// </summary>
+        /// <returns>Returns true if there are any rows in the result set, otherwise false</returns>
+        bool Any();
+
+        /// <summary>
+        /// Executes the query and retuns the first row
+        /// </summary>
+        /// <returns>The first row in the result set</returns>
+        TRecord First();
+
+        /// <summary>
+        ///  Executes the query and returns the specified number of rows
+        /// </summary>
+        /// <param name="take">The number of rows to return</param>
+        /// <returns>The specified number of rows from the start of the result set</returns>
+        IEnumerable<TRecord> Take(int take);
+
+        /// <summary>
+        /// Executes the query and returns the specified number of rows, after first skipping a specified number of rows.
+        /// The rows are completely enumerated and stored in a List in memory.
+        /// </summary>
+        /// <param name="skip">The number of rows to skip before starting to return rows</param>
+        /// <param name="take">The number of rows to return</param>
+        /// <returns>The specified number of rows taken from the result set, after first skipping the specified number of rows</returns>
+        List<TRecord> ToList(int skip, int take);
+
+        /// <summary>
+        /// Executes the query and returns the specified number of rows, after first skipping a specified number of rows.
+        /// Additionally executes the query a second time to determine the total number of available rows.
+        /// The rows are completely enumerated and stored in a List in memory.
+        /// </summary>
+        /// <param name="skip">The number of rows to skip before starting to return rows</param>
+        /// <param name="take">The number of rows to return</param>
+        /// <param name="totalResults">The total number of available rows</param>
+        /// <returns>The specified number of rows taken from the result set, after first skipping the specified number of rows</returns>
+        List<TRecord> ToList(int skip, int take, out int totalResults);
+
+        /// <summary>
+        /// Executes the query and returns all of the rows. 
+        /// The rows are completely enumerated and stored in a List in memory.
+        /// </summary>
+        /// <returns>All of the rows from the result set</returns>
+        List<TRecord> ToList();
+
+        /// <summary>
+        /// Executes the query and streams the rows.
+        /// The rows are not enumerated up front and are not all stored in memory at the same time.
+        /// This is useful when executing an unbounded query that will produce a large result set.
+        /// </summary>
+        /// <returns>An IEnumerable that can be used to enumerate through all of the rows in the result set</returns>
+        IEnumerable<TRecord> Stream();
+
+        /// <summary>
+        /// Executes the query and converts the result to dictionary.
+        /// </summary>
+        /// <param name="keySelector">Defines how to select a key for the dictionary from a row</param>
+        /// <returns>A dictionary that maps the specified keys to rows from the result set</returns>
+        IDictionary<string, TRecord> ToDictionary(Func<TRecord, string> keySelector);
+    }
+}

--- a/source/Nevermore/IDeleteQueryBuilder.cs
+++ b/source/Nevermore/IDeleteQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Nevermore
@@ -13,6 +14,6 @@ namespace Nevermore
 
         IDeleteQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class;
 
-        void Delete(int? commandTimeoutSeconds = null);
+        void Delete(TimeSpan? commandTimeout = null);
     }
 }

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -76,6 +76,13 @@ namespace Nevermore
     public interface IQueryBuilder<TRecord> where TRecord : class
     {
         /// <summary>
+        /// Sets the command timeout for the query execution
+        /// </summary>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout);
+
+        /// <summary>
         /// Adds a custom where expression to the query. Avoid using this as it is difficult to refactor. Prefer using Where methods from <see cref="QueryBuilderWhereExtensions" />
         /// </summary>
         /// <param name="whereClause">Where clause expression that will be inserted directly into the resulting SQL string</param>

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -73,14 +73,14 @@ namespace Nevermore
         IJoinSourceQueryBuilder<TRecord> On(string leftField, JoinOperand operand, string rightField);
     }
 
-    public interface IQueryBuilder<TRecord> where TRecord : class
+    public interface IQueryBuilder<TRecord> : ICompleteQuery<TRecord> where TRecord : class
     {
         /// <summary>
         /// Sets the command timeout for execution of the query
         /// </summary>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout);
+        ICompleteQuery<TRecord> WithTimeout(TimeSpan commandTimeout);
 
         /// <summary>
         /// Adds a custom where expression to the query. Avoid using this as it is difficult to refactor. Prefer using Where methods from <see cref="QueryBuilderWhereExtensions" />
@@ -275,75 +275,7 @@ namespace Nevermore
         /// </summary>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         ISubquerySourceBuilder<TRecord> Subquery(); 
-
-        /// <summary>
-        /// Executes the query, and counts the number of rows.
-        /// Any order by clauses will be ignored
-        /// </summary>
-        /// <returns>The number of rows in the result set</returns>
-        int Count();
-
-        /// <summary>
-        /// Executes the query and determines if there are any rows
-        /// </summary>
-        /// <returns>Returns true if there are any rows in the result set, otherwise false</returns>
-        bool Any();
-
-        /// <summary>
-        /// Executes the query and retuns the first row
-        /// </summary>
-        /// <returns>The first row in the result set</returns>
-        TRecord First();
-
-        /// <summary>
-        ///  Executes the query and returns the specified number of rows
-        /// </summary>
-        /// <param name="take">The number of rows to return</param>
-        /// <returns>The specified number of rows from the start of the result set</returns>
-        IEnumerable<TRecord> Take(int take);
-
-        /// <summary>
-        /// Executes the query and returns the specified number of rows, after first skipping a specified number of rows.
-        /// The rows are completely enumerated and stored in a List in memory.
-        /// </summary>
-        /// <param name="skip">The number of rows to skip before starting to return rows</param>
-        /// <param name="take">The number of rows to return</param>
-        /// <returns>The specified number of rows taken from the result set, after first skipping the specified number of rows</returns>
-        List<TRecord> ToList(int skip, int take);
-
-        /// <summary>
-        /// Executes the query and returns the specified number of rows, after first skipping a specified number of rows.
-        /// Additionally executes the query a second time to determine the total number of available rows.
-        /// The rows are completely enumerated and stored in a List in memory.
-        /// </summary>
-        /// <param name="skip">The number of rows to skip before starting to return rows</param>
-        /// <param name="take">The number of rows to return</param>
-        /// <param name="totalResults">The total number of available rows</param>
-        /// <returns>The specified number of rows taken from the result set, after first skipping the specified number of rows</returns>
-        List<TRecord> ToList(int skip, int take, out int totalResults);
-
-        /// <summary>
-        /// Executes the query and returns all of the rows. 
-        /// The rows are completely enumerated and stored in a List in memory.
-        /// </summary>
-        /// <returns>All of the rows from the result set</returns>
-        List<TRecord> ToList();
-
-        /// <summary>
-        /// Executes the query and streams the rows.
-        /// The rows are not enumerated up front and are not all stored in memory at the same time.
-        /// This is useful when executing an unbounded query that will produce a large result set.
-        /// </summary>
-        /// <returns>An IEnumerable that can be used to enumerate through all of the rows in the result set</returns>
-        IEnumerable<TRecord> Stream();
-
-        /// <summary>
-        /// Executes the query and converts the result to dictionary.
-        /// </summary>
-        /// <param name="keySelector">Defines how to select a key for the dictionary from a row</param>
-        /// <returns>A dictionary that maps the specified keys to rows from the result set</returns>
-        IDictionary<string, TRecord> ToDictionary(Func<TRecord, string> keySelector);
-
+    
         /// <summary>
         /// Used internally. Can also be used for testing, debugging, and for extension methods. Avoid using directly
         /// </summary>

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -76,7 +76,7 @@ namespace Nevermore
     public interface IQueryBuilder<TRecord> where TRecord : class
     {
         /// <summary>
-        /// Sets the command timeout for the query execution
+        /// Sets the command timeout for execution of the query
         /// </summary>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>

--- a/source/Nevermore/IQueryExecutor.cs
+++ b/source/Nevermore/IQueryExecutor.cs
@@ -14,9 +14,9 @@ namespace Nevermore
         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A scalar value.</returns>
-        TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, int? commandTimeoutSeconds = null);
+        TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns a data reader, and allows you to manually read the fields.
@@ -26,8 +26,8 @@ namespace Nevermore
         ///     A callback that will be invoked with the SQL data reader. The reader will be disposed
         ///     after the callback returns.
         /// </param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void ExecuteReader(string query, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null);
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void ExecuteReader(string query, Action<IDataReader> readerCallback, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns a data reader, and allows you to manually read the fields.
@@ -38,8 +38,8 @@ namespace Nevermore
         ///     A callback that will be invoked with the SQL data reader. The reader will be disposed
         ///     after the callback returns.
         /// </param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void ExecuteReader(string query, CommandParameterValues args, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null);
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void ExecuteReader(string query, CommandParameterValues args, Action<IDataReader> readerCallback, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns strongly typed documents.
@@ -47,9 +47,9 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A stream of resulting documents.</returns>
-        IEnumerable<TDocument> ExecuteReader<TDocument>(string query, CommandParameterValues args, int? commandTimeoutSeconds = null);
+        IEnumerable<TDocument> ExecuteReader<TDocument>(string query, CommandParameterValues args, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns strongly typed documents using a custom mapper function.
@@ -58,18 +58,18 @@ namespace Nevermore
         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
         /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A stream of resulting documents.</returns>
-        IEnumerable<TDocument> ExecuteReaderWithProjection<TDocument>(string query, CommandParameterValues args, Func<IProjectionMapper, TDocument> projectionMapper, int? commandTimeoutSeconds = null);
+        IEnumerable<TDocument> ExecuteReaderWithProjection<TDocument>(string query, CommandParameterValues args, Func<IProjectionMapper, TDocument> projectionMapper, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns no results.
         /// </summary>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>The number of rows affected.</returns>
-        int ExecuteNonQuery(string query, CommandParameterValues args = null, int? commandTimeoutSeconds = null);
+        int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Creates a query that returns strongly typed documents.
@@ -143,8 +143,8 @@ namespace Nevermore
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="instance">The document instance to insert.</param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void Insert<TDocument>(TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Insert<TDocument>(TDocument instance, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into a specific table. The item will have an automatically assigned ID, and that ID
@@ -153,8 +153,8 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="tableName">The name of the table to insert the document into.</param>
         /// <param name="instance">The document instance to insert.</param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void Insert<TDocument>(string tableName, TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Insert<TDocument>(string tableName, TDocument instance, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into the default table for the document type. Uses a specific ID rather than
@@ -163,8 +163,8 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="instance">The document instance to insert.</param>
         /// <param name="customAssignedId">The ID to assign to the document.</param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void Insert<TDocument>(TDocument instance, string customAssignedId, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Insert<TDocument>(TDocument instance, string customAssignedId, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into a specific table. Uses a specific ID rather than automatically generating one.
@@ -174,8 +174,8 @@ namespace Nevermore
         /// <param name="instance">The document instance to insert.</param>
         /// <param name="customAssignedId">The ID to assign to the document.</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
-        void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts multiple items into a specific table.
@@ -185,8 +185,8 @@ namespace Nevermore
         /// <param name="instances">The document instances to insert (will be formed into a multiple VALUES for a single SQL INSERT.</param>
         /// <param name="includeDefaultModelColumns">Whether to include the Id and Json columns in the mapping (can disable for certain tables that do not use Json - like the EventRelatedDocument table etc).</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        /// <param name="commandTimeoutSeconds"></param>
-        void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances, bool includeDefaultModelColumns, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances, bool includeDefaultModelColumns, string tableHint = null, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Updates an existing document in the database.
@@ -194,24 +194,24 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being updated.</typeparam>
         /// <param name="instance">The document to update.</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
-        void Update<TDocument>(TDocument instance, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Update<TDocument>(TDocument instance, string tableHint = null, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="instance">The document to delete.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
-        void Delete<TDocument>(TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void Delete<TDocument>(TDocument instance, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Deletes an existing document from the database by it's ID.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
-        /// <param name="commandTimeoutSeconds">A custom timeout in seconds to use for the command instead of the default.</param>
-        void DeleteById<TDocument>(string id, int? commandTimeoutSeconds = null) where TDocument : class, IId;
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        void DeleteById<TDocument>(string id, TimeSpan? commandTimeout = null) where TDocument : class, IId;
 
         /// <summary>
         /// Allocate an ID for the specified type. The type must be mapped.

--- a/source/Nevermore/IQueryExecutor.cs
+++ b/source/Nevermore/IQueryExecutor.cs
@@ -23,10 +23,11 @@ namespace Nevermore
         /// </summary>
         /// <param name="query">The SQL query to execute. Example: <c>SELECT DISTINCT ProjectId FROM Release...</c></param>
         /// <param name="readerCallback">
-        /// A callback that will be invoked with the SQL data reader. The reader will be disposed
-        /// after the callback returns.
+        ///     A callback that will be invoked with the SQL data reader. The reader will be disposed
+        ///     after the callback returns.
         /// </param>
-        void ExecuteReader(string query, Action<IDataReader> readerCallback);
+        /// <param name="commandTimeoutSeconds"></param>
+        void ExecuteReader(string query, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Executes a query that returns a data reader, and allows you to manually read the fields.
@@ -34,10 +35,11 @@ namespace Nevermore
         /// <param name="query">The SQL query to execute. Example: <c>SELECT DISTINCT ProjectId FROM Release...</c></param>
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
         /// <param name="readerCallback">
-        /// A callback that will be invoked with the SQL data reader. The reader will be disposed
-        /// after the callback returns.
+        ///     A callback that will be invoked with the SQL data reader. The reader will be disposed
+        ///     after the callback returns.
         /// </param>
-        void ExecuteReader(string query, CommandParameterValues args, Action<IDataReader> readerCallback);
+        /// <param name="commandTimeoutSeconds"></param>
+        void ExecuteReader(string query, CommandParameterValues args, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null);
 
         /// <summary>
         /// Executes a query that returns strongly typed documents.
@@ -141,7 +143,8 @@ namespace Nevermore
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="instance">The document instance to insert.</param>
-        void Insert<TDocument>(TDocument instance) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds"></param>
+        void Insert<TDocument>(TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into a specific table. The item will have an automatically assigned ID, and that ID
@@ -150,7 +153,8 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="tableName">The name of the table to insert the document into.</param>
         /// <param name="instance">The document instance to insert.</param>
-        void Insert<TDocument>(string tableName, TDocument instance) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds"></param>
+        void Insert<TDocument>(string tableName, TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into the default table for the document type. Uses a specific ID rather than
@@ -159,7 +163,8 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="instance">The document instance to insert.</param>
         /// <param name="customAssignedId">The ID to assign to the document.</param>
-        void Insert<TDocument>(TDocument instance, string customAssignedId) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds"></param>
+        void Insert<TDocument>(TDocument instance, string customAssignedId, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Immediately inserts a new item into a specific table. Uses a specific ID rather than automatically generating one.
@@ -180,7 +185,8 @@ namespace Nevermore
         /// <param name="instances">The document instances to insert (will be formed into a multiple VALUES for a single SQL INSERT.</param>
         /// <param name="includeDefaultModelColumns">Whether to include the Id and Json columns in the mapping (can disable for certain tables that do not use Json - like the EventRelatedDocument table etc).</param>
         /// <param name="tableHint">The table hint to use for the insert (useful when we need a table lock on insert).</param>
-        void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances, bool includeDefaultModelColumns, string tableHint = null) where TDocument : class, IId;
+        /// <param name="commandTimeoutSeconds"></param>
+        void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances, bool includeDefaultModelColumns, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId;
 
         /// <summary>
         /// Updates an existing document in the database.

--- a/source/Nevermore/ISqlCommandFactory.cs
+++ b/source/Nevermore/ISqlCommandFactory.cs
@@ -6,6 +6,6 @@ namespace Nevermore
 {
     public interface ISqlCommandFactory
     {
-        IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, int? commandTimeoutSeconds = null);
+        IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, TimeSpan? commandTimeout = null);
     }
 }

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -35,7 +35,7 @@ namespace Nevermore
             this.paramDefaults = paramDefaults;
         }
 
-        public IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout)
+        public ICompleteQuery<TRecord> WithTimeout(TimeSpan commandTimeout)
         {
             this.commandTimeout = commandTimeout;
             return this;

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -16,7 +16,8 @@ namespace Nevermore
         readonly CommandParameterValues paramValues;
         readonly Parameters @params;
         readonly ParameterDefaults paramDefaults;
-
+        TimeSpan? commandTimeout;
+        
         public QueryBuilder(TSelectBuilder selectBuilder, 
             IRelationalTransaction transaction,
             ITableAliasGenerator tableAliasGenerator, 
@@ -32,6 +33,12 @@ namespace Nevermore
             this.paramValues = paramValues;
             this.@params = @params;
             this.paramDefaults = paramDefaults;
+        }
+
+        public IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout)
+        {
+            this.commandTimeout = commandTimeout;
+            return this;
         }
 
         public IQueryBuilder<TRecord> Where(string whereClause)
@@ -224,7 +231,7 @@ namespace Nevermore
         {
             var clonedSelectBuilder = selectBuilder.Clone();
             clonedSelectBuilder.AddColumnSelection(new SelectCountSource());
-            return transaction.ExecuteScalar<int>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues);
+            return transaction.ExecuteScalar<int>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, commandTimeout);
         }
 
         [Pure]
@@ -235,7 +242,7 @@ namespace Nevermore
             var trueParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("true"));
             var falseParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("false"));
 
-            var result = transaction.ExecuteScalar<int>(CreateQuery().GenerateSql(), CreateParameterValues());
+            var result = transaction.ExecuteScalar<int>(CreateQuery().GenerateSql(), CreateParameterValues(), commandTimeout);
 
             return result != falseValue;
 
@@ -269,7 +276,7 @@ namespace Nevermore
         {
             var clonedSelectBuilder = selectBuilder.Clone();
             clonedSelectBuilder.AddTop(take);
-            return transaction.ExecuteReader<TRecord>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues);
+            return transaction.ExecuteReader<TRecord>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, commandTimeout);
         }
 
         [Pure]
@@ -295,7 +302,7 @@ namespace Nevermore
                 {maxRowParameter.ParameterName, take + skip}
             };
 
-            return transaction.ExecuteReader<TRecord>(subqueryBuilder.GenerateSelect().GenerateSql(), parmeterValues).ToList();
+            return transaction.ExecuteReader<TRecord>(subqueryBuilder.GenerateSelect().GenerateSql(), parmeterValues, commandTimeout).ToList();
         }
 
         [Pure]
@@ -314,7 +321,7 @@ namespace Nevermore
         [Pure]
         public IEnumerable<TRecord> Stream()
         {
-            return transaction.ExecuteReader<TRecord>(selectBuilder.GenerateSelect().GenerateSql(), paramValues);
+            return transaction.ExecuteReader<TRecord>(selectBuilder.GenerateSelect().GenerateSql(), paramValues, commandTimeout);
         }
 
         [Pure]

--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -159,24 +159,28 @@ namespace Nevermore
             return results;
         }
 
-        public void Insert<TDocument>(TDocument instance) where TDocument : class, IId
+        public void Insert<TDocument>(TDocument instance, int? commandTimeoutSeconds = null)
+            where TDocument : class, IId
         {
-            Insert(null, instance, null);
+            Insert(null, instance, null, commandTimeoutSeconds: commandTimeoutSeconds);
         }
 
-        public void Insert<TDocument>(string tableName, TDocument instance) where TDocument : class, IId
+        public void Insert<TDocument>(string tableName, TDocument instance, int? commandTimeoutSeconds = null)
+            where TDocument : class, IId
         {
-            Insert(tableName, instance, null);
+            Insert(tableName, instance, null, commandTimeoutSeconds: commandTimeoutSeconds);
         }
 
-        public void Insert<TDocument>(TDocument instance, string customAssignedId) where TDocument : class, IId
+        public void Insert<TDocument>(TDocument instance, string customAssignedId, int? commandTimeoutSeconds = null)
+            where TDocument : class, IId
         {
-            Insert(null, instance, customAssignedId);
+            Insert(null, instance, customAssignedId, commandTimeoutSeconds: commandTimeoutSeconds);
         }
 
-        public void InsertWithHint<TDocument>(TDocument instance, string tableHint) where TDocument : class, IId
+        public void InsertWithHint<TDocument>(TDocument instance, string tableHint, int? commandTimeoutSeconds = null)
+            where TDocument : class, IId
         {
-            Insert(null, instance, null, tableHint);
+            Insert(null, instance, null, tableHint, commandTimeoutSeconds);
         }
 
         public void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId
@@ -218,7 +222,9 @@ namespace Nevermore
             }
         }
 
-        public void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances, bool includeDefaultModelColumns = true, string tableHint = null) where TDocument : class, IId
+        public void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances,
+            bool includeDefaultModelColumns = true, string tableHint = null, int? commandTimeoutSeconds = null)
+            where TDocument : class, IId
         {
             if (!instances.Any())
                 return;
@@ -232,7 +238,7 @@ namespace Nevermore
                 includeDefaultModelColumns);
 
             using (new TimedSection(Log, ms => $"Insert took {ms}ms in transaction '{name}': {statement}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeoutSeconds))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -571,20 +577,29 @@ namespace Nevermore
             }
         }
 
-        public void ExecuteReader(string query, Action<IDataReader> readerCallback)
+        public void ExecuteReader(string query, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null)
         {
-            ExecuteReader(query, null, readerCallback);
+            ExecuteReader(query, null, readerCallback, commandTimeoutSeconds);
         }
 
-        public void ExecuteReader(string query, object args, Action<IDataReader> readerCallback)
+        public void ExecuteReader(
+            string query,
+            object args,
+            Action<IDataReader> readerCallback,
+            int? commandTimeoutSeconds = null)
         {
-            ExecuteReader(query, new CommandParameterValues(args), readerCallback);
+            ExecuteReader(query, new CommandParameterValues(args), readerCallback, commandTimeoutSeconds);
         }
 
-        public void ExecuteReader(string query, CommandParameterValues args, Action<IDataReader> readerCallback)
+        public void ExecuteReader(
+            string query,
+            CommandParameterValues args,
+            Action<IDataReader> readerCallback,
+            int? commandTimeoutSeconds = null)
         {
             using (new TimedSection(Log, ms => $"Executing reader took {ms}ms in transaction '{name}': {query}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args,
+                commandTimeoutSeconds: commandTimeoutSeconds))
             {
                 AddCommandTrace(command.CommandText);
                 try

--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -90,10 +90,10 @@ namespace Nevermore
         {
             return new DeleteQueryBuilder<TDocument>(
                 uniqueParameterNameGenerator,
-                (documentType, where, parameterValues, commandTimeoutSeconds) => DeleteInternal(
+                (documentType, where, parameterValues, commandTimeout) => DeleteInternal(
                     dataModificationQueryBuilder.CreateDelete(documentType, where),
                     parameterValues, 
-                    commandTimeoutSeconds
+                    commandTimeout
                 ), 
                 Enumerable.Empty<IWhereClause>(), 
                 new CommandParameterValues()
@@ -159,31 +159,31 @@ namespace Nevermore
             return results;
         }
 
-        public void Insert<TDocument>(TDocument instance, int? commandTimeoutSeconds = null)
+        public void Insert<TDocument>(TDocument instance, TimeSpan? commandTimeout = null)
             where TDocument : class, IId
         {
-            Insert(null, instance, null, commandTimeoutSeconds: commandTimeoutSeconds);
+            Insert(null, instance, null, commandTimeout: commandTimeout);
         }
 
-        public void Insert<TDocument>(string tableName, TDocument instance, int? commandTimeoutSeconds = null)
+        public void Insert<TDocument>(string tableName, TDocument instance, TimeSpan? commandTimeout = null)
             where TDocument : class, IId
         {
-            Insert(tableName, instance, null, commandTimeoutSeconds: commandTimeoutSeconds);
+            Insert(tableName, instance, null, commandTimeout: commandTimeout);
         }
 
-        public void Insert<TDocument>(TDocument instance, string customAssignedId, int? commandTimeoutSeconds = null)
+        public void Insert<TDocument>(TDocument instance, string customAssignedId, TimeSpan? commandTimeout = null)
             where TDocument : class, IId
         {
-            Insert(null, instance, customAssignedId, commandTimeoutSeconds: commandTimeoutSeconds);
+            Insert(null, instance, customAssignedId, commandTimeout: commandTimeout);
         }
 
-        public void InsertWithHint<TDocument>(TDocument instance, string tableHint, int? commandTimeoutSeconds = null)
+        public void InsertWithHint<TDocument>(TDocument instance, string tableHint, TimeSpan? commandTimeout = null)
             where TDocument : class, IId
         {
-            Insert(null, instance, null, tableHint, commandTimeoutSeconds);
+            Insert(null, instance, null, tableHint, commandTimeout);
         }
 
-        public void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId
+        public void Insert<TDocument>(string tableName, TDocument instance, string customAssignedId, string tableHint = null, TimeSpan? commandTimeout = null) where TDocument : class, IId
         {
             if (customAssignedId != null && instance.Id != null && customAssignedId != instance.Id)
                 throw new ArgumentException("Do not pass a different Id when one is already set on the document");
@@ -197,7 +197,7 @@ namespace Nevermore
              );
             
             using (new TimedSection(Log, ms => $"Insert took {ms}ms in transaction '{name}': {statement}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -223,7 +223,7 @@ namespace Nevermore
         }
 
         public void InsertMany<TDocument>(string tableName, IReadOnlyCollection<TDocument> instances,
-            bool includeDefaultModelColumns = true, string tableHint = null, int? commandTimeoutSeconds = null)
+            bool includeDefaultModelColumns = true, string tableHint = null, TimeSpan? commandTimeout = null)
             where TDocument : class, IId
         {
             if (!instances.Any())
@@ -238,7 +238,7 @@ namespace Nevermore
                 includeDefaultModelColumns);
 
             using (new TimedSection(Log, ms => $"Insert took {ms}ms in transaction '{name}': {statement}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -299,12 +299,12 @@ namespace Nevermore
             return $"{idPrefix}-{key}";
         }
 
-        public void Update<TDocument>(TDocument instance, string tableHint = null, int? commandTimeoutSeconds = null) where TDocument : class, IId
+        public void Update<TDocument>(TDocument instance, string tableHint = null, TimeSpan? commandTimeout = null) where TDocument : class, IId
         {
             var (mapping, statement, parameters) = dataModificationQueryBuilder.CreateUpdate(instance, tableHint);
             
             using (new TimedSection(Log, ms => $"Update took {ms}ms in transaction '{name}': {statement}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameters, mapping, commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -327,22 +327,22 @@ namespace Nevermore
         }
 
         // Delete does not require TDocument to implement IId because during recursive document delete we have only objects
-        public void Delete<TDocument>(TDocument instance, int? commandTimeoutSeconds = null) where TDocument : class, IId
+        public void Delete<TDocument>(TDocument instance, TimeSpan? commandTimeout = null) where TDocument : class, IId
         {
             var (statement, parameterValues) = dataModificationQueryBuilder.CreateDelete(instance);
-            DeleteInternal(statement, parameterValues, commandTimeoutSeconds);
+            DeleteInternal(statement, parameterValues, commandTimeout);
         }
 
-        public void DeleteById<TDocument>(string id, int? commandTimeoutSeconds = null) where TDocument : class, IId
+        public void DeleteById<TDocument>(string id, TimeSpan? commandTimeout = null) where TDocument : class, IId
         {
             var (statement, parameterValues) = dataModificationQueryBuilder.CreateDelete<TDocument>(id);
-            DeleteInternal(statement, parameterValues, commandTimeoutSeconds);
+            DeleteInternal(statement, parameterValues, commandTimeout);
         }
 
-        void DeleteInternal(string statement, CommandParameterValues parameterValues, int? commandTimeoutSeconds = null)
+        void DeleteInternal(string statement, CommandParameterValues parameterValues, TimeSpan? commandTimeout = null)
         {
             using (new TimedSection(Log, ms => $"Delete took {ms}ms in transaction '{name}': {statement}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameterValues, commandTimeoutSeconds: commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, statement, parameterValues, commandTimeout: commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -363,10 +363,10 @@ namespace Nevermore
         }
 
 
-        public int ExecuteNonQuery(string query, CommandParameterValues args, int? commandTimeoutSeconds = null)
+        public int ExecuteNonQuery(string query, CommandParameterValues args, TimeSpan? commandTimeout = null)
         {
             using (new TimedSection(Log, ms => $"Executing non query took {ms}ms in transaction '{name}': {query}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeoutSeconds: commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeout: commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -387,11 +387,11 @@ namespace Nevermore
 
 
         [Pure]
-        public IEnumerable<T> ExecuteReader<T>(string query, CommandParameterValues args, int? commandTimeoutSeconds = null)
+        public IEnumerable<T> ExecuteReader<T>(string query, CommandParameterValues args, TimeSpan? commandTimeout = null)
         {
             var mapping = mappings.Get(typeof(T));
 
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, mapping, commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, mapping, commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 return Stream<T>(command, mapping);
@@ -399,9 +399,9 @@ namespace Nevermore
         }
 
         [Pure]
-        public IEnumerable<T> ExecuteReaderWithProjection<T>(string query, CommandParameterValues args, Func<IProjectionMapper, T> projectionMapper, int? commandTimeoutSeconds = null)
+        public IEnumerable<T> ExecuteReaderWithProjection<T>(string query, CommandParameterValues args, Func<IProjectionMapper, T> projectionMapper, TimeSpan? commandTimeout = null)
         {
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeoutSeconds: commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeout: commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -554,10 +554,10 @@ namespace Nevermore
         }
 
         [Pure]
-        public T ExecuteScalar<T>(string query, CommandParameterValues args, int? commandTimeoutSeconds = null)
+        public T ExecuteScalar<T>(string query, CommandParameterValues args, TimeSpan? commandTimeout = null)
         {
             using (new TimedSection(Log, ms => $"Scalar took {ms}ms in transaction '{name}': {query}", 300))
-            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeoutSeconds: commandTimeoutSeconds))
+            using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args, commandTimeout: commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try
@@ -577,29 +577,29 @@ namespace Nevermore
             }
         }
 
-        public void ExecuteReader(string query, Action<IDataReader> readerCallback, int? commandTimeoutSeconds = null)
+        public void ExecuteReader(string query, Action<IDataReader> readerCallback, TimeSpan? commandTimeout = null)
         {
-            ExecuteReader(query, null, readerCallback, commandTimeoutSeconds);
+            ExecuteReader(query, null, readerCallback, commandTimeout);
         }
 
         public void ExecuteReader(
             string query,
             object args,
             Action<IDataReader> readerCallback,
-            int? commandTimeoutSeconds = null)
+            TimeSpan? commandTimeout = null)
         {
-            ExecuteReader(query, new CommandParameterValues(args), readerCallback, commandTimeoutSeconds);
+            ExecuteReader(query, new CommandParameterValues(args), readerCallback, commandTimeout);
         }
 
         public void ExecuteReader(
             string query,
             CommandParameterValues args,
             Action<IDataReader> readerCallback,
-            int? commandTimeoutSeconds = null)
+            TimeSpan? commandTimeout = null)
         {
             using (new TimedSection(Log, ms => $"Executing reader took {ms}ms in transaction '{name}': {query}", 300))
             using (var command = sqlCommandFactory.CreateCommand(connection, transaction, query, args,
-                commandTimeoutSeconds: commandTimeoutSeconds))
+                commandTimeout: commandTimeout))
             {
                 AddCommandTrace(command.CommandText);
                 try

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -302,6 +302,11 @@ namespace Nevermore
             return new QueryBuilder<TRecord, ISelectBuilder>(selectBuilder, RelationalTransaction, TableAliasGenerator, UniqueParameterNameGenerator, ParamValues, Params, ParamDefaults);
         }
 
+        public IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout)
+        {
+            return Builder.WithTimeout(commandTimeout);
+        }
+
         public IQueryBuilder<TRecord> Where(string whereClause)
         {
             return Builder.Where(whereClause);

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -302,7 +302,7 @@ namespace Nevermore
             return new QueryBuilder<TRecord, ISelectBuilder>(selectBuilder, RelationalTransaction, TableAliasGenerator, UniqueParameterNameGenerator, ParamValues, Params, ParamDefaults);
         }
 
-        public IQueryBuilder<TRecord> WithTimeout(TimeSpan commandTimeout)
+        public ICompleteQuery<TRecord> WithTimeout(TimeSpan commandTimeout)
         {
             return Builder.WithTimeout(commandTimeout);
         }

--- a/source/Nevermore/SqlCommandFactory.cs
+++ b/source/Nevermore/SqlCommandFactory.cs
@@ -6,15 +6,15 @@ namespace Nevermore
 {
     public class SqlCommandFactory : ISqlCommandFactory
     {
-        public static readonly int DefaultCommandTimeoutSeconds = 60;
+        public static readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(60);
 
-        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, int? commandTimeoutSeconds = null)
+        public IDbCommand CreateCommand(IDbConnection connection, IDbTransaction transaction, string statement, CommandParameterValues args, DocumentMap mapping = null, TimeSpan? commandTimeout = null)
         {
             var command = connection.CreateCommand();
 
             try
             {
-                command.CommandTimeout = commandTimeoutSeconds ?? DefaultCommandTimeoutSeconds;
+                command.CommandTimeout = (int)(commandTimeout ?? DefaultCommandTimeout).TotalSeconds;
                 command.CommandText = statement;
                 command.Transaction = transaction;
                 args?.ContributeTo(command, mapping);


### PR DESCRIPTION
Add missing timing log messages for `RelationalTransaction.ExecuteReader()` and `RelationalTransaction.Stream()`

Add missing command timeout options to `IQueryExecutor` methods

Add `IQueryBuilder.WithTimeout()` method which allows you to specify a command timeout when using `IQueryBuilder`.

Fixes: https://github.com/OctopusDeploy/Nevermore/issues/68