### PR TITLE
Improve development experience of Nevermore on Linux

### DIFF
--- a/source/Nevermore.Contracts/Nevermore.Contracts.csproj
+++ b/source/Nevermore.Contracts/Nevermore.Contracts.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>A JSON Document Store library for SQL Server</Description>
     <Authors>Octopus Deploy</Authors>
-    <TargetFrameworks>netstandard1.2;net451</TargetFrameworks>
     <AssemblyName>Nevermore.Contracts</AssemblyName>
     <PackageId>Nevermore.Contracts</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
@@ -21,6 +20,7 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <WarningsAsErrors />
+    <TargetFramework>netstandard1.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -17,6 +17,8 @@ namespace Nevermore.IntegrationTests
     {
         readonly TextWriter output = Console.Out;
         readonly string SqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "(local)\\SQLEXPRESS,1433";
+        readonly string Username = Environment.GetEnvironmentVariable("NevermoreTestUsername");
+        readonly string Password = Environment.GetEnvironmentVariable("NevermoreTestPassword");
         readonly string TestDatabaseName;
         readonly string TestDatabaseConnectionString;
 
@@ -28,11 +30,16 @@ namespace Nevermore.IntegrationTests
         public IntegrationTestDatabase()
         {
             TestDatabaseName = "Nevermore-IntegrationTests";
-
-            var builder = new SqlConnectionStringBuilder(string.Format("Server={0};Database={1};Trusted_connection=true;", SqlInstance, TestDatabaseName))
+            
+            var builder = new SqlConnectionStringBuilder($"Server={SqlInstance};Database={TestDatabaseName};{(Username == null ? "Trusted_connection=true;" : string.Empty)}")
             {
-                ApplicationName = TestDatabaseName
+                ApplicationName = TestDatabaseName,
             };
+            if (Username != null)
+            {
+                builder.UserID = Username;
+                builder.Password = Password;
+            }
             TestDatabaseConnectionString = builder.ToString();
 
             DropDatabase();

--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <AssemblyName>Nevermore.IntegrationTests</AssemblyName>
     <PackageId>Nevermore.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,6 +12,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <IsPackable>false</IsPackable>
     <WarningsAsErrors />
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nevermore.Contracts\Nevermore.Contracts.csproj" />

--- a/source/Nevermore.Tests/Nevermore.Tests.csproj
+++ b/source/Nevermore.Tests/Nevermore.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <AssemblyName>Nevermore.Tests</AssemblyName>
     <PackageId>Nevermore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -13,6 +12,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <IsPackable>false</IsPackable>
     <WarningsAsErrors />
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nevermore\Nevermore.csproj" />

--- a/source/Nevermore/AST/JoinedSource.cs
+++ b/source/Nevermore/AST/JoinedSource.cs
@@ -19,7 +19,7 @@ namespace Nevermore.AST
         public string GenerateSql()
         {
             var sourceParts = new [] {Source.GenerateSql()}.Concat(joins.Select(j => j.GenerateSql()));
-            return string.Join("\r\n", sourceParts);
+            return string.Join(Environment.NewLine, sourceParts);
         }
         
         public override string ToString() => GenerateSql();

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -38,10 +38,6 @@
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
     <AssemblyName>Nevermore</AssemblyName>
     <PackageId>Nevermore</PackageId>


### PR DESCRIPTION
Enables development on non-windows machines.

Changes include
- Removing .net framework target support. Only target netstandard and netcore
- Add support for supplying a username/password instead of relying on integrated auth in integration tests.