### PR TITLE
Order by with table alias

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_LatestSuccessfulDeployments.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_LatestSuccessfulDeployments.approved.txt
@@ -1,0 +1,13 @@
+SELECT *
+FROM (
+    SELECT deployments.*,
+    ROW_NUMBER() OVER (PARTITION BY deployments.[EnvironmentId], deployments.[ProjectId], deployments.[TenantId] ORDER BY e.[occurred] DESC) AS Rank
+    FROM dbo.[Deployment] deployments
+    INNER JOIN dbo.[EventRelatedDocument] eventRelatedDocuments
+    ON deployments.[Id] = eventRelatedDocuments.[RelatedDocumentId]
+    INNER JOIN dbo.[Event] e
+    ON eventRelatedDocuments.[EventId] = e.[Id]
+    WHERE (e.category = 'DeploymentSucceeded')
+) d
+WHERE ([Rank] = @rank_0)
+ORDER BY d.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_Release_LatestByProjectChannel.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_Release_LatestByProjectChannel.approved.txt
@@ -1,0 +1,8 @@
+SELECT *
+FROM (
+    SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY [SpaceId], [ProjectId], [ChannelId] ORDER BY [Assembled] DESC) AS RowNum
+    FROM dbo.[Release]
+) rs
+WHERE ([RowNum] = @rownum_0)
+ORDER BY rs.[Id]

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -140,6 +140,15 @@ namespace Nevermore
         /// <param name="fieldName">The column that the query should be ordered by</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         IOrderedQueryBuilder<TRecord> OrderBy(string fieldName);
+        
+        /// <summary>
+        /// Adds an order by clause to the query using a table alias, where the order by clause will be in the default order (ascending).
+        /// If no order by clauses are added to the query, the query will be ordered by the Id column in ascending order.
+        /// </summary>
+        /// <param name="fieldName">The column that the query should be ordered by</param>
+        /// <param name="tableAlias">The alias for where the column exists</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IOrderedQueryBuilder<TRecord> OrderBy(string fieldName, string tableAlias);
 
         /// <summary>
         /// Adds an order by clause to the query, where the order by clause will be in descending order.
@@ -148,6 +157,15 @@ namespace Nevermore
         /// <param name="fieldName">The column that the query should be ordered by</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName);
+        
+        /// <summary>
+        /// Adds an order by clause to the query using a table alias, where the order by clause will be in descending order.
+        /// If no order by clauses are explicitly added to the query, the query will be ordered by the Id column in ascending order.
+        /// </summary>
+        /// <param name="fieldName">The column that the query should be ordered by</param>
+        /// <param name="tableAlias">The alias for where the column exists</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName, string tableAlias);
 
         /// <summary>
         /// Adds a column to the column selection for the query.

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -8,6 +8,7 @@ namespace Nevermore
         void AddTop(int top);
 
         void AddOrder(string fieldName, bool descending);
+        void AddOrder(string fieldName, string tableAlias, bool descending);
         void AddWhere(UnaryWhereParameter whereParams);
         void AddWhere(BinaryWhereParameter whereParams);
         void AddWhere(ArrayWhereParameter whereParams);

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -203,7 +203,7 @@ namespace Nevermore
         
         public IOrderedQueryBuilder<TRecord> OrderBy(string fieldName, string tableAlias)
         {
-            selectBuilder.AddOrder(fieldName, tableAlias, true);
+            selectBuilder.AddOrder(fieldName, tableAlias, false);
             return this;
         }
 

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -200,11 +200,22 @@ namespace Nevermore
             selectBuilder.AddOrder(fieldName, false);
             return this;
         }
-
+        
+        public IOrderedQueryBuilder<TRecord> OrderBy(string fieldName, string tableAlias)
+        {
+            selectBuilder.AddOrder(fieldName, tableAlias, true);
+            return this;
+        }
 
         public IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName)
         {
             selectBuilder.AddOrder(fieldName, true);
+            return this;
+        }
+        
+        public IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName, string tableAlias)
+        {
+            selectBuilder.AddOrder(fieldName, tableAlias, true);
             return this;
         }
 

--- a/source/Nevermore/SelectBuilder.cs
+++ b/source/Nevermore/SelectBuilder.cs
@@ -260,6 +260,11 @@ namespace Nevermore
         {
             OrderByClauses.Add(new OrderByField(new Column(fieldName), @descending ? OrderByDirection.Descending : OrderByDirection.Ascending));
         }
+        
+        public virtual void AddOrder(string fieldName, string tableAlias, bool @descending)
+        {
+            OrderByClauses.Add(new OrderByField(new TableColumn(new Column(fieldName), tableAlias), @descending ? OrderByDirection.Descending : OrderByDirection.Ascending));
+        }
 
         public virtual void AddWhere(UnaryWhereParameter whereParams)
         {

--- a/source/Nevermore/SelectBuilder.cs
+++ b/source/Nevermore/SelectBuilder.cs
@@ -261,7 +261,7 @@ namespace Nevermore
             OrderByClauses.Add(new OrderByField(new Column(fieldName), @descending ? OrderByDirection.Descending : OrderByDirection.Ascending));
         }
         
-        public virtual void AddOrder(string fieldName, string tableAlias, bool @descending)
+        public void AddOrder(string fieldName, string tableAlias, bool @descending)
         {
             OrderByClauses.Add(new OrderByField(new TableColumn(new Column(fieldName), tableAlias), @descending ? OrderByDirection.Descending : OrderByDirection.Ascending));
         }

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -343,10 +343,20 @@ namespace Nevermore
         {
             return Builder.OrderBy(fieldName);
         }
-
+        
+        public IOrderedQueryBuilder<TRecord> OrderBy(string fieldName, string tableAlias)
+        {
+            return Builder.OrderBy(fieldName, tableAlias);
+        }
+        
         public IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName)
         {
             return Builder.OrderByDescending(fieldName);
+        }
+
+        public IOrderedQueryBuilder<TRecord> OrderByDescending(string fieldName, string tableAlias)
+        {
+            return Builder.OrderByDescending(fieldName, tableAlias);
         }
 
         public IQueryBuilder<TRecord> Column(string name)


### PR DESCRIPTION
To minimize the number of subqueries required to generate what's required by `Replace_LatestSuccessfulDeployments` the orderby column requires alias support so it can be selected from another table in the query