### PR TITLE
Add schema name support (#101)

### DIFF
--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -20,7 +20,7 @@ namespace Nevermore.Tests.Column
             actual.ShouldBeEquivalentTo(@"SELECT [Foo],
 [Bar],
 [Baz]
-FROM dbo.[Records]
+FROM [dbo].[Records]
 ORDER BY [Id]");
         }
 
@@ -36,7 +36,7 @@ ORDER BY [Id]");
             actual.ShouldBeEquivalentTo(@"SELECT [Foo] AS [A],
 [Bar] AS [B],
 [Baz] AS [C]
-FROM dbo.[Records]
+FROM [dbo].[Records]
 ORDER BY [Id]");
         }
 
@@ -54,7 +54,7 @@ ORDER BY [Id]");
             actual.ShouldBeEquivalentTo(@"SELECT MyTable.[Foo] AS [A],
 MyTable.[Bar] AS [B],
 MyTable.[Baz] AS [C]
-FROM dbo.[Records] MyTable
+FROM [dbo].[Records] MyTable
 ORDER BY [Id]");
         }
 

--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -61,6 +61,7 @@ ORDER BY [Id]");
         static ITableSourceQueryBuilder<Record> CreateQueryBuilder()
         {
             return new TableSourceQueryBuilder<Record>("Records", 
+                "dbo",
                 Substitute.For<IRelationalTransaction>(), 
                 new TableAliasGenerator(), 
                 new UniqueParameterNameGenerator(), 

--- a/source/Nevermore.Tests/Linq/LinqOrderByClauseTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqOrderByClauseTests.cs
@@ -15,7 +15,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int]");
         }
         
@@ -29,7 +29,7 @@ ORDER BY [Int]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int] DESC");
         }
         
@@ -45,7 +45,7 @@ ORDER BY [Int] DESC");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int]");
         }
         
@@ -61,7 +61,7 @@ ORDER BY [Int]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int] DESC");
         }
         
@@ -75,7 +75,7 @@ ORDER BY [Int] DESC");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int], [String]");
         }
         
@@ -89,7 +89,7 @@ ORDER BY [Int], [String]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int], [String] DESC");
         }
         
@@ -105,7 +105,7 @@ ORDER BY [Int], [String] DESC");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int], [String]");
         }
         
@@ -121,7 +121,7 @@ ORDER BY [Int], [String]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 ORDER BY [Int], [String] DESC");
         }
     }

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseComparisonTypeTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseComparisonTypeTests.cs
@@ -15,7 +15,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] < @int)
 ORDER BY [Id]");
         }
@@ -30,7 +30,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] <= @int)
 ORDER BY [Id]");
         }
@@ -46,7 +46,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] > @int)
 ORDER BY [Id]");
         }
@@ -61,7 +61,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] >= @int)
 ORDER BY [Id]");
         }
@@ -76,7 +76,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] <> @int)
 ORDER BY [Id]");
         }
@@ -87,14 +87,14 @@ ORDER BY [Id]");
             NewQueryBuilder().builder.Where(f => f.String == null).DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] is null)
 ORDER BY [Id]");
             
             NewQueryBuilder().builder.Where(f => f.String != null).DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] is not null)
 ORDER BY [Id]");
         }

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseLogicalClausesTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseLogicalClausesTests.cs
@@ -15,7 +15,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] < @int)
 AND ([String] = @string)
 ORDER BY [Id]");
@@ -31,7 +31,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] > @int)
 AND ([Int] < @int_1)
 ORDER BY [Id]");

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseMethodOperationTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseMethodOperationTests.cs
@@ -92,7 +92,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] IN (@string1, @string2, @string3))
 ORDER BY [Id]");
 
@@ -107,7 +107,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] LIKE @string)
 ORDER BY [Id]");
 
@@ -121,7 +121,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] IN (@int1, @int2, @int3))
 ORDER BY [Id]");
 

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseQuerySyntaxTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseQuerySyntaxTests.cs
@@ -17,7 +17,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] < @int)
 ORDER BY [Id]");
         }
@@ -35,7 +35,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] < @int)
 AND ([Int] > @int_1)
 ORDER BY [Id]");
@@ -54,7 +54,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] < @int)
 AND ([String] = @string)
 ORDER BY [Id]");
@@ -72,7 +72,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE (N = 100)
 ORDER BY [Id]");
         }

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseStringOperationTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseStringOperationTests.cs
@@ -42,7 +42,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] LIKE @string)
 ORDER BY [Id]");
 

--- a/source/Nevermore.Tests/Linq/LinqWhereClauseValueSourcesAndTypeTests.cs
+++ b/source/Nevermore.Tests/Linq/LinqWhereClauseValueSourcesAndTypeTests.cs
@@ -87,7 +87,7 @@ namespace Nevermore.Tests.Linq
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Int] = @int)
 ORDER BY [Id]");
 
@@ -105,7 +105,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Bool] = @bool)
 ORDER BY [Id]");
 
@@ -123,7 +123,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Bool] = @bool)
 ORDER BY [Id]");
 
@@ -141,7 +141,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Bool] = @bool)
 ORDER BY [Id]");
 
@@ -159,7 +159,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([DateTime] = @datetime)
 ORDER BY [Id]");
 
@@ -177,7 +177,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Enum] = @enum)
 ORDER BY [Id]");
 
@@ -200,7 +200,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Enum] = @enum)
 ORDER BY [Id]");
 
@@ -220,7 +220,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Enum] IN (@enum1, @enum2))
 ORDER BY [Id]");
 
@@ -240,7 +240,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Enum] IN (@enum1, @enum2))
 ORDER BY [Id]");
 
@@ -260,7 +260,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([Enum] NOT IN (@enum1, @enum2))
 ORDER BY [Id]");
 
@@ -274,7 +274,7 @@ ORDER BY [Id]");
             result.DebugViewRawQuery()
                 .Should()
                 .Be(@"SELECT *
-FROM dbo.[Foo]
+FROM [dbo].[Foo]
 WHERE ([String] = @string)
 ORDER BY [Id]");
 

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_LatestSuccessfulDeployments.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_LatestSuccessfulDeployments.approved.txt
@@ -2,10 +2,10 @@ SELECT *
 FROM (
     SELECT deployments.*,
     ROW_NUMBER() OVER (PARTITION BY deployments.[EnvironmentId], deployments.[ProjectId], deployments.[TenantId] ORDER BY e.[occurred] DESC) AS Rank
-    FROM dbo.[Deployment] deployments
-    INNER JOIN dbo.[EventRelatedDocument] eventRelatedDocuments
+    FROM [dbo].[Deployment] deployments
+    INNER JOIN [dbo].[EventRelatedDocument] eventRelatedDocuments
     ON deployments.[Id] = eventRelatedDocuments.[RelatedDocumentId]
-    INNER JOIN dbo.[Event] e
+    INNER JOIN [dbo].[Event] e
     ON eventRelatedDocuments.[EventId] = e.[Id]
     WHERE (e.category = 'DeploymentSucceeded')
 ) d

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_Release_LatestByProjectChannel.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.Replace_Release_LatestByProjectChannel.approved.txt
@@ -2,7 +2,7 @@ SELECT *
 FROM (
     SELECT *,
     ROW_NUMBER() OVER (PARTITION BY [SpaceId], [ProjectId], [ChannelId] ORDER BY [Assembled] DESC) AS RowNum
-    FROM dbo.[Release]
+    FROM [dbo].[Release]
 ) rs
 WHERE ([RowNum] = @rownum)
 ORDER BY rs.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldCollectParametersAndDefaultsFromSubqueriesInJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldCollectParametersAndDefaultsFromSubqueriesInJoin.approved.txt
@@ -1,14 +1,14 @@
-CREATE PROCEDURE dbo.[ShouldCollectParametersFromSubqueriesInJoin]
+CREATE PROCEDURE [dbo].[ShouldCollectParametersFromSubqueriesInJoin]
 (
     @name NVARCHAR(MAX) = 'Bob'
 )
 AS
 BEGIN (
     SELECT ALIAS_Orders_2.*
-    FROM dbo.[Orders] ALIAS_Orders_2
+    FROM [dbo].[Orders] ALIAS_Orders_2
     INNER JOIN (
         SELECT *
-        FROM dbo.[Customers]
+        FROM [dbo].[Customers]
         WHERE ([Name] = @name)
     ) ALIAS_GENERATED_1
     ON ALIAS_Orders_2.[CustomerId] = ALIAS_GENERATED_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldCollectParametersAndDefaultsFromUnion.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldCollectParametersAndDefaultsFromUnion.approved.txt
@@ -1,4 +1,4 @@
-CREATE PROCEDURE dbo.[ShouldCollectParametersAndDefaultsFromUnion]
+CREATE PROCEDURE [dbo].[ShouldCollectParametersAndDefaultsFromUnion]
 (
     @name NVARCHAR(MAX) = 'ABC'
 )
@@ -7,10 +7,10 @@ BEGIN (
     SELECT *
     FROM (
         SELECT [Id] AS [Id]
-        FROM dbo.[Orders]
+        FROM [dbo].[Orders]
         UNION
         SELECT [Id] AS [Id]
-        FROM dbo.[Account]
+        FROM [dbo].[Account]
         WHERE ([Name] = @name)
     ) ALIAS_GENERATED_1
     ORDER BY ALIAS_GENERATED_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasForSubquery.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasForSubquery.approved.txt
@@ -1,6 +1,6 @@
 SELECT *
 FROM (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
 ) ORD
 ORDER BY ORD.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasForTable.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasForTable.approved.txt
@@ -1,3 +1,3 @@
 SELECT *
-FROM dbo.[Orders] ORD
+FROM [dbo].[Orders] ORD
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasesForSourcesInJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateAliasesForSourcesInJoin.approved.txt
@@ -1,8 +1,8 @@
 SELECT ORD.*
-FROM dbo.[Orders] ORD
+FROM [dbo].[Orders] ORD
 INNER JOIN (
     SELECT *
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
 ) ACC
 ON ORD.[AccountId] = ACC.[Id]
 WHERE (ORD.[Id] = @id)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateCalculatedColumn.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateCalculatedColumn.approved.txt
@@ -1,3 +1,3 @@
 SELECT 'CONSTANT' AS [MyConstant]
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelection.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelection.approved.txt
@@ -1,5 +1,5 @@
 SELECT [Foo],
 [Bar],
 [Baz]
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionForJoin.approved.txt
@@ -2,10 +2,10 @@ SELECT ORD.[Id] AS [OrderId],
 Acc.[Id] AS [AccountId],
 ORD.[Number],
 ORD.[Id] AS [OrderId2]
-FROM dbo.[Orders] ORD
+FROM [dbo].[Orders] ORD
 INNER JOIN (
     SELECT *
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
 ) ACC
 ON ORD.[AccountId] = ACC.[Id]
 ORDER BY ORD.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionWithAliases.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionWithAliases.approved.txt
@@ -1,5 +1,5 @@
 SELECT [Foo] AS [F],
 [Bar] AS [B],
 [Baz] AS [B2]
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionWithTableAlias.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateColumnSelectionWithTableAlias.approved.txt
@@ -1,5 +1,5 @@
 SELECT ORD.[Foo] AS [F],
 ORD.[Bar] AS [B],
 ORD.[Baz] AS [B2]
-FROM dbo.[Orders] ORD
+FROM [dbo].[Orders] ORD
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateComplexDashboardView.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateComplexDashboardView.approved.txt
@@ -1,4 +1,4 @@
-CREATE VIEW dbo.[Dashboard] AS
+CREATE VIEW [dbo].[Dashboard] AS
     SELECT d.[Id] AS [Id],
     d.[Created] AS [Created],
     d.[ProjectId] AS [ProjectId],
@@ -24,8 +24,8 @@ CREATE VIEW dbo.[Dashboard] AS
         d.[TaskId] AS [TaskId],
         d.[ChannelId] AS [ChannelId],
         ROW_NUMBER() OVER (PARTITION BY d.[EnvironmentId], d.[ProjectId] ORDER BY d.[Created] DESC) AS Rank
-        FROM dbo.[Deployment] d
-        INNER JOIN dbo.[ServerTask] t
+        FROM [dbo].[Deployment] d
+        INNER JOIN [dbo].[ServerTask] t
         ON d.[TaskId] = t.[Id]
         WHERE (NOT ((t.State = 'Canceled' OR t.State = 'Cancelling') AND t.StartTime IS NULL))
         UNION
@@ -38,16 +38,16 @@ CREATE VIEW dbo.[Dashboard] AS
         d.[TaskId] AS [TaskId],
         d.[ChannelId] AS [ChannelId],
         ROW_NUMBER() OVER (PARTITION BY d.[EnvironmentId], d.[ProjectId] ORDER BY d.[Created] DESC) AS Rank
-        FROM dbo.[Deployment] d
-        INNER JOIN dbo.[ServerTask] t
+        FROM [dbo].[Deployment] d
+        INNER JOIN [dbo].[ServerTask] t
         ON d.[TaskId] = t.[Id]
         LEFT HASH JOIN (
             SELECT [Id]
             FROM (
                 SELECT d.[Id] AS [Id],
                 ROW_NUMBER() OVER (PARTITION BY d.[EnvironmentId], d.[ProjectId] ORDER BY d.[Created] DESC) AS Rank
-                FROM dbo.[Deployment] d
-                INNER JOIN dbo.[ServerTask] t
+                FROM [dbo].[Deployment] d
+                INNER JOIN [dbo].[ServerTask] t
                 ON d.[TaskId] = t.[Id]
                 WHERE (NOT ((t.State = 'Canceled' OR t.State = 'Cancelling') AND t.StartTime IS NULL))
             ) LatestDeployment
@@ -57,9 +57,9 @@ CREATE VIEW dbo.[Dashboard] AS
         WHERE (t.State = 'Success')
         AND (l.Id is null)
     ) d
-    INNER JOIN dbo.[ServerTask] t
+    INNER JOIN [dbo].[ServerTask] t
     ON d.[TaskId] = t.[Id]
-    INNER JOIN dbo.[Release] r
+    INNER JOIN [dbo].[Release] r
     ON d.[ReleaseId] = r.[Id]
     WHERE (([Rank]=1 AND CurrentOrPrevious='P') OR ([Rank]=1 AND CurrentOrPrevious='C'))
     ORDER BY d.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateComplexStoredProcedureWithParameters.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateComplexStoredProcedureWithParameters.approved.txt
@@ -1,4 +1,4 @@
-CREATE PROCEDURE dbo.[LatestSuccessfulDeploymentsToMachine]
+CREATE PROCEDURE [dbo].[LatestSuccessfulDeploymentsToMachine]
 (
     @machineid NVARCHAR(MAX)
 )
@@ -8,12 +8,12 @@ BEGIN (
     FROM (
         SELECT ALIAS_Deployment_2.*,
         ROW_NUMBER() OVER (PARTITION BY ALIAS_Deployment_2.[EnvironmentId], ALIAS_Deployment_2.[ProjectId], ALIAS_Deployment_2.[TenantId] ORDER BY ALIAS_Deployment_2.[[Event].[Occurred]] DESC) AS Rank
-        FROM dbo.[Deployment] ALIAS_Deployment_2
-        INNER JOIN dbo.[DeploymentRelatedMachine] ALIAS_DeploymentRelatedMachine_1
+        FROM [dbo].[Deployment] ALIAS_Deployment_2
+        INNER JOIN [dbo].[DeploymentRelatedMachine] ALIAS_DeploymentRelatedMachine_1
         ON ALIAS_Deployment_2.[Id] = ALIAS_DeploymentRelatedMachine_1.[DeploymentId]
-        INNER JOIN dbo.[EventRelatedDocument] ALIAS_EventRelatedDocument_3
+        INNER JOIN [dbo].[EventRelatedDocument] ALIAS_EventRelatedDocument_3
         ON ALIAS_Deployment_2.[Id] = ALIAS_EventRelatedDocument_3.[RelatedDocumentId]
-        INNER JOIN dbo.[Event] Event
+        INNER JOIN [dbo].[Event] Event
         ON ALIAS_Deployment_2.[Id] = Event.[EventId]
         WHERE ([DeploymentRelatedMachine].MachineId = @machineid)
         AND ([Event].Category = 'DeploymentSucceeded')

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateCountForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateCountForJoin.approved.txt
@@ -1,8 +1,8 @@
 SELECT COUNT(*)
 FROM (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Price] > 5)
 ) ALIAS_GENERATED_2
-INNER JOIN dbo.[Customers] ALIAS_Customers_1
+INNER JOIN [dbo].[Customers] ALIAS_Customers_1
 ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateFunctionWithDefaultValues.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateFunctionWithDefaultValues.approved.txt
@@ -1,4 +1,4 @@
-CREATE FUNCTION dbo.[PackagesMatchingId]
+CREATE FUNCTION [dbo].[PackagesMatchingId]
 (
     @packageid NVARCHAR(250) = ''
 )
@@ -6,7 +6,7 @@ RETURNS TABLE
 AS
 RETURN (
     SELECT *
-    FROM dbo.[NuGetPackages]
+    FROM [dbo].[NuGetPackages]
     WHERE ((@packageid is '') or (PackageId = @packageid))
     ORDER BY [Id]
 )

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateFunctionWithParameters.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateFunctionWithParameters.approved.txt
@@ -1,4 +1,4 @@
-CREATE FUNCTION dbo.[PackagesMatchingId]
+CREATE FUNCTION [dbo].[PackagesMatchingId]
 (
     @packageid NVARCHAR(250)
 )
@@ -6,7 +6,7 @@ RETURNS TABLE
 AS
 RETURN (
     SELECT *
-    FROM dbo.[NuGetPackages]
+    FROM [dbo].[NuGetPackages]
     WHERE (PackageId = @packageid)
     ORDER BY [Id]
 )

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateLeftHashJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateLeftHashJoin.approved.txt
@@ -1,5 +1,5 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
-LEFT HASH JOIN dbo.[Account] ALIAS_Account_1
+FROM [dbo].[Orders] ALIAS_Orders_2
+LEFT HASH JOIN [dbo].[Account] ALIAS_Account_1
 ON ALIAS_Orders_2.[AccountId] = ALIAS_Account_1.[Id]
 ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateMultipleJoinTypes.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateMultipleJoinTypes.approved.txt
@@ -1,11 +1,11 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
+FROM [dbo].[Orders] ALIAS_Orders_2
 INNER JOIN (
     SELECT *
-    FROM dbo.[Customers]
+    FROM [dbo].[Customers]
     WHERE ([Name] LIKE @name)
 ) ALIAS_GENERATED_1
 ON ALIAS_Orders_2.[CustomerId] = ALIAS_GENERATED_1.[Id]
-LEFT HASH JOIN dbo.[Account] ALIAS_Account_3
+LEFT HASH JOIN [dbo].[Account] ALIAS_Account_3
 ON ALIAS_Orders_2.[AccountId] = ALIAS_Account_3.[Id]
 ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateMultipleUnionsWithoutNesting.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateMultipleUnionsWithoutNesting.approved.txt
@@ -1,12 +1,12 @@
 SELECT *
 FROM (
     SELECT [Id] AS [Id]
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     UNION
     SELECT [Id] AS [Id]
-    FROM dbo.[Account]
+    FROM [dbo].[Account]
     UNION
     SELECT [Id] AS [Id]
-    FROM dbo.[Customers]
+    FROM [dbo].[Customers]
 ) ALIAS_GENERATED_1
 ORDER BY ALIAS_GENERATED_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginate.approved.txt
@@ -2,7 +2,7 @@ SELECT *
 FROM (
     SELECT *,
     ROW_NUMBER() OVER (ORDER BY [Foo]) AS RowNum
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Price] > 5)
 ) ALIAS_GENERATED_1
 WHERE ([RowNum] >= @_minrow)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateForJoin.approved.txt
@@ -4,10 +4,10 @@ FROM (
     ROW_NUMBER() OVER (ORDER BY ALIAS_GENERATED_2.[Id]) AS RowNum
     FROM (
         SELECT *
-        FROM dbo.[Orders]
+        FROM [dbo].[Orders]
         WHERE ([Price] > 5)
     ) ALIAS_GENERATED_2
-    INNER JOIN dbo.[Customers] ALIAS_Customers_1
+    INNER JOIN [dbo].[Customers] ALIAS_Customers_1
     ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]
 ) ALIAS_GENERATED_3
 WHERE ([RowNum] >= @_minrow)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumber.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumber.approved.txt
@@ -1,3 +1,3 @@
 SELECT ROW_NUMBER() OVER (ORDER BY [Id]) AS ROWNUM
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [ROWNUM]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithOrderBy.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithOrderBy.approved.txt
@@ -1,3 +1,3 @@
 SELECT ROW_NUMBER() OVER (ORDER BY [Foo]) AS ROWNUM
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionBy.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionBy.approved.txt
@@ -1,3 +1,3 @@
 SELECT ROW_NUMBER() OVER (PARTITION BY [Region], [Area] ORDER BY [Foo]) AS ROWNUM
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 ORDER BY [Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionByInJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionByInJoin.approved.txt
@@ -1,5 +1,5 @@
 SELECT ROW_NUMBER() OVER (PARTITION BY ALIAS_Orders_2.[Region], ALIAS_Orders_2.[Area] ORDER BY ALIAS_Orders_2.[Foo]) AS ROWNUM
-FROM dbo.[Orders] ALIAS_Orders_2
-INNER JOIN dbo.[Account] ALIAS_Account_1
+FROM [dbo].[Orders] ALIAS_Orders_2
+INNER JOIN [dbo].[Account] ALIAS_Account_1
 ON ALIAS_Orders_2.[AccountId] = ALIAS_Account_1.[Id]
 ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionByInJoinWithCustomAliases.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateRowNumberWithPartitionByInJoinWithCustomAliases.approved.txt
@@ -1,5 +1,5 @@
 SELECT ROW_NUMBER() OVER (PARTITION BY ACC.[Region], ACC.[Area] ORDER BY ORD.[Foo]) AS ROWNUM
-FROM dbo.[Orders] ORD
-INNER JOIN dbo.[Account] ACC
+FROM [dbo].[Orders] ORD
+INNER JOIN [dbo].[Account] ACC
 ON ORD.[AccountId] = ACC.[Id]
 ORDER BY ORD.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForChainedJoins.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForChainedJoins.approved.txt
@@ -1,8 +1,8 @@
 SELECT Orders.*
-FROM dbo.[Orders] Orders
-INNER JOIN dbo.[Customers] Customers
+FROM [dbo].[Orders] Orders
+INNER JOIN [dbo].[Customers] Customers
 ON Orders.[CustomerId] = Customers.[Id]
-INNER JOIN dbo.[Accounts] Accounts
+INNER JOIN [dbo].[Accounts] Accounts
 ON Customers.[Id] = Accounts.[CustomerId]
 AND Orders.[AccountId] = Accounts.[Id]
 ORDER BY Orders.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForComplicatedSubqueryJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForComplicatedSubqueryJoin.approved.txt
@@ -1,8 +1,8 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
+FROM [dbo].[Orders] ALIAS_Orders_2
 INNER JOIN (
     SELECT *
-    FROM dbo.[Customers]
+    FROM [dbo].[Customers]
     WHERE (IsActive = 1)
     ORDER BY [Created]
 ) ALIAS_GENERATED_1
@@ -10,7 +10,7 @@ ON ALIAS_Orders_2.[CustomerId] = ALIAS_GENERATED_1.[Id]
 AND ALIAS_Orders_2.[Owner] = ALIAS_GENERATED_1.[Owner]
 INNER JOIN (
     SELECT *
-    FROM dbo.[Accounts] WITH (UPDLOCK)
+    FROM [dbo].[Accounts] WITH (UPDLOCK)
 ) ALIAS_GENERATED_3
 ON ALIAS_Orders_2.[AccountId] = ALIAS_GENERATED_3.[Id]
 ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForJoin.approved.txt
@@ -1,9 +1,9 @@
 SELECT ALIAS_GENERATED_2.*
 FROM (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Price] > 5)
 ) ALIAS_GENERATED_2
-INNER JOIN dbo.[Customers] ALIAS_Customers_1
+INNER JOIN [dbo].[Customers] ALIAS_Customers_1
 ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]
 ORDER BY ALIAS_GENERATED_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForJoinWithSchemaName.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForJoinWithSchemaName.approved.txt
@@ -1,0 +1,9 @@
+SELECT ALIAS_GENERATED_2.*
+FROM (
+    SELECT *
+    FROM [schema1].[Orders]
+    WHERE ([Price] > 5)
+) ALIAS_GENERATED_2
+INNER JOIN [schema2].[Customers] ALIAS_Customers_1
+ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]
+ORDER BY ALIAS_GENERATED_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoins.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoins.approved.txt
@@ -1,7 +1,7 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
-INNER JOIN dbo.[Customers] ALIAS_Customers_1
+FROM [dbo].[Orders] ALIAS_Orders_2
+INNER JOIN [dbo].[Customers] ALIAS_Customers_1
 ON ALIAS_Orders_2.[CustomerId] = ALIAS_Customers_1.[Id]
-INNER JOIN dbo.[Accounts] ALIAS_Accounts_3
+INNER JOIN [dbo].[Accounts] ALIAS_Accounts_3
 ON ALIAS_Orders_2.[AccountId] = ALIAS_Accounts_3.[Id]
 ORDER BY ALIAS_Orders_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoinsWithParameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSelectForMultipleJoinsWithParameter.approved.txt
@@ -1,18 +1,18 @@
 SELECT ALIAS_GENERATED_2.*
 FROM (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([CustomerId] = @customerid)
 ) ALIAS_GENERATED_2
 INNER JOIN (
     SELECT *
-    FROM dbo.[Customers]
+    FROM [dbo].[Customers]
     WHERE ([Name] = @name)
 ) ALIAS_GENERATED_1
 ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_GENERATED_1.[Id]
 INNER JOIN (
     SELECT *
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
     WHERE ([Name] = @name_1)
 ) ALIAS_GENERATED_3
 ON ALIAS_GENERATED_2.[AccountId] = ALIAS_GENERATED_3.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateStoredProcWithDefaultValues.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateStoredProcWithDefaultValues.approved.txt
@@ -1,11 +1,11 @@
-CREATE PROCEDURE dbo.[PackagesMatchingId]
+CREATE PROCEDURE [dbo].[PackagesMatchingId]
 (
     @packageid NVARCHAR(250) = ''
 )
 AS
 BEGIN (
     SELECT *
-    FROM dbo.[NuGetPackages]
+    FROM [dbo].[NuGetPackages]
     WHERE ((@packageid is '') or (PackageId = @packageid))
     ORDER BY [Id]
 )

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSubqueryWhenThereAreNoCustomizations.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateSubqueryWhenThereAreNoCustomizations.approved.txt
@@ -1,5 +1,5 @@
 SELECT *
 FROM (
     SELECT *
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
 ) ALIAS_GENERATED_1

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateTopForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateTopForJoin.approved.txt
@@ -1,9 +1,9 @@
 SELECT TOP 100 ALIAS_GENERATED_2.*
 FROM (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Price] > 5)
 ) ALIAS_GENERATED_2
-INNER JOIN dbo.[Customers] ALIAS_Customers_1
+INNER JOIN [dbo].[Customers] ALIAS_Customers_1
 ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]
 ORDER BY ALIAS_GENERATED_2.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateUnion.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateUnion.approved.txt
@@ -1,9 +1,9 @@
 SELECT *
 FROM (
     SELECT [Id] AS [Id]
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     UNION
     SELECT [Id] AS [Id]
-    FROM dbo.[Account]
+    FROM [dbo].[Account]
 ) ALIAS_GENERATED_1
 ORDER BY ALIAS_GENERATED_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsSubQueryWithPrameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsSubQueryWithPrameter.approved.txt
@@ -1,14 +1,14 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
+FROM [dbo].[Orders] ALIAS_Orders_2
 LEFT HASH JOIN (
     SELECT *
-    FROM dbo.[Account]
+    FROM [dbo].[Account]
     WHERE ([Name] = @name)
 ) ALIAS_GENERATED_1
 ON ALIAS_Orders_2.[AccountId] = ALIAS_GENERATED_1.[Id]
 LEFT HASH JOIN (
     SELECT *
-    FROM dbo.[Company]
+    FROM [dbo].[Company]
     WHERE ([Name] = @name_1)
 ) ALIAS_GENERATED_3
 ON ALIAS_Orders_2.[CompanyId] = ALIAS_GENERATED_3.[CompanyId]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsWithTableAndSubQueryWithPrameter.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateWithMultipleLeftHashJoinsWithTableAndSubQueryWithPrameter.approved.txt
@@ -1,10 +1,10 @@
 SELECT ALIAS_Orders_2.*
-FROM dbo.[Orders] ALIAS_Orders_2
-LEFT HASH JOIN dbo.[Account] ALIAS_Account_1
+FROM [dbo].[Orders] ALIAS_Orders_2
+LEFT HASH JOIN [dbo].[Account] ALIAS_Account_1
 ON ALIAS_Orders_2.[AccountId] = ALIAS_Account_1.[Id]
 LEFT HASH JOIN (
     SELECT *
-    FROM dbo.[Company]
+    FROM [dbo].[Company]
     WHERE ([Name] = @name)
 ) ALIAS_GENERATED_3
 ON ALIAS_Orders_2.[CompanyId] = ALIAS_GENERATED_3.[CompanyId]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -24,9 +24,9 @@ namespace Nevermore.Tests.QueryBuilderFixture
             transaction.ClearReceivedCalls();
         }
         
-        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName) where TDocument : class
+        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo") where TDocument : class
         {
-            return new TableSourceQueryBuilder<TDocument>(tableName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
         
         [Test]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -38,7 +38,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
                 .DebugViewRawQuery();
 
             const string expected = @"SELECT *
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 WHERE ([Price] > 5)
 ORDER BY [Name]";
 
@@ -53,7 +53,7 @@ ORDER BY [Name]";
                 .DebugViewRawQuery();
 
             const string expected = @"SELECT *
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 WHERE ([Price] > 5)
 ORDER BY [Id]";
 
@@ -68,7 +68,7 @@ ORDER BY [Id]";
              .DebugViewRawQuery();
 
             const string expected = @"SELECT *
-FROM dbo.[Orders]
+FROM [dbo].[Orders]
 WHERE ([Price] > 5)
 ORDER BY [Id]";
 
@@ -170,7 +170,7 @@ ORDER BY [Id]";
                 .Count();
 
             var expected = @"SELECT COUNT(*)
-FROM dbo.[Orders]";
+FROM [dbo].[Orders]";
 
             actual.Should().Be(expected);
         }
@@ -187,7 +187,7 @@ FROM dbo.[Orders]";
                 .Count();
 
             var expected = @"SELECT COUNT(*)
-FROM dbo.[Orders] NOLOCK
+FROM [dbo].[Orders] NOLOCK
 WHERE ([Price] > 5)";
 
             actual.Should().Be(expected);
@@ -205,7 +205,7 @@ WHERE ([Price] > 5)";
                 .Count();
 
             const string expected = @"SELECT COUNT(*)
-FROM dbo.[Orders] NOLOCK
+FROM [dbo].[Orders] NOLOCK
 WHERE ([Price] > 5)";
 
             actual.Should().Be(expected);
@@ -268,7 +268,7 @@ WHERE ([Price] > 5)";
                 .Take(100);
 
             var expected = @"SELECT TOP 100 *
-FROM dbo.[Orders] NOLOCK
+FROM [dbo].[Orders] NOLOCK
 WHERE ([Price] > 5)
 ORDER BY [Id]";
 
@@ -336,7 +336,7 @@ ORDER BY [Id]";
         public void ShouldGetCorrectSqlQueryForAnyWithResults()
         {
             const string expectedSql = @"IF EXISTS(SELECT *
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] < @completed))
     SELECT @true
 ELSE
@@ -365,7 +365,7 @@ ELSE
         public void ShouldGetCorrectSqlQueryForAnyWithNoResults()
         {
             const string expectedSql = @"IF EXISTS(SELECT *
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] < @completed))
     SELECT @true
 ELSE
@@ -394,7 +394,7 @@ ELSE
         public void ShouldGetCorrectSqlQueryForAnyIgnoreOrderBy()
         {
             const string expectedSql = @"IF EXISTS(SELECT *
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] < @completed))
     SELECT @true
 ELSE
@@ -424,7 +424,7 @@ ELSE
         public void ShouldGetCorrectSqlQueryForWhereLessThan()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] < @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -446,7 +446,7 @@ WHERE ([Completed] < @completed)";
         public void ShouldGetCorrectSqlQueryForWhereLessThanExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] < @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -467,7 +467,7 @@ WHERE ([Completed] < @completed)";
         public void ShouldGetCorrectSqlQueryForWhereLessThanOrEqual()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] <= @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -489,7 +489,7 @@ WHERE ([Completed] <= @completed)";
         public void ShouldGetCorrectSqlQueryForWhereLessThanOrEqualExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] <= @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -510,7 +510,7 @@ WHERE ([Completed] <= @completed)";
         public void ShouldGetCorrectSqlQueryForWhereEquals()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] = @title)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -532,7 +532,7 @@ WHERE ([Title] = @title)";
         public void ShouldGetCorrectSqlQueryForWhereEqualsExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] = @title)";
             
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -553,7 +553,7 @@ WHERE ([Title] = @title)";
         public void ShouldGetCorrectSqlQueryForWhereNotEquals()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] <> @title)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -575,7 +575,7 @@ WHERE ([Title] <> @title)";
         public void ShouldGetCorrectSqlQueryForWhereNotEqualsExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] <> @title)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -596,7 +596,7 @@ WHERE ([Title] <> @title)";
         public void ShouldGetCorrectSqlQueryForWhereGreaterThan()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] > @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -618,7 +618,7 @@ WHERE ([Completed] > @completed)";
         public void ShouldGetCorrectSqlQueryForWhereGreaterThanExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] > @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -639,7 +639,7 @@ WHERE ([Completed] > @completed)";
         public void ShouldGetCorrectSqlQueryForWhereGreaterThanOrEqual()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] >= @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -661,7 +661,7 @@ WHERE ([Completed] >= @completed)";
         public void ShouldGetCorrectSqlQueryForWhereGreaterThanOrEqualExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] >= @completed)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -682,7 +682,7 @@ WHERE ([Completed] >= @completed)";
         public void ShouldGetCorrectSqlQueryForWhereContains()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] LIKE @title)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -704,7 +704,7 @@ WHERE ([Title] LIKE @title)";
         public void ShouldGetCorrectSqlQueryForWhereContainsExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] LIKE @title)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -725,7 +725,7 @@ WHERE ([Title] LIKE @title)";
         public void ShouldGetCorrectSqlQueryForWhereInUsingWhereString()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] IN (@nevermore, @octofront))";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -750,7 +750,7 @@ WHERE ([Title] IN (@nevermore, @octofront))";
         public void ShouldGetCorrectSqlQueryForWhereInUsingWhereArray()
         {
             const string expectedSql = @"SELECT *
-FROM dbo.[Project]
+FROM [dbo].[Project]
 WHERE ([State] IN (@state1, @state2))
 ORDER BY [Id]";
 
@@ -769,7 +769,7 @@ ORDER BY [Id]";
                 State.Running
             };
             const string expectedSql = @"SELECT *
-FROM dbo.[Project]
+FROM [dbo].[Project]
 WHERE ([State] IN (@state1, @state2))
 ORDER BY [Id]";
             var queryBuilder = CreateQueryBuilder<object>("Project")
@@ -782,7 +782,7 @@ ORDER BY [Id]";
         public void ShouldGetCorrectSqlQueryForWhereInUsingEmptyList()
         {
             const string expextedSql = @"SELECT *
-FROM dbo.[Project]
+FROM [dbo].[Project]
 WHERE (0 = 1)
 ORDER BY [Id]";
 
@@ -797,7 +797,7 @@ ORDER BY [Id]";
         public void ShouldGetCorrectSqlQueryForWhereInExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 WHERE ([Title] IN (@title1, @title2))";
 
 
@@ -821,7 +821,7 @@ WHERE ([Title] IN (@title1, @title2))";
         public void ShouldGetCorrectSqlQueryForWhereBetween()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] BETWEEN @startvalue AND @endvalue)";
 
 
@@ -849,7 +849,7 @@ WHERE ([Completed] BETWEEN @startvalue AND @endvalue)";
         public void ShouldGetCorrectSqlQueryForWhereBetweenExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] BETWEEN @startvalue AND @endvalue)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -872,7 +872,7 @@ WHERE ([Completed] BETWEEN @startvalue AND @endvalue)";
         public void ShouldGetCorrectSqlQueryForWhereBetweenOrEqual()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] >= @startvalue AND [Completed] <= @endvalue)";
 
             transaction.ExecuteScalar<int>(Arg.Is<string>(s => s.Equals(expectedSql)), Arg.Any<CommandParameterValues>())
@@ -899,7 +899,7 @@ WHERE ([Completed] >= @startvalue AND [Completed] <= @endvalue)";
         public void ShouldGetCorrectSqlQueryForWhereBetweenOrEqualExtension()
         {
             const string expectedSql = @"SELECT COUNT(*)
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([Completed] >= @startvalue)
 AND ([Completed] <= @endvalue)";
 
@@ -923,7 +923,7 @@ AND ([Completed] <= @endvalue)";
         public void ShouldGetCorrectSqlQueryForOrderBy()
         {
             const string expectedSql = @"SELECT TOP 1 *
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 ORDER BY [Title]";
             var todoItem = new TodoItem { Id = 1, Title = "Complete Nevermore", Completed = false };
 
@@ -946,7 +946,7 @@ ORDER BY [Title]";
         public void ShouldGetCorrectSqlQueryForOrderByDescending()
         {
             const string expectedSql = @"SELECT TOP 1 *
-FROM dbo.[TodoItem]
+FROM [dbo].[TodoItem]
 ORDER BY [Title] DESC";
             var todoItem = new TodoItem { Id = 1, Title = "Complete Nevermore", Completed = false };
 
@@ -1516,7 +1516,7 @@ ORDER BY [Title] DESC";
 FROM (
     SELECT *,
     ROW_NUMBER() OVER (ORDER BY [Id]) AS RowNum
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Id] = @id)
 ) ALIAS_GENERATED_1
 WHERE ([RowNum] >= @_minrow)
@@ -1546,7 +1546,7 @@ ORDER BY [RowNum]");
             query.FirstOrDefault();
 
             const string expected = @"SELECT TOP 1 *
-FROM dbo.[Todos]
+FROM [dbo].[Todos]
 WHERE ([AddedDate] > @addeddate)
 AND ([AddedDate] < @addeddate_1)
 ORDER BY [Id]";
@@ -1585,12 +1585,12 @@ ORDER BY [Id]";
                 @"SELECT TOP 1 ALIAS_GENERATED_2.*
 FROM (
     SELECT *
-    FROM dbo.[Customer]
+    FROM [dbo].[Customer]
     WHERE ([Date] = @date_1)
 ) ALIAS_GENERATED_2
 INNER JOIN (
     SELECT *
-    FROM dbo.[Orders]
+    FROM [dbo].[Orders]
     WHERE ([Date] = @date)
 ) ALIAS_GENERATED_1
 ON ALIAS_GENERATED_2.[Id] = ALIAS_GENERATED_1.[CustomerId]
@@ -1637,7 +1637,7 @@ ORDER BY ALIAS_GENERATED_2.[Id]";
                 .ToList();
 
             const string expected = @"SELECT *
-FROM dbo.[Customers]
+FROM [dbo].[Customers]
 WHERE ([Name] <> @name)
 AND ([Name] <> @name_1)
 ORDER BY [Id]";

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -46,6 +46,22 @@ ORDER BY [Name]";
         }
 
         [Test]
+        public void ShouldGenerateSelectWithSchemaName()
+        {
+            var actual = CreateQueryBuilder<object>("Orders", "schema")
+                .Where("[Price] > 5")
+                .OrderBy("Name")
+                .DebugViewRawQuery();
+
+            const string expected = @"SELECT *
+FROM [schema].[Orders]
+WHERE ([Price] > 5)
+ORDER BY [Name]";
+
+            actual.Should().Be(expected);
+        }
+
+        [Test]
         public void ShouldGenerateSelectNoOrder()
         {
             var actual = CreateQueryBuilder<object>("Orders")
@@ -81,6 +97,21 @@ ORDER BY [Id]";
             var leftQueryBuilder = CreateQueryBuilder<object>("Orders")
                 .Where("[Price] > 5");
             var rightQueryBuilder = CreateQueryBuilder<object>("Customers");
+
+            var actual = leftQueryBuilder
+                .InnerJoin(rightQueryBuilder)
+                .On("CustomerId", JoinOperand.Equal, "Id")
+                .DebugViewRawQuery();
+
+            this.Assent(actual);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectForJoinWithSchemaName()
+        {
+            var leftQueryBuilder = CreateQueryBuilder<object>("Orders", "schema1")
+                .Where("[Price] > 5");
+            var rightQueryBuilder = CreateQueryBuilder<object>("Customers", "schema2");
 
             var actual = leftQueryBuilder
                 .InnerJoin(rightQueryBuilder)

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -236,7 +236,7 @@ ORDER BY [Id]");
 
         ITableSourceQueryBuilder<object> TableQueryBuilder(string tableName)
         {
-            return new TableSourceQueryBuilder<object>(tableName, transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(tableName, "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -35,12 +35,12 @@ namespace Nevermore.Tests.QueryBuilderFixture
             queryBuilder.Count();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT COUNT(*)
-FROM dbo.[Accounts]");
+FROM [dbo].[Accounts]");
 
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -52,7 +52,7 @@ ORDER BY [Id]");
             queryBuilder.Any();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"IF EXISTS(SELECT *
-FROM dbo.[Accounts])
+FROM [dbo].[Accounts])
     SELECT @true
 ELSE
     SELECT @false");
@@ -60,7 +60,7 @@ ELSE
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -72,13 +72,13 @@ ORDER BY [Id]");
             queryBuilder.Take(1);
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
 
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -90,13 +90,13 @@ ORDER BY [Id]");
             queryBuilder.FirstOrDefault();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
 
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -111,7 +111,7 @@ ORDER BY [Id]");
 FROM (
     SELECT *,
     ROW_NUMBER() OVER (ORDER BY [Id]) AS RowNum
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
 ) ALIAS_GENERATED_1
 WHERE ([RowNum] >= @_minrow)
 AND ([RowNum] <= @_maxrow)
@@ -121,7 +121,7 @@ ORDER BY [RowNum]");
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -134,13 +134,13 @@ ORDER BY [Id]");
 
             executedQueries.Count.ShouldBeEquivalentTo(2);
             executedQueries.First().ShouldBeEquivalentTo(@"SELECT COUNT(*)
-FROM dbo.[Accounts]");
+FROM [dbo].[Accounts]");
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
 FROM (
     SELECT *,
     ROW_NUMBER() OVER (ORDER BY [Id]) AS RowNum
-    FROM dbo.[Accounts]
+    FROM [dbo].[Accounts]
 ) ALIAS_GENERATED_1
 WHERE ([RowNum] >= @_minrow)
 AND ([RowNum] <= @_maxrow)
@@ -151,7 +151,7 @@ ORDER BY [RowNum]");
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -163,13 +163,13 @@ ORDER BY [Id]");
             queryBuilder.ToList();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
 
             queryBuilder.Take(1);
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -181,13 +181,13 @@ ORDER BY [Id]");
             queryBuilder.Stream();
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
 
             queryBuilder.Take(1);
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 
@@ -199,13 +199,13 @@ ORDER BY [Id]");
             queryBuilder.ToDictionary(d => d.GetHashCode().ToString());
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
 
             queryBuilder.Take(1);
 
             LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT TOP 1 *
-FROM dbo.[Accounts]
+FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
 

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -28,7 +28,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
         IQueryBuilder<object> CreateQueryBuilder()
         {
-            return new TableSourceQueryBuilder<object>("Order", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>("Order", "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocument.approved.txt
@@ -1,3 +1,3 @@
-DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [dbo].[TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithManyRelatedTables.approved.txt
@@ -1,4 +1,4 @@
-DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [dbo].[TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
 DELETE FROM [RelatedDocument] WITH (ROWLOCK) WHERE [Id] = @Id
 DELETE FROM [OtherRelatedTable] WITH (ROWLOCK) WHERE [Id] = @Id
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByDocumentWithOneRelatedTable.approved.txt
@@ -1,4 +1,4 @@
-DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [dbo].[TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
 DELETE FROM [RelatedDocument] WITH (ROWLOCK) WHERE [Id] = @Id
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteById.approved.txt
@@ -1,3 +1,3 @@
-DELETE FROM [TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
+DELETE FROM [dbo].[TestDocumentTbl] WITH (ROWLOCK) WHERE [Id] = @Id
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByWhere.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByWhere.approved.txt
@@ -1,2 +1,2 @@
-DELETE FROM [TestDocumentTbl] 
+DELETE FROM [dbo].[TestDocumentTbl] 
 WHERE [Foo] > @1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@0__Id, @0__AColumn, @0__JSON)
 ,(@1__Id, @1__AColumn, @1__JSON)
 ,(@2__Id, @2__AColumn, @2__JSON)

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@0__Id, @0__AColumn, @0__JSON)
 ,(@1__Id, @1__AColumn, @1__JSON)
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=SuppliedId

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithSuppliedId.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithSuppliedId.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocument]  (AColumn, Id, JSON) VALUES 
+INSERT INTO [dbo].[TestDocument]  (AColumn, Id, JSON) VALUES 
 (@AColumn, @Id, @JSON)
 
 @Id=SuppliedId

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO dbo.[TestDocumentTbl]  ([AColumn]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn]) VALUES 
 (@AColumn)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithManyRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DECLARE @references as TABLE (Reference nvarchar(400), ReferenceTable nvarchar(400))
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithNoRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DELETE FROM [RelatedDocument] WHERE [Id] = @Id
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithOneRelatedDocument.approved.txt
@@ -1,4 +1,4 @@
-UPDATE dbo.[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
 
 DECLARE @references as TABLE (Reference nvarchar(400), ReferenceTable nvarchar(400))
 

--- a/source/Nevermore/Advanced/NevermoreDefaults.cs
+++ b/source/Nevermore/Advanced/NevermoreDefaults.cs
@@ -16,5 +16,7 @@ namespace Nevermore.Advanced
         public const int DefaultKeyBlockSize = 20;
 
         public const int LargeDocumentCutoffSize = 1024;
+
+        public const string DefaultSchemaName = "dbo";
     }
 }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -160,7 +160,8 @@ namespace Nevermore.Advanced
 
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
-            return new TableSourceQueryBuilder<TRecord>(configuration.DocumentMaps.Resolve(typeof(TRecord)).TableName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, map.SchemaName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class
@@ -328,7 +329,7 @@ namespace Nevermore.Advanced
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
             var tableName = mapping.TableName;
             var args = new CommandParameterValues {{"Id", id}};
-            return new PreparedCommand($"SELECT TOP 1 * FROM dbo.[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
+            return new PreparedCommand($"SELECT TOP 1 * FROM [{mapping.SchemaName}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 
         PreparedCommand PrepareLoadMany<TDocument>(IEnumerable<string> idList)
@@ -338,7 +339,7 @@ namespace Nevermore.Advanced
             
             var param = new CommandParameterValues();
             param.AddTable("criteriaTable", idList);
-            var statement = $"SELECT s.* FROM dbo.[{tableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
+            var statement = $"SELECT s.* FROM [{mapping.SchemaName}].[{tableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }
         

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -196,8 +196,10 @@ namespace Nevermore.Advanced
     {
         string tableOrViewName;
         string alias;
+        string schemaName;
 
         public TableSourceQueryBuilder(string tableOrViewName,
+            string schemaName,
             IReadTransaction readQueryExecutor,
             ITableAliasGenerator tableAliasGenerator,
             IUniqueParameterNameGenerator uniqueParameterNameGenerator,
@@ -206,6 +208,7 @@ namespace Nevermore.Advanced
             ParameterDefaults parameterDefaults)
             : base(readQueryExecutor, tableAliasGenerator, uniqueParameterNameGenerator, parameterValues, parameters, parameterDefaults)
         {
+            this.schemaName = schemaName;
             this.tableOrViewName = tableOrViewName;
         }
 
@@ -260,14 +263,14 @@ namespace Nevermore.Advanced
         {
             if (alias == null)
             {
-                return new SimpleTableSource(tableOrViewName);
+                return new SimpleTableSource(tableOrViewName, schemaName);
             }
-            return new AliasedTableSource(new SimpleTableSource(tableOrViewName), alias);
+            return new AliasedTableSource(new SimpleTableSource(tableOrViewName, schemaName), alias);
         }
 
         AliasedTableSource CreateAliasedTableSource()
         {
-            return new AliasedTableSource(new SimpleTableSource(tableOrViewName), alias ?? TableAliasGenerator.GenerateTableAlias(tableOrViewName));
+            return new AliasedTableSource(new SimpleTableSource(tableOrViewName, schemaName), alias ?? TableAliasGenerator.GenerateTableAlias(tableOrViewName));
         }
     }
 

--- a/source/Nevermore/CommandOptions.cs
+++ b/source/Nevermore/CommandOptions.cs
@@ -17,7 +17,13 @@ namespace Nevermore
         /// mapping for the type.
         /// </summary>
         public string TableName { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the schema of the table that the query will use. If null, defaults to the schema configured in the
+        /// mapping for the type.
+        /// </summary>
+        public string SchemaName { get; set; }
+
         /// <summary>
         /// Any hints to add when referencing the table.
         /// </summary>

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reflection;
+using Nevermore.Advanced;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.Advanced.PropertyHandlers;
 
@@ -255,7 +256,7 @@ namespace Nevermore.Mapping
             {
                 Type = typeof(TDocument),
                 IdColumn = GetDefaultIdColumn(),
-                SchemaName = "dbo",
+                SchemaName = NevermoreDefaults.DefaultSchemaName,
                 TableName = typeof(TDocument).Name,
                 IdPrefix = typeof(TDocument).Name + "s",
                 JsonStorageFormat = JsonStorageFormat.TextOnly

--- a/source/Nevermore/QueryBuilderExtensions.cs
+++ b/source/Nevermore/QueryBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Nevermore.Advanced;
 using Nevermore.Querying.AST;
 
 namespace Nevermore
@@ -10,10 +11,11 @@ namespace Nevermore
         /// <typeparam name="TRecord">The record type of the query builder</typeparam>
         /// <param name="queryBuilder">The query builder</param>
         /// <param name="storedProcedureName">The name of the stored procedure</param>
+        /// <param name="schemaName">The schema name of the stored procedure</param>
         /// <returns>A plain SQL string representing a create stored procedure query</returns>
-        public static string AsStoredProcedure<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string storedProcedureName) where TRecord : class
+        public static string AsStoredProcedure<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string storedProcedureName, string schemaName = NevermoreDefaults.DefaultSchemaName) where TRecord : class
         {
-            return new StoredProcedure(queryBuilder.GetSelectBuilder().GenerateSelect(), queryBuilder.Parameters, queryBuilder.ParameterDefaults, storedProcedureName).GenerateSql();
+            return new StoredProcedure(queryBuilder.GetSelectBuilder().GenerateSelect(), queryBuilder.Parameters, queryBuilder.ParameterDefaults, storedProcedureName, schemaName).GenerateSql();
         }
 
         /// <summary>
@@ -22,10 +24,11 @@ namespace Nevermore
         /// <typeparam name="TRecord">The record type of the query builder</typeparam>
         /// <param name="queryBuilder">The query builder</param>
         /// <param name="viewName">The name of the view</param>
+        /// <param name="schemaName">The schema name of the view</param>
         /// <returns>A plain SQL string representing a create view query</returns>
-        public static string AsView<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string viewName) where TRecord : class
+        public static string AsView<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string viewName, string schemaName = NevermoreDefaults.DefaultSchemaName) where TRecord : class
         {
-            return new View(queryBuilder.GetSelectBuilder().GenerateSelect(), viewName).GenerateSql();
+            return new View(queryBuilder.GetSelectBuilder().GenerateSelect(), viewName, schemaName).GenerateSql();
         }
 
         /// <summary>
@@ -34,10 +37,11 @@ namespace Nevermore
         /// <typeparam name="TRecord">The record type of the query builder</typeparam>
         /// <param name="queryBuilder">The query builder</param>
         /// <param name="functionName">The name of the function</param>
+        /// <param name="schemaName">The schema name of the function</param>
         /// <returns>A plain SQL string representing a create function query</returns>
-        public static string AsFunction<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string functionName) where TRecord : class
+        public static string AsFunction<TRecord>(this IQueryBuilder<TRecord> queryBuilder, string functionName, string schemaName = NevermoreDefaults.DefaultSchemaName) where TRecord : class
         {
-            return new Function(queryBuilder.GetSelectBuilder().GenerateSelect(), queryBuilder.Parameters, queryBuilder.ParameterDefaults, functionName).GenerateSql();
+            return new Function(queryBuilder.GetSelectBuilder().GenerateSelect(), queryBuilder.Parameters, queryBuilder.ParameterDefaults, functionName, schemaName).GenerateSql();
         }
     }
 }

--- a/source/Nevermore/Querying/AST/Function.cs
+++ b/source/Nevermore/Querying/AST/Function.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nevermore.Advanced;
+using System;
 using System.Linq;
 
 namespace Nevermore.Querying.AST
@@ -9,8 +10,9 @@ namespace Nevermore.Querying.AST
         readonly Parameters parameters;
         readonly ParameterDefaults defaults;
         readonly string functionName;
+        readonly string schemaName;
 
-        public Function(ISelect @select, Parameters parameters, ParameterDefaults defaults, string functionName)
+        public Function(ISelect @select, Parameters parameters, ParameterDefaults defaults, string functionName, string schemaName = NevermoreDefaults.DefaultSchemaName)
         {
             if (parameters.Any(p => p.DataType == null))
             {
@@ -21,11 +23,12 @@ namespace Nevermore.Querying.AST
             this.parameters = parameters;
             this.defaults = defaults;
             this.functionName = functionName;
+            this.schemaName = schemaName;
         }
 
         public string GenerateSql()
         {
-            return $@"CREATE FUNCTION dbo.[{functionName}]
+            return $@"CREATE FUNCTION [{schemaName}].[{functionName}]
 (
 {Format.IndentLines(string.Join("\r\n", parameters.Select(ParameterSql)))}
 )

--- a/source/Nevermore/Querying/AST/ITableSource.cs
+++ b/source/Nevermore/Querying/AST/ITableSource.cs
@@ -1,4 +1,6 @@
-﻿namespace Nevermore.Querying.AST
+﻿using Nevermore.Advanced;
+
+namespace Nevermore.Querying.AST
 {
     public interface ITableSource : ISelectSource
     {
@@ -11,13 +13,15 @@
     public class SimpleTableSource : ISimpleTableSource
     {
         readonly string tableOrViewName;
+        readonly string schemaName;
 
-        public SimpleTableSource(string tableOrViewName)
+        public SimpleTableSource(string tableOrViewName, string schemaName = NevermoreDefaults.DefaultSchemaName)
         {
             this.tableOrViewName = tableOrViewName;
+            this.schemaName = schemaName;
         }
 
-        public string GenerateSql() => $"dbo.[{tableOrViewName}]";
+        public string GenerateSql() => $"[{schemaName}].[{tableOrViewName}]";
         public override string ToString() => GenerateSql();
     }
 

--- a/source/Nevermore/Querying/AST/StoredProcedure.cs
+++ b/source/Nevermore/Querying/AST/StoredProcedure.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nevermore.Advanced;
+using System;
 using System.Linq;
 
 namespace Nevermore.Querying.AST
@@ -9,8 +10,9 @@ namespace Nevermore.Querying.AST
         readonly Parameters parameters;
         readonly ParameterDefaults defaults;
         readonly string procedureName;
+        readonly string schemaName;
 
-        public StoredProcedure(ISelect select, Parameters parameters, ParameterDefaults defaults, string procedureName)
+        public StoredProcedure(ISelect select, Parameters parameters, ParameterDefaults defaults, string procedureName, string schemaName = NevermoreDefaults.DefaultSchemaName)
         {
             if (parameters.Any(p => p.DataType == null))
             {
@@ -21,11 +23,12 @@ namespace Nevermore.Querying.AST
             this.parameters = parameters;
             this.defaults = defaults;
             this.procedureName = procedureName;
+            this.schemaName = schemaName;
         }
 
         public string GenerateSql()
         {
-            return $@"CREATE PROCEDURE dbo.[{procedureName}]
+            return $@"CREATE PROCEDURE [{schemaName}].[{procedureName}]
 (
 {Format.IndentLines(string.Join("\r\n", parameters.Select(ParameterSql)))}
 )

--- a/source/Nevermore/Querying/AST/View.cs
+++ b/source/Nevermore/Querying/AST/View.cs
@@ -1,19 +1,23 @@
-﻿namespace Nevermore.Querying.AST
+﻿using Nevermore.Advanced;
+
+namespace Nevermore.Querying.AST
 {
     public class View
     {
         readonly ISelect select;
         readonly string viewName;
+        readonly string schemaName;
 
-        public View(ISelect select, string viewName)
+        public View(ISelect select, string viewName, string schemaName = NevermoreDefaults.DefaultSchemaName)
         {
             this.select = @select;
             this.viewName = viewName;
+            this.schemaName = schemaName;
         }
 
         public string GenerateSql()
         {
-            return $@"CREATE VIEW dbo.[{viewName}] AS
+            return $@"CREATE VIEW [{schemaName}].[{viewName}] AS
 {Format.IndentLines(select.GenerateSql())}";
         }
     }


### PR DESCRIPTION
Adds support for the schema name which can be configured on DocumentMap.

Please have a look if this conforms with your ideas, or if something is missing, like more tests or such.
I didn't quite grasp how the related document mappings work (as I haven't used the library much yet). If you can give me a hint how it works, I could add the schema name there as well.