### PR TITLE
Faster Load(array)

### DIFF
--- a/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/IntegrationTestDatabase.cs
@@ -55,6 +55,7 @@ namespace Nevermore.IntegrationTests
         void CreateDatabase()
         {
             ExecuteScript(@"create database [" + TestDatabaseName + "] COLLATE SQL_Latin1_General_CP1_CS_AS", GetMaster(TestDatabaseConnectionString));
+            ExecuteScript(@"CREATE TYPE dbo.[ParameterList] as TABLE([ParameterValue] nvarchar(300))", TestDatabaseConnectionString);
         }
 
         void DropDatabase()

--- a/source/Nevermore.IntegrationTests/LoadStreamFixture.cs
+++ b/source/Nevermore.IntegrationTests/LoadStreamFixture.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Nevermore.IntegrationTests.Model;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests
+{
+    public class LoadStreamFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void LoadManyPerformanceTest()
+        {
+            using (var creator = Store.BeginTransaction())
+            {
+                for (var i = 0; i < 30000; i++)
+                {
+                    creator.Insert(new Product { Name = "Product " + i, Price = i, Type = ProductType.Dodgy});
+                }
+                
+                creator.Commit();
+            }
+
+            using (var reader = Store.BeginTransaction())
+            {
+                var all = reader.Query<Product>().ToList().Select(p => p.Id).OrderByDescending(p => Guid.NewGuid()).ToList();
+
+                DoLoad(reader, all.Take(100).ToList());
+                DoLoad(reader, all.Take(100).ToList());
+                DoLoad(reader, all.Take(300).ToList());
+                DoLoad(reader, all.Take(600).ToList());
+                DoLoad(reader, all.Take(1200).ToList());
+                DoLoad(reader, all.Take(1800).ToList());
+                DoLoad(reader, all.Take(2400).ToList());
+            }
+        }
+
+        static void DoLoad(IRelationalTransaction transaction, List<string> ids)
+        {
+            var watch = Stopwatch.StartNew();
+            var products = transaction.Load<Product>(ids);
+            Assert.That(products.Length, Is.EqualTo(ids.Count));
+            Console.WriteLine($"Loaded {products.Length} products in {watch.ElapsedMilliseconds}ms");
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/LoadStreamFixture.cs
+++ b/source/Nevermore.IntegrationTests/LoadStreamFixture.cs
@@ -9,7 +9,7 @@ namespace Nevermore.IntegrationTests
 {
     public class LoadStreamFixture : FixtureWithRelationalStore
     {
-        [Test]
+        [Test, Ignore("For performance")]
         public void LoadManyPerformanceTest()
         {
             using (var creator = Store.BeginTransaction())

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 #if NETFRAMEWORK
 using System.Data.SqlClient;
+using Microsoft.SqlServer.Server;
 #else
 using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
 #endif
 using System.Linq;
 using System.Reflection;
@@ -50,6 +53,18 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
+        public void AddTable(string name, IEnumerable<string> ids)
+        {
+            var idColumnMetadata = new SqlMetaData("ParameterValue", SqlDbType.NVarChar, 300);
+            
+            Add(name, ids.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v =>
+            {
+                var record = new SqlDataRecord(idColumnMetadata);
+                record.SetValue(0, v);
+                return record;
+            }).ToList());
+        }
+        
         void AddFromParametersObject(object args)
         {
             if (args == null)
@@ -79,6 +94,14 @@ namespace Nevermore
             if (value == null)
             {
                 command.Parameters.Add(new SqlParameter(name, DBNull.Value));
+                return;
+            }
+
+            if (value is List<SqlDataRecord> dr && command is SqlCommand sqlCommand)
+            {
+                var p = sqlCommand.Parameters.Add(name, SqlDbType.Structured);
+                p.Value = dr;
+                p.TypeName = "dbo.[ParameterList]";
                 return;
             }
 
@@ -137,6 +160,141 @@ namespace Nevermore
                     throw new Exception($"The parameter {item.Key} already exists");
                 this[item.Key] = item.Value;
             }
+        }
+    }
+
+    public class MyDataReader : DbDataReader
+    {
+        public override bool GetBoolean(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte GetByte(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override char GetChar(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetDataTypeName(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override DateTime GetDateTime(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override decimal GetDecimal(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override double GetDouble(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override float GetFloat(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Guid GetGuid(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override short GetInt16(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetInt32(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetInt64(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetName(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetString(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object GetValue(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetValues(object[] values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool IsDBNull(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int FieldCount { get; }
+
+        public override object this[int ordinal] => throw new NotImplementedException();
+
+        public override object this[string name] => throw new NotImplementedException();
+
+        public override int RecordsAffected { get; }
+        public override bool HasRows { get; }
+        public override bool IsClosed { get; }
+
+        public override bool NextResult()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Read()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Depth { get; }
+
+        public override IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Nevermore provides a Load overload that takes an array of ID's. The common use case is that you perform a select, find a set of related document IDs, then load that set of related documents. 

It currently works by generating large "IN" statements. E.g.,:

    SELECT * FROM Product WHERE Id in (@ids_0, @ids_1, .....)

This has a few downsides:

- You can only have so many parameters in a statement, so when searching on hundreds of ID's, it needs to split them into chunks
 - Queries with different numbers of parameters (e.g., 317 vs 407) don't get to reuse the same query plan
 - It's generally just slower

This new version makes use of tabled value parameters. 

Here's the performance difference (on my local SQLEXPRESS)

Old approach:

```
Loaded 100 products in 42ms  // warm up
Loaded 100 products in 2ms 
Loaded 300 products in 32ms
Loaded 600 products in 79ms
Loaded 1200 products in 105ms
Loaded 1800 products in 130ms
Loaded 2400 products in 166ms
```

New approach (table valued parameters)

```
Loaded 100 products in 47ms
Loaded 100 products in 2ms
Loaded 300 products in 5ms
Loaded 600 products in 9ms
Loaded 1200 products in 16ms
Loaded 1800 products in 23ms
Loaded 2400 products in 30ms
```

The new approach is faster because SQL is able to reuse the same query plan whether you ask for 5 ID's or 5000. It also doesn't have to batch, so it can load thousands in one go. 

For large data sets, the difference is more obvious. Here it is loading 50,000 items:

```
Loaded 50000 products in 684ms (new way)
Loaded 50000 products in 7347ms (old way)
```

This feels fast enough (for 50,000 items!) that it might move this from being a strategy we want to avoid to one we can actually use more frequently. 

**There is one catch though**. You have to define this type (with this name):

```
CREATE TYPE dbo.[ParameterList] as TABLE([ParameterValue] nvarchar(300))
```

This would need to be a migration script in Octopus/Octofront.