### PR TITLE
Allow a blank prefix when mapping a projection

### DIFF
--- a/source/Nevermore/Advanced/ProjectionMapper.cs
+++ b/source/Nevermore/Advanced/ProjectionMapper.cs
@@ -24,7 +24,7 @@ namespace Nevermore.Advanced
         {
             if (!readers.ContainsKey(prefix))
             {
-                var prefixedReader = new PrefixedDataReader(prefix + "_", reader);
+                var prefixedReader = new PrefixedDataReader(string.IsNullOrWhiteSpace(prefix) ? string.Empty : prefix + "_", reader);
                 var func = readerStrategies.Resolve<TResult>(command);
                 readers.Add(prefix, new ProjectingReader<TResult>(func, prefixedReader));
             }


### PR DESCRIPTION
There are times where prefixing every column individually in a projection is problematic. Octopus server has cases, for example, where it needs a Release document plus 1 other value from a projected SELECT. In this scenario the columns primarily map to a single document and it is easier to not require a prefix.

This change assumes column names will match the mapped column names if the prefix is null or whitespace.