### PR TITLE
Ensure list parameter replacement doesn't partially match similar parameter names

### DIFF
--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -22,6 +22,22 @@ namespace Nevermore.Tests
             command.Parameters["someId_1"].Value.Should().Be("id2");
             command.Parameters["someIdentifier"].Value.Should().Be("value");
         }
+        
+        [Test]
+        public void ShouldReplaceParametersWithExactMatchEndOfQuery()
+        {
+            var parameters = new CommandParameterValues();
+            parameters.Add("someId", "value");
+            parameters.Add("someIdentifier", new[] { "id1", "id2" });
+            var command = new SqlCommand("SELECT * FROM [Table] WHERE [Id] = @someId AND [OtherId] IN @someIdentifier");
+
+            parameters.ContributeTo(command);
+
+            command.CommandText.Should().Be("SELECT * FROM [Table] WHERE [Id] = @someId AND [OtherId] IN (@someIdentifier_0, @someIdentifier_1)");
+            command.Parameters["someId"].Value.Should().Be("value");
+            command.Parameters["someIdentifier_0"].Value.Should().Be("id1");
+            command.Parameters["someIdentifier_1"].Value.Should().Be("id2");
+        }
 
         [TestCase("@")]
         [TestCase("#")]

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -18,6 +18,9 @@ namespace Nevermore.Tests
             parameters.ContributeTo(command);
 
             command.CommandText.Should().Be("SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @someIdentifier");
+            command.Parameters["someId_0"].Value.Should().Be("id1");
+            command.Parameters["someId_1"].Value.Should().Be("id2");
+            command.Parameters["someIdentifier"].Value.Should().Be("value");
         }
 
         [Test]
@@ -31,6 +34,9 @@ namespace Nevermore.Tests
             parameters.ContributeTo(command);
 
             command.CommandText.Should().Be($"SELECT * FROM [Table]{Environment.NewLine}WHERE [Id] IN (@someId_0, @someId_1){Environment.NewLine}AND [OtherId] = @someIdentifier");
+            command.Parameters["someId_0"].Value.Should().Be("id1");
+            command.Parameters["someId_1"].Value.Should().Be("id2");
+            command.Parameters["someIdentifier"].Value.Should().Be("value");
         }
     }
 }

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -23,6 +23,25 @@ namespace Nevermore.Tests
             command.Parameters["someIdentifier"].Value.Should().Be("value");
         }
 
+        [TestCase("@")]
+        [TestCase("#")]
+        [TestCase("_")]
+        [TestCase("$")]
+        public void ShouldReplaceParametersWithExactMatchSpecialCharacters(string specialCharacter)
+        {
+            var parameters = new CommandParameterValues();
+            parameters.Add("someId", new[] { "id1", "id2" });
+            parameters.Add($"someId{specialCharacter}entifier", "value");
+            var command = new SqlCommand($"SELECT * FROM [Table] WHERE [Id] IN @someId AND [OtherId] = @someId{specialCharacter}entifier");
+
+            parameters.ContributeTo(command);
+
+            command.CommandText.Should().Be($"SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @someId{specialCharacter}entifier");
+            command.Parameters["someId_0"].Value.Should().Be("id1");
+            command.Parameters["someId_1"].Value.Should().Be("id2");
+            command.Parameters[$"someId{specialCharacter}entifier"].Value.Should().Be("value");
+        }
+
         [Test]
         public void ShouldReplaceParametersAcrossLineBreaks()
         {

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -1,5 +1,6 @@
-using Microsoft.Data.SqlClient;
+using System;
 using FluentAssertions;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 
 namespace Nevermore.Tests
@@ -17,6 +18,19 @@ namespace Nevermore.Tests
             parameters.ContributeTo(command);
 
             command.CommandText.Should().Be("SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @someIdentifier");
+        }
+
+        [Test]
+        public void ShouldReplaceParametersAcrossLineBreaks()
+        {
+            var parameters = new CommandParameterValues();
+            parameters.Add("someId", new[] { "id1", "id2" });
+            parameters.Add("someIdentifier", "value");
+            var command = new SqlCommand($"SELECT * FROM [Table]{Environment.NewLine}WHERE [Id] IN @someId{Environment.NewLine}AND [OtherId] = @someIdentifier");
+
+            parameters.ContributeTo(command);
+
+            command.CommandText.Should().Be($"SELECT * FROM [Table]{Environment.NewLine}WHERE [Id] IN (@someId_0, @someId_1){Environment.NewLine}AND [OtherId] = @someIdentifier");
         }
     }
 }

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -1,0 +1,22 @@
+using Microsoft.Data.SqlClient;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Nevermore.Tests
+{
+    public class CommandParameterValuesFixture
+    {
+        [Test]
+        public void ShouldReplaceParametersWithExactMatch()
+        {
+            var parameters = new CommandParameterValues();
+            parameters.Add("someId", new[] { "id1", "id2" });
+            parameters.Add("someIdentifier", "value");
+            var command = new SqlCommand("SELECT * FROM [Table] WHERE [Id] IN @someId AND [OtherId] = @someIdentifier");
+
+            parameters.ContributeTo(command);
+
+            command.CommandText.Should().Be("SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @someIdentifier");
+        }
+    }
+}

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -39,23 +39,23 @@ namespace Nevermore.Tests
             command.Parameters["someIdentifier_1"].Value.Should().Be("id2");
         }
 
-        [TestCase("@")]
-        [TestCase("#")]
-        [TestCase("_")]
-        [TestCase("$")]
-        public void ShouldReplaceParametersWithExactMatchSpecialCharacters(string specialCharacter)
+        [TestCase("someId@entifier")]
+        [TestCase("someId#entifier")]
+        [TestCase("someId_entifier")]
+        [TestCase("someId$entifier")]
+        public void ShouldReplaceParametersWithExactMatchSpecialCharacters(string paramName)
         {
             var parameters = new CommandParameterValues();
             parameters.Add("someId", new[] { "id1", "id2" });
-            parameters.Add($"someId{specialCharacter}entifier", "value");
-            var command = new SqlCommand($"SELECT * FROM [Table] WHERE [Id] IN @someId AND [OtherId] = @someId{specialCharacter}entifier");
+            parameters.Add(paramName, "value");
+            var command = new SqlCommand($"SELECT * FROM [Table] WHERE [Id] IN @someId AND [OtherId] = @{paramName}");
 
             parameters.ContributeTo(command);
 
-            command.CommandText.Should().Be($"SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @someId{specialCharacter}entifier");
+            command.CommandText.Should().Be($"SELECT * FROM [Table] WHERE [Id] IN (@someId_0, @someId_1) AND [OtherId] = @{paramName}");
             command.Parameters["someId_0"].Value.Should().Be("id1");
             command.Parameters["someId_1"].Value.Should().Be("id2");
-            command.Parameters[$"someId{specialCharacter}entifier"].Value.Should().Be("value");
+            command.Parameters[paramName].Value.Should().Be("value");
         }
 
         [Test]

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -102,7 +102,7 @@ namespace Nevermore
                 }
 
 
-                var originalParameter = Regex.Escape("@" + name.TrimStart('@'));
+                var originalParameter = Regex.Escape("@" + name.TrimStart('@')) + @"(?=[^\w\$@#_])";
                 var replacementParameters = "(" + string.Join(", ", inClauseNames.Select(x => "@" + x)) + ")";
                 command.CommandText = Regex.Replace(command.CommandText, originalParameter, match => replacementParameters, RegexOptions.IgnoreCase);
                 return;

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -102,7 +102,7 @@ namespace Nevermore
                 }
 
 
-                var originalParameter = Regex.Escape("@" + name.TrimStart('@')) + @"(?=[^\w\$@#_])";
+                var originalParameter = Regex.Escape("@" + name.TrimStart('@')) + @"(?=[^\w\$@#_]|$)";
                 var replacementParameters = "(" + string.Join(", ", inClauseNames.Select(x => "@" + x)) + ")";
                 command.CommandText = Regex.Replace(command.CommandText, originalParameter, match => replacementParameters, RegexOptions.IgnoreCase);
                 return;


### PR DESCRIPTION
## Problem
This issue was discovered [here](https://github.com/OctopusDeploy/Issues/issues/6185).

When using a parameter with a list of values, Nevermore will rewrite the query to build an inline list featuring a new parameter for each list item. For example:

```
SELECT * FROM [Table] WHERE [Id] IN @ids
```
becomes:
```
SELECT * FROM [Table] WHERE [Id] IN (@ids_0, @ids_1, ...@ids_n)
```

This uses a Regex to match the name of the parameter to replace, but will also match other identifiers that partially match. For example:
```
SELECT * FROM [Table] WHERE [Id] IN @ids AND [OtherThing] = @ids123
```
becomes:
```
SELECT * FROM [Table] WHERE [Id] IN (@ids_0, @ids_1) AND [OtherThing] = (@ids_0, @ids_1)123
```
which is clearly not valid SQL.

## Solution
Adjust the Regex match pattern to include a look-ahead for a character that is not valid for use in identifiers `(letters, numbers, _, $ #, @)`, which would denote the end of the parameter name. This means that other identifiers which start with same characters would not be replaced.