### PR TITLE
Update to the QueryBuilder to support custom types better

### DIFF
--- a/source/Nevermore.Contracts/ExtensibleEnum.cs
+++ b/source/Nevermore.Contracts/ExtensibleEnum.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+
+namespace Nevermore.Contracts
+{
+    [DebuggerDisplay("{Name}")]
+    public abstract class ExtensibleEnum
+    {
+        protected ExtensibleEnum(string name, string description = null)
+        {
+            Name = name;
+            Description = description;
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -79,7 +79,8 @@ namespace Nevermore.IntegrationTests
                 new ProductToTestSerializationMap(),
                 new LineItemMap(),
                 new MachineMap(),
-                new MachineToTestSerializationMap()
+                new MachineToTestSerializationMap(),
+                new FeedMap()
             });
             Store = BuildRelationalStore(TestDatabaseConnectionString, 0.01);
         }
@@ -126,7 +127,8 @@ namespace Nevermore.IntegrationTests
                 new SpecialProductMap(),
                 new LineItemMap(),
                 new BrandMap(),
-                new MachineMap()
+                new MachineMap(),
+                new FeedMap()
             };
 
             Mappings.Install(mappings);

--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -9,6 +9,7 @@ using Nevermore.IntegrationTests.Chaos;
 using Nevermore.IntegrationTests.Model;
 using Nevermore.Mapping;
 using Nevermore.RelatedDocuments;
+using Nevermore.Serialization;
 using Newtonsoft.Json;
 
 namespace Nevermore.IntegrationTests
@@ -103,6 +104,8 @@ namespace Nevermore.IntegrationTests
             jsonSerializerSettings.Converters.Add(new ProductConverter(Mappings));
             jsonSerializerSettings.Converters.Add(new BrandConverter(Mappings));
             jsonSerializerSettings.Converters.Add(new EndpointConverter());
+            jsonSerializerSettings.Converters.Add(new FeedConverter());
+            jsonSerializerSettings.Converters.Add(new FeedTypeConverter());
 
             return new RelationalStore(connectionString ?? TestDatabaseConnectionString, TestDatabaseName, sqlCommandFactory, Mappings, jsonSerializerSettings, new EmptyRelatedDocumentStore());
         }

--- a/source/Nevermore.IntegrationTests/Model/Feed.cs
+++ b/source/Nevermore.IntegrationTests/Model/Feed.cs
@@ -1,0 +1,28 @@
+using Nevermore.Contracts;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public abstract class Feed : IDocument
+    {
+        public string Id { get; protected set; }
+        public string Name { get; set; }
+        
+        public FeedType FeedType { get; set; }        
+    }
+
+    public class NuGetFeed : Feed
+    {
+        public NuGetFeed()
+        {
+            FeedType = FeedType.NuGet;
+        }
+    }
+
+    public class BuiltInFeed : Feed
+    {
+        public BuiltInFeed()
+        {
+            FeedType = FeedType.BuiltIn;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/Feed.cs
+++ b/source/Nevermore.IntegrationTests/Model/Feed.cs
@@ -7,7 +7,7 @@ namespace Nevermore.IntegrationTests.Model
         public string Id { get; protected set; }
         public string Name { get; set; }
         
-        public FeedType FeedType { get; set; }        
+        public FeedType FeedType { get; protected set; }        
     }
 
     public class NuGetFeed : Feed

--- a/source/Nevermore.IntegrationTests/Model/FeedMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/FeedMap.cs
@@ -1,0 +1,16 @@
+using System.Data;
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class FeedMap : DocumentMap<Feed>
+    {
+        public FeedMap()
+        {
+            IdColumn.MaxLength = 210;
+
+            Column(m => m.Name);
+            VirtualColumn(nameof(Feed.FeedType), DbType.String, m => m.FeedType.Name);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/FeedMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/FeedMap.cs
@@ -1,5 +1,7 @@
-using System.Data;
+using System;
+using System.Collections.Generic;
 using Nevermore.Mapping;
+using Nevermore.Serialization;
 
 namespace Nevermore.IntegrationTests.Model
 {
@@ -10,7 +12,20 @@ namespace Nevermore.IntegrationTests.Model
             IdColumn.MaxLength = 210;
 
             Column(m => m.Name);
-            VirtualColumn(nameof(Feed.FeedType), DbType.String, m => m.FeedType.Name);
+            Column(m => m.FeedType);
         }
     }
+    
+    public class FeedConverter : InheritedClassByExtensibleEnumConverter<Feed, FeedType>
+    {
+        readonly Dictionary<string, Type> derivedTypeMappings = new Dictionary<string, Type>
+        {
+            {FeedType.BuiltIn.Name, typeof(BuiltInFeed)},
+            {FeedType.NuGet.Name, typeof(NuGetFeed)}
+        };
+
+        protected override IDictionary<string, Type> DerivedTypeMappings => derivedTypeMappings;
+        protected override string TypeDesignatingPropertyName => nameof(Feed.FeedType);
+    }
+
 }

--- a/source/Nevermore.IntegrationTests/Model/FeedType.cs
+++ b/source/Nevermore.IntegrationTests/Model/FeedType.cs
@@ -1,25 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Nevermore.Contracts;
+using Nevermore.Serialization;
+
 namespace Nevermore.IntegrationTests.Model
 {
-    public class FeedType : ICustomThing
+    public class FeedType : ExtensibleEnum
     {
         public static readonly FeedType BuiltIn = new FeedType("BuiltIn");
         public static readonly FeedType NuGet = new FeedType("NuGet");
 
-        public FeedType(string name)
+        public FeedType(string name, string description = null) : base(name, description)
         {
-            Name = name;
-        }
-        
-        public string Name { get; }
-
-        public override string ToString()
-        {
-            return Name;
         }
     }
-
-    public interface ICustomThing
+    
+    public class FeedTypeConverter : ExtensibleEnumConverter<FeedType>
     {
-        string Name { get; }
+        protected override IDictionary<string, FeedType> Mappings { get; } = new Dictionary<string, FeedType>
+        {
+            {FeedType.BuiltIn.Name, FeedType.BuiltIn},
+            {FeedType.NuGet.Name, FeedType.NuGet},
+        };
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/FeedType.cs
+++ b/source/Nevermore.IntegrationTests/Model/FeedType.cs
@@ -1,0 +1,25 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    public class FeedType : ICustomThing
+    {
+        public static readonly FeedType BuiltIn = new FeedType("BuiltIn");
+        public static readonly FeedType NuGet = new FeedType("NuGet");
+
+        public FeedType(string name)
+        {
+            Name = name;
+        }
+        
+        public string Name { get; }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+
+    public interface ICustomThing
+    {
+        string Name { get; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -255,6 +255,45 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         }
 
         [Test]
+        public void StoreCustomInheritedTypesThatArePropertiesSerializeCorrectly()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var builtInFeed = new BuiltInFeed {Name = "BuiltIn"};
+                var nugetFeed = new NuGetFeed {Name = "NuGet"};
+
+                trn.Insert(builtInFeed);
+                trn.Insert(nugetFeed);
+                trn.Commit();
+
+                var allFeeds = trn.TableQuery<Feed>().ToList();
+
+                allFeeds.SingleOrDefault(x => x.Name == "BuiltIn").Should().NotBeNull("Didn't retrieve BuiltIn feed");
+            }
+        }
+
+        [Test]
+        public void QueryCustomInheritedTypesThatArePropertiesSerializeCorrectly()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var builtInFeed = new BuiltInFeed {Name = "BuiltIn"};
+                var nugetFeed = new NuGetFeed {Name = "NuGet"};
+
+                trn.Insert(builtInFeed);
+                trn.Insert(nugetFeed);
+                trn.Commit();
+
+                var queryBuilder = trn.TableQuery<Feed>().Where(f => f.FeedType == FeedType.BuiltIn);
+
+                var feed = queryBuilder.FirstOrDefault() as BuiltInFeed;
+
+                feed.Should().NotBeNull();
+                feed.Name.Should().Be("BuiltIn");
+            }
+        }
+
+        [Test]
         public void StoreAndLoadFromParameterizedRawSql()
         {
             using (var trn = Store.BeginTransaction())

--- a/source/Nevermore.Tests/Mapping/ExtensibleEnumFixture.SerializesCorrectly.approved.txt
+++ b/source/Nevermore.Tests/Mapping/ExtensibleEnumFixture.SerializesCorrectly.approved.txt
@@ -1,0 +1,4 @@
+{
+  "TestType": "TestType1",
+  "Name": "Test 1"
+}

--- a/source/Nevermore.Tests/Mapping/ExtensibleEnumFixture.cs
+++ b/source/Nevermore.Tests/Mapping/ExtensibleEnumFixture.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Assent;
+using FluentAssertions;
+using Nevermore.Contracts;
+using Nevermore.Serialization;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Nevermore.Tests.Mapping
+{
+    [TestFixture]
+    public class ExtensibleEnumFixture
+    {
+        abstract class Test
+        {
+            public string Name { get; set; }
+            public abstract TestType TestType { get; }
+        }
+
+        class Test1 : Test
+        {
+            public override TestType TestType => TestType.TestType1;
+        }
+        
+        class Test2 : Test
+        {
+            public override TestType TestType => TestType.TestType2;
+        }
+
+        class TestType : ExtensibleEnum
+        {
+            public static readonly TestType TestType1 = new TestType("TestType1"); 
+            public static readonly TestType TestType2 = new TestType("TestType2");
+
+            TestType(string name, string description = null) : base(name, description)
+            {
+            }
+        }
+
+        class TestConverter : InheritedClassByExtensibleEnumConverter<Test, TestType>
+        {
+            protected override IDictionary<string, Type> DerivedTypeMappings { get; } = new Dictionary<string, Type>
+            {
+                {TestType.TestType1.Name, typeof(Test1)},
+                {TestType.TestType2.Name, typeof(Test2)},
+            };
+            protected override string TypeDesignatingPropertyName => nameof(Test.TestType);
+        }
+
+        class TestTypeConverter : ExtensibleEnumConverter<TestType>
+        {
+            protected override IDictionary<string, TestType> Mappings { get; } = new Dictionary<string, TestType>
+            {
+                {TestType.TestType1.Name, TestType.TestType1},
+                {TestType.TestType2.Name, TestType.TestType2},
+            };
+        }
+        
+        [Test]
+        public void SerializesCorrectly()
+        {
+            var test = new Test1
+            {
+                Name = "Test 1"
+            };
+
+            var json = JsonConvert.SerializeObject(test, Formatting.Indented, new TestTypeConverter(), new TestConverter());
+            this.Assent(json);
+        }
+
+        [Test]
+        public void DeserializesCorrectly()
+        {
+            var json = "{TestType: \"TestType2\", Name: \"Test 2\"}";
+
+            var test = JsonConvert.DeserializeObject<Test>(json, new TestTypeConverter(), new TestConverter());
+            test.Should().BeOfType<Test2>();
+            test.Name.Should().Be("Test 2");
+        }
+    }
+}

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -67,6 +67,13 @@ namespace Nevermore.Mapping
                 DbType = DbType.String;
             }
 
+            if (typeof(ExtensibleEnum).GetTypeInfo().IsAssignableFrom(property.PropertyType))
+            {
+                MaxLength = DefaultMaxEnumLength;
+                DbType = DbType.String;
+                ReaderWriter = new ExtensibleEnumReaderWriter(ReaderWriter);
+            }
+
             if (property.PropertyType == typeof(ReferenceCollection))
             {
                 DbType = DbType.String;

--- a/source/Nevermore/Mapping/DatabaseTypeConverter.cs
+++ b/source/Nevermore/Mapping/DatabaseTypeConverter.cs
@@ -54,7 +54,8 @@ namespace Nevermore.Mapping
 
         public static DbType AsDbType(Type propertyType)
         {
-            if (propertyType.GetTypeInfo().IsEnum)
+            if (propertyType.GetTypeInfo().IsEnum ||
+                typeof(ExtensibleEnum).GetTypeInfo().IsAssignableFrom(propertyType))
             {
                 return DbType.String;
             }
@@ -63,7 +64,7 @@ namespace Nevermore.Mapping
             {
                 return DbType.String;
             }
-
+            
             DbType result;
             if (!TypeMap.TryGetValue(propertyType, out result))
                 throw new KeyNotFoundException("Cannot map database type from: " + propertyType.FullName);

--- a/source/Nevermore/Mapping/ExtensibleEnumReaderWriter.cs
+++ b/source/Nevermore/Mapping/ExtensibleEnumReaderWriter.cs
@@ -1,0 +1,26 @@
+using Nevermore.Contracts;
+
+namespace Nevermore.Mapping
+{
+    class ExtensibleEnumReaderWriter : PropertyReaderWriterDecorator
+    {
+        public ExtensibleEnumReaderWriter(IPropertyReaderWriter<object> original) : base(original)
+        {
+        }
+
+        public override object Read(object target)
+        {
+            var value = base.Read(target) as ExtensibleEnum;
+            if (value == null)
+                return "";
+
+            return value.Name;
+        }
+
+        public override void Write(object target, object value)
+        {
+            // ExtensibleEnum is write only to the database by it's nature, we don't need to write to
+            // the object here because the ExtensibleEnumConverter will have taken care of that.
+        }
+    }
+}

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Nevermore.AST;
 
@@ -145,7 +147,10 @@ namespace Nevermore
 
         public IQueryBuilder<TRecord> Parameter(Parameter parameter, object value)
         {
-            paramValues.Add(parameter.ParameterName, value);
+            if (value.GetType().GetTypeInfo().IsClass && !(value is string) && !(value is IEnumerable))
+                paramValues.Add(parameter.ParameterName, value.ToString());
+            else
+                paramValues.Add(parameter.ParameterName, value);
             return this;
         }
 

--- a/source/Nevermore/QueryBuilder.cs
+++ b/source/Nevermore/QueryBuilder.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Nevermore.AST;
+using Nevermore.Contracts;
 
 namespace Nevermore
 {
@@ -147,8 +146,8 @@ namespace Nevermore
 
         public IQueryBuilder<TRecord> Parameter(Parameter parameter, object value)
         {
-            if (value.GetType().GetTypeInfo().IsClass && !(value is string) && !(value is IEnumerable))
-                paramValues.Add(parameter.ParameterName, value.ToString());
+            if (value is ExtensibleEnum v)
+                paramValues.Add(parameter.ParameterName, v.Name);
             else
                 paramValues.Add(parameter.ParameterName, value);
             return this;

--- a/source/Nevermore/Serialization/ExtensibleEnumConverter.cs
+++ b/source/Nevermore/Serialization/ExtensibleEnumConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Nevermore.Contracts;
 using Newtonsoft.Json;
 
@@ -38,7 +39,7 @@ namespace Nevermore.Serialization
         
         public override bool CanConvert(Type objectType)
         {
-            return objectType is T;
+            return typeof(T).GetTypeInfo().IsAssignableFrom(objectType);
         }
     }
 }

--- a/source/Nevermore/Serialization/ExtensibleEnumConverter.cs
+++ b/source/Nevermore/Serialization/ExtensibleEnumConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Nevermore.Contracts;
+using Newtonsoft.Json;
+
+namespace Nevermore.Serialization
+{
+    public abstract class ExtensibleEnumConverter<T> : JsonConverter
+        where T : ExtensibleEnum
+    {
+        protected abstract IDictionary<string, T> Mappings { get; }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                var enumValue = value as T;
+                writer.WriteValue(enumValue.Name);
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+            
+            var readerValue = (string)reader.Value;
+            if (!Mappings.ContainsKey(readerValue))
+            {
+                throw new InvalidOperationException($"Unknown {typeof(T)} '{readerValue}'");                
+            }
+            return Mappings[readerValue];
+        }
+        
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType is T;
+        }
+    }
+}

--- a/source/Nevermore/Serialization/InheritedClassByExtensibleEnumConverter.cs
+++ b/source/Nevermore/Serialization/InheritedClassByExtensibleEnumConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+using Nevermore.Contracts;
+using Nevermore.Mapping;
+using Newtonsoft.Json.Linq;
+
+namespace Nevermore.Serialization
+{
+    public abstract class InheritedClassByExtensibleEnumConverter<TDocument, TDiscriminator> : InheritedClassConverterBase<TDocument, string>
+        where TDiscriminator : ExtensibleEnum
+    {
+        protected InheritedClassByExtensibleEnumConverter(RelationalMappings relationalMappings = null) : base(relationalMappings)
+        {
+        }
+
+        protected override string GetDesignatingValue(JToken designatingProperty)
+        {
+            foreach (var property in designatingProperty)
+            {
+                if (property.Type == JTokenType.Property &&
+                    ((JProperty)property).Name == "Name")
+                {
+                    return ((JProperty)property).Value.ToString();
+                }
+            }
+            return String.Empty;
+        }
+
+        protected override TypeInfo GetTypeInfoFromDerivedType(string derivedType)
+        {
+            if (!DerivedTypeMappings.ContainsKey(derivedType))
+            {
+                throw new Exception($"Unable to determine type to deserialize. {TypeDesignatingPropertyName} `{derivedType}` does not map to a known type");
+            }
+
+            var typeInfo = DerivedTypeMappings[derivedType].GetTypeInfo();
+            return typeInfo;
+        }
+    }
+}

--- a/source/Nevermore/Serialization/InheritedClassConverterBase.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverterBase.cs
@@ -79,7 +79,7 @@ namespace Nevermore.Serialization
             else
             {
                 string derivedType;
-                if (designatingProperty.Type is JTokenType.Object)
+                if (designatingProperty.Type == JTokenType.Object)
                 {
                     derivedType = GetDesignatingValue(designatingProperty);
                 }

--- a/source/Nevermore/Serialization/InheritedClassConverterBase.cs
+++ b/source/Nevermore/Serialization/InheritedClassConverterBase.cs
@@ -78,7 +78,15 @@ namespace Nevermore.Serialization
             }
             else
             {
-                var derivedType = designatingProperty.ToObject<string>();
+                string derivedType;
+                if (designatingProperty.Type is JTokenType.Object)
+                {
+                    derivedType = GetDesignatingValue(designatingProperty);
+                }
+                else
+                {
+                    derivedType = designatingProperty.ToObject<string>();
+                }
                 typeInfo = GetTypeInfoFromDerivedType(derivedType);
             }
 
@@ -118,6 +126,11 @@ namespace Nevermore.Serialization
             prop.SetValue(instance, value, null);
         }
 
+        protected virtual string GetDesignatingValue(JToken designatingProperty)
+        {
+            throw new Exception($"{this.GetType().Name} is using an object as a designating property but has not override GetDesignatingValue to map the value");
+        }
+        
         protected abstract TypeInfo GetTypeInfoFromDerivedType(string derivedType);
 
         public override bool CanConvert(Type objectType)


### PR DESCRIPTION
For the new extensibility work we are using static instances to represent what used to be enum values. This has caused some trouble because Nevermore tries to push the object into the SQL Parameter, rather than it's string representation.

This PR modifies the QueryBuilder to make it call `value.ToString()` for custom types and adds some tests to prove that the queries are working correctly.