### PR TITLE
Rename `First` (which can return null) to `FirstOrDefault`

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -927,7 +927,7 @@ ORDER BY [Title]";
 
             var result = CreateQueryBuilder<TodoItem>("TodoItem")
                 .OrderBy("Title")
-                .First();
+                .FirstOrDefault();
 
             transaction.Received(1).ExecuteReader<TodoItem>(
                 Arg.Is(expectedSql),
@@ -950,7 +950,7 @@ ORDER BY [Title] DESC";
 
             var result = CreateQueryBuilder<TodoItem>("TodoItem")
                 .OrderByDescending("Title")
-                .First();
+                .FirstOrDefault();
 
             transaction.Received(1).ExecuteReader<TodoItem>(
                 Arg.Is(expectedSql),
@@ -1538,7 +1538,7 @@ ORDER BY [RowNum]");
                 .Where("AddedDate", UnarySqlOperand.GreaterThan, earlyDate)
                 .Where("AddedDate", UnarySqlOperand.LessThan, laterDate);
 
-            query.First();
+            query.FirstOrDefault();
 
             const string expected = @"SELECT TOP 1 *
 FROM dbo.[Todos]
@@ -1574,7 +1574,7 @@ ORDER BY [Id]";
                 .InnerJoin(orders.Subquery())
                 .On("Id", JoinOperand.Equal, "CustomerId");
 
-            query.First();
+            query.FirstOrDefault();
 
             const string expected =
                 @"SELECT TOP 1 ALIAS_GENERATED_2.*

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -86,7 +86,7 @@ ORDER BY [Id]");
         {
             var queryBuilder = QueryBuilder("Accounts");
 
-            queryBuilder.First();
+            queryBuilder.FirstOrDefault();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
 FROM dbo.[Accounts]

--- a/source/Nevermore/ICompleteQuery.cs
+++ b/source/Nevermore/ICompleteQuery.cs
@@ -18,7 +18,7 @@ namespace Nevermore
         /// <returns>Returns true if there are any rows in the result set, otherwise false</returns>
         bool Any();
 
-        [Obsolete("Use FirstOrDefault instead.")]
+        [Obsolete("Use FirstOrDefault instead")]
         TRecord First();
         
         /// <summary>

--- a/source/Nevermore/ICompleteQuery.cs
+++ b/source/Nevermore/ICompleteQuery.cs
@@ -18,11 +18,13 @@ namespace Nevermore
         /// <returns>Returns true if there are any rows in the result set, otherwise false</returns>
         bool Any();
 
-        /// <summary>
-        /// Executes the query and retuns the first row
-        /// </summary>
-        /// <returns>The first row in the result set</returns>
+        [Obsolete("Use FirstOrDefault instead.")]
         TRecord First();
+        
+        /// <summary>
+        /// Executes the query and returns the first row, or null if there are no rows 
+        /// </summary>
+        TRecord FirstOrDefault();
 
         /// <summary>
         ///  Executes the query and returns the specified number of rows

--- a/source/Nevermore/ICompleteQuery.cs
+++ b/source/Nevermore/ICompleteQuery.cs
@@ -18,7 +18,7 @@ namespace Nevermore
         /// <returns>Returns true if there are any rows in the result set, otherwise false</returns>
         bool Any();
 
-        [Obsolete("Use FirstOrDefault instead")]
+        [Obsolete("First returns the first row, or null if there are no rows. To make your code easier to read, use FirstOrDefault instead.")]
         TRecord First();
         
         /// <summary>

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -279,6 +279,12 @@ namespace Nevermore
         [Pure]
         public TRecord First()
         {
+            return FirstOrDefault();
+        }
+
+        [Pure]
+        public TRecord FirstOrDefault()
+        {
             return Take(1).FirstOrDefault();
         }
 

--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -106,7 +106,7 @@ namespace Nevermore
             return TableQuery<T>()
                 .Where("[Id] = @id")
                 .Parameter("id", id)
-                .First();
+                .FirstOrDefault();
         }
 
         [Pure]

--- a/source/Nevermore/SourceQueryBuilder.cs
+++ b/source/Nevermore/SourceQueryBuilder.cs
@@ -447,7 +447,12 @@ namespace Nevermore
 
         public TRecord First()
         {
-            return Builder.First();
+            return Builder.FirstOrDefault();
+        }
+
+        public TRecord FirstOrDefault()
+        {
+            return Builder.FirstOrDefault();
         }
 
         public IEnumerable<TRecord> Take(int take)


### PR DESCRIPTION
## Background
`ICompleteQuery.First` currently returns `null` if the result of the query returns no records. In contrast, the commonly used `Enumerable.First` method never returns null, and the behavior of `ICompleteQuery.First` more closely mirrors that of `Enumerable.FirstOrDefault`. This inconsistency has [caused some confusion](https://github.com/OctopusDeploy/Octofront/pull/1093#discussion_r311825078), which gave rise to the suggestion for the following change in Nevermore.

## Fix
This PR marks the `ICompleteQuery.First` as `Obsolete`, and introduces a new, equivalent method in its place called `ICompleteQuery.FirstOrDefault`, which is more consistent with the naming scheme used by `Enumerable` and is hoped to be less surprising for users.

## Impact
While this PR will likely initially cause a significant number of `Obsolete` warnings to be emitted for most projects due to existing usages of `First`, these warnings should at least be trivial to fix. To review this PR, please assess whether you agree that the potential benefit in clarity/maintainability for users justifies the impact of this change.