### PR TITLE
QueryBuilder supports Join columns that are not on the primary table

### DIFF
--- a/source/Nevermore.Tests/Joins/JoinClauseFixture.cs
+++ b/source/Nevermore.Tests/Joins/JoinClauseFixture.cs
@@ -9,10 +9,10 @@ namespace Nevermore.Tests.Joins
         [Test]
         public void ShouldReturnEqualsString()
         {
-            var target = new JoinClause("FieldA", JoinOperand.Equal, "FieldB");
+            var target = new JoinClause("t1", "FieldA", JoinOperand.Equal, "t2","FieldB");
 
             const string expected = "t1.[FieldA] = t2.[FieldB]";
-            var actual = target.GenerateSql("t1", "t2");
+            var actual = target.GenerateSql();
 
             actual.Should().Be(expected);
         }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForChainedJoins.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForChainedJoins.approved.txt
@@ -1,0 +1,8 @@
+SELECT Orders.*
+FROM dbo.[Orders] Orders
+INNER JOIN dbo.[Customers] Customers
+ON Orders.[CustomerId] = Customers.[Id]
+INNER JOIN dbo.[Accounts] Accounts
+ON Customers.[Id] = Accounts.[CustomerId]
+AND Orders.[AccountId] = Accounts.[Id]
+ORDER BY Orders.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -105,6 +105,24 @@ ORDER BY [Id]";
         }
 
         [Test]
+        public void ShouldGenerateSelectForChainedJoins()
+        {
+
+            var leftQueryBuilder = CreateQueryBuilder<IDocument>("Orders").Alias("Orders");
+            var join1QueryBuilder = CreateQueryBuilder<IDocument>("Customers").Alias("Customers");
+            var join2QueryBuilder = CreateQueryBuilder<IDocument>("Accounts").Alias("Accounts");
+
+            var actual = leftQueryBuilder
+                .InnerJoin(join1QueryBuilder).On("CustomerId", JoinOperand.Equal, "Id")
+                .InnerJoin(join2QueryBuilder)
+                    .On("Customers", "Id", JoinOperand.Equal, "CustomerId")
+                    .On("AccountId", JoinOperand.Equal, "Id")
+                .DebugViewRawQuery();
+
+            this.Assent(actual);
+        }
+        
+        [Test]
         public void ShouldGenerateSelectForMultipleJoinsWithParameter()
         {
 

--- a/source/Nevermore/AST/JoinedSource.cs
+++ b/source/Nevermore/AST/JoinedSource.cs
@@ -18,7 +18,7 @@ namespace Nevermore.AST
 
         public string GenerateSql()
         {
-            var sourceParts = new [] {Source.GenerateSql()}.Concat(joins.Select(j => j.GenerateSql(Source.Alias)));
+            var sourceParts = new [] {Source.GenerateSql()}.Concat(joins.Select(j => j.GenerateSql()));
             return string.Join("\r\n", sourceParts);
         }
         
@@ -39,15 +39,15 @@ namespace Nevermore.AST
             this.type = type;
         }
 
-        public string GenerateSql(string leftSourceAlias)
+        public string GenerateSql()
         {
             var separator = @"
 AND ";
             return $@"{GenerateJoinTypeSql(type)} {source.GenerateSql()}
-ON {string.Join(separator, clauses.Select(c => c.GenerateSql(leftSourceAlias, source.Alias)))}";
+ON {string.Join(separator, clauses.Select(c => c.GenerateSql()))}";
         }
 
-        string DebugSql() => GenerateSql("leftSource");
+        string DebugSql() => GenerateSql();
 
         string GenerateJoinTypeSql(JoinType joinType)
         {
@@ -77,23 +77,27 @@ ON {string.Join(separator, clauses.Select(c => c.GenerateSql(leftSourceAlias, so
     [DebuggerDisplay("{" + nameof(DebugSql) + "()}")]
     public class JoinClause
     {
+        readonly string leftTableAlias;
         readonly string leftFieldName;
         readonly JoinOperand operand;
+        readonly string rightTableAlias;
         readonly string rightFieldName;
 
-        public JoinClause(string leftFieldName, JoinOperand operand, string rightFieldName)
+        public JoinClause(string leftTableAlias, string leftFieldName, JoinOperand operand, string rightTableAlias, string rightFieldName)
         {
+            this.leftTableAlias = leftTableAlias;
             this.leftFieldName = leftFieldName;
             this.operand = operand;
+            this.rightTableAlias = rightTableAlias;
             this.rightFieldName = rightFieldName;
         }
 
-        public string GenerateSql(string leftTableAlias, string rightTableAlias)
+        public string GenerateSql()
         {
             return $"{leftTableAlias}.[{leftFieldName}] {GetQueryOperand()} {rightTableAlias}.[{rightFieldName}]";
         }
 
-        string DebugSql() => GenerateSql("leftSource", "rightSource");
+        string DebugSql() => GenerateSql();
 
         string GetQueryOperand()
         {

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -71,6 +71,16 @@ namespace Nevermore
         /// <param name="rightField">The column from the right side of the join to use in the join condition</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         IJoinSourceQueryBuilder<TRecord> On(string leftField, JoinOperand operand, string rightField);
+        
+        /// <summary>
+        /// Adds a join condition (ON expression) to a join. At least one join condition must be added for each join.
+        /// </summary>
+        /// <param name="leftTableAlias">The table alias for the column from the left side of the join to use in the join condition</param>
+        /// <param name="leftField">The column from the left side of the join to use in the join condition</param>
+        /// <param name="operand">The operator to use in the join condition</param>
+        /// <param name="rightField">The column from the right side of the join to use in the join condition</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IJoinSourceQueryBuilder<TRecord> On(string leftTableAlias, string leftField, JoinOperand operand, string rightField);
     }
 
     public interface IQueryBuilder<TRecord> : ICompleteQuery<TRecord> where TRecord : class

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -104,6 +104,7 @@ namespace Nevermore
             {
                 Alias(TableAliasGenerator.GenerateTableAlias());
             } 
+
             return new SubquerySource(select, alias);
         }
 
@@ -177,7 +178,7 @@ namespace Nevermore
 
         public IJoinSourceQueryBuilder<TRecord> On(string leftField, JoinOperand operand, string rightField)
         {
-            var newClause = new JoinClause(leftField, operand, rightField);
+            var newClause = new JoinClause(originalSource.Alias, leftField, operand, joinSource.Alias, rightField);
             clauses.Add(newClause);
             return this;
         }

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -178,7 +178,12 @@ namespace Nevermore
 
         public IJoinSourceQueryBuilder<TRecord> On(string leftField, JoinOperand operand, string rightField)
         {
-            var newClause = new JoinClause(originalSource.Alias, leftField, operand, joinSource.Alias, rightField);
+            return On(originalSource.Alias, leftField, operand, rightField);
+        }
+        
+        public IJoinSourceQueryBuilder<TRecord> On(string leftTableAlias, string leftField, JoinOperand operand, string rightField)
+        {
+            var newClause = new JoinClause(leftTableAlias, leftField, operand, joinSource.Alias, rightField);
             clauses.Add(newClause);
             return this;
         }


### PR DESCRIPTION
Previously you could only use columns from the primary table when performing a join.

```
SELECT *
FROM Table1
INNER JOIN Table2
ON Table1.Table2Fk = Table2.Pk
INNER JOIN Table3
ON Table1.Table3Fk = Table3.Pk
```

The changes allow you to use a column from any table on the join condition
```
SELECT *
FROM Table1
INNER JOIN Table2 Table2Alias
ON Table1.Table2Fk = Table2.Pk
INNER JOIN Table3
ON Table2Alias.Table3Fk = Table3.Pk
```

By calling:
```
table1
    .InnerJoin(table2).On("Table2Fk", JoinOperand.Equal, "Pk")
    .InnerJoin(table3).On("Table2Alias", "Table3Fk", JoinOperand.Equal, "Pk")
```