### PR TITLE
Fixed bug with collection properties with no setter

### DIFF
--- a/source/Nevermore.IntegrationTests/Contracts/ReferenceCollection.cs
+++ b/source/Nevermore.IntegrationTests/Contracts/ReferenceCollection.cs
@@ -6,7 +6,7 @@ namespace Nevermore.IntegrationTests.Contracts
     /// <summary>
     /// A case-insensitive collection of unique strings used for holding document ID's.
     /// </summary>
-    public class ReferenceCollection : HashSet<string>, IReadOnlyCollection<string>
+    public class ReferenceCollection : HashSet<string>
     {
         public ReferenceCollection()
             : base(StringComparer.OrdinalIgnoreCase)

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Nevermore.IntegrationTests.Contracts;
 
 namespace Nevermore.IntegrationTests.Model
@@ -13,7 +12,7 @@ namespace Nevermore.IntegrationTests.Model
         public string Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public ReferenceCollection Roles { get; private set; }
+        public ReferenceCollection Roles { get; }
         public string Nickname { get; set; }
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }

--- a/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderExpressionBuilder.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderExpressionBuilder.cs
@@ -186,6 +186,14 @@ namespace Nevermore.Advanced.ReaderStrategies.Documents
                 // We don't read this field
                 return;
 
+            if (!column.Property.CanWrite && column.PropertyHandler.CanWrite)
+            {
+                // if the property itself can't be written directly, but the PropertyHandler says it can write then it
+                // is handling this case and no assigner is required here. This can happen with properties that are
+                // collection types.
+                return;
+            } 
+
             if (column.Property != null && column.PropertyHandler is PropertyHandler)
             {
                 // Optimization: Rather than call the property handler, we can embed the expression to assign the


### PR DESCRIPTION
The `PropertyHandler` had set itself up to handle this case, but `DocumentReaderExpressionBuilder` had a bug where it was still trying to cache an assigner. This threw an exception because the assigner couldn't work without the setter.

Changed the Customer object in the model to expose the issue and prove the fix.