### PR TITLE
Improve error message when a document is missing a setter

### DIFF
--- a/source/Nevermore/Mapping/PropertyReaderFactory.cs
+++ b/source/Nevermore/Mapping/PropertyReaderFactory.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
-using JetBrains.Annotations;
 
 namespace Nevermore.Mapping
 {
@@ -72,10 +71,9 @@ namespace Nevermore.Mapping
             where TReturn : TCast
         {
             readonly Func<TInput, TReturn> caller;
+            readonly Action<TInput, TReturn> writer;
 
-            [CanBeNull] readonly Action<TInput, TReturn> writer;
-
-            public DelegatePropertyReaderWriter(Func<TInput, TReturn> caller, [CanBeNull] Action<TInput, TReturn> writer)
+            public DelegatePropertyReaderWriter(Func<TInput, TReturn> caller, Action<TInput, TReturn> writer)
             {
                 this.caller = caller;
                 this.writer = writer;

--- a/source/Nevermore/Mapping/PropertyReaderFactory.cs
+++ b/source/Nevermore/Mapping/PropertyReaderFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace Nevermore.Mapping
 {
@@ -71,9 +72,10 @@ namespace Nevermore.Mapping
             where TReturn : TCast
         {
             readonly Func<TInput, TReturn> caller;
-            readonly Action<TInput, TReturn> writer;
 
-            public DelegatePropertyReaderWriter(Func<TInput, TReturn> caller, Action<TInput, TReturn> writer)
+            [CanBeNull] readonly Action<TInput, TReturn> writer;
+
+            public DelegatePropertyReaderWriter(Func<TInput, TReturn> caller, [CanBeNull] Action<TInput, TReturn> writer)
             {
                 this.caller = caller;
                 this.writer = writer;
@@ -86,8 +88,12 @@ namespace Nevermore.Mapping
 
             public void Write(object target, TCast value)
             {
-                var returnble = (TReturn)AmazingConverter.Convert(value, typeof (TReturn));
-                writer((TInput)target, returnble);
+                if (writer == null)
+                {
+                    throw new InvalidOperationException("Cannot write to a property without a setter");
+                }
+                var returnable = (TReturn)AmazingConverter.Convert(value, typeof (TReturn));
+                writer((TInput)target, returnable);
             }
         }
 

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nevermore.Contracts\Nevermore.Contracts.csproj" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Nevermore.Contracts\Nevermore.Contracts.csproj" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Steps to reproduce
```
public class Customer : IId
{
    public string Id { get; }
}

// ...

transaction.Insert(new Customer());
```

## Actual result
Confusing null ref:
```
System.NullReferenceException: Object reference not set to an instance of an object.
```

## Expected result
A slightly more informative error message that points to the issue (i.e. in this case, that the `Id` has no `set` accessor):
```
System.InvalidOperationException: Cannot write to a property without a setter
```