### PR TITLE
Log SQL parameters along with the query

### DIFF
--- a/source/Nevermore/RelationalTransaction.cs
+++ b/source/Nevermore/RelationalTransaction.cs
@@ -680,7 +680,7 @@ namespace Nevermore
 
         string QueryInfoForLogging(string query, CommandParameterValues parameterValues)
         {
-            return QueryInfoForLogging(query, parameterValues.Select(p => (p.Key, p.Value)).ToList());
+            return QueryInfoForLogging(query, parameterValues?.Select(p => (p.Key, p.Value)).ToList() ?? new List<(string Key, object Value)>());
         }
         
         string QueryInfoForLogging(IDbCommand command)


### PR DESCRIPTION
Only logging the query doesn't give us the full picture, since we don't know what the parameter values are.

This will let us know the exactly query that was run on the machine to help diagnose performance issues.