### PR TITLE
Fix default schema usage on configuration

### DIFF
--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -19,7 +19,7 @@ namespace Nevermore.IntegrationTests.SetUp
             var config = new RelationalStoreConfiguration(ConnectionString);
             config.CommandFactory = new ChaosSqlCommandFactory(new SqlCommandFactory());
             config.ApplicationName = "Nevermore-IntegrationTests";
-            config.DocumentMaps = new DocumentMapRegistry("TestSchema");
+            config.DefaultSchema = "TestSchema";
             config.DocumentMaps.Register(
                 new CustomerMap(),
                 new BrandMap(),

--- a/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
@@ -39,9 +39,11 @@ namespace Nevermore.Tests.Delete
 
         IDeleteQueryBuilder<TDocument> CreateQueryBuilder<TDocument>() where TDocument : class
         {
+            var configuration = new RelationalStoreConfiguration("a") { DocumentMaps = mappings };
+            configuration.DocumentSerializer = new NewtonsoftDocumentSerializer(configuration);
             return new DeleteQueryBuilder<TDocument>(
                 new UniqueParameterNameGenerator(),
-                new DataModificationQueryBuilder(mappings, new NewtonsoftDocumentSerializer(new RelationalStoreConfiguration("a") { DocumentMaps = mappings }), s => null),
+                new DataModificationQueryBuilder(configuration, s => null),
                 queryExecutor
             );
         }

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -21,15 +21,15 @@ namespace Nevermore.Tests.Util
 
         public DataModificationQueryBuilderFixture()
         {
-            var mappings = new DocumentMapRegistry("dbo");
-            mappings.Register(
+            var configuration = new RelationalStoreConfiguration("");
+            configuration.DocumentSerializer = new NewtonsoftDocumentSerializer(configuration);
+            configuration.DocumentMaps.Register(
                 new TestDocumentMap(),
                 new TestDocumentWithRelatedDocumentsMap(),
                 new TestDocumentWithMultipleRelatedDocumentsMap(),
                 new OtherMap());
             builder = new DataModificationQueryBuilder(
-                mappings,
-                new NewtonsoftDocumentSerializer(new RelationalStoreConfiguration("") { DocumentMaps = mappings}),
+                configuration,
                 m => idAllocator() 
             );
         }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -164,7 +164,7 @@ namespace Nevermore.Advanced
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
-            return new TableSourceQueryBuilder<TRecord>(map.TableName, map.SchemaName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class
@@ -332,7 +332,7 @@ namespace Nevermore.Advanced
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
             var tableName = mapping.TableName;
             var args = new CommandParameterValues {{"Id", id}};
-            return new PreparedCommand($"SELECT TOP 1 * FROM [{mapping.SchemaName}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
+            return new PreparedCommand($"SELECT TOP 1 * FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 
         PreparedCommand PrepareLoadMany<TDocument>(IEnumerable<string> idList)
@@ -342,7 +342,7 @@ namespace Nevermore.Advanced
             
             var param = new CommandParameterValues();
             param.AddTable("criteriaTable", idList);
-            var statement = $"SELECT s.* FROM [{mapping.SchemaName}].[{tableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
+            var statement = $"SELECT s.* FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }
         

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -29,7 +29,7 @@ namespace Nevermore.Advanced
         {
             this.configuration = configuration;
             this.keyAllocator = keyAllocator;
-            builder = new DataModificationQueryBuilder(configuration.DocumentMaps, configuration.DocumentSerializer, AllocateId);
+            builder = new DataModificationQueryBuilder(configuration, AllocateId);
         }
         
         public void Insert<TDocument>(TDocument instance, InsertOptions options = null) where TDocument : class

--- a/source/Nevermore/ConfigurationExtensions.cs
+++ b/source/Nevermore/ConfigurationExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using Nevermore.Advanced;
 using Nevermore.Advanced.Serialization;
+using Nevermore.Mapping;
 using Newtonsoft.Json;
 
 namespace Nevermore
@@ -15,5 +17,18 @@ namespace Nevermore
 
             callback(jsonNet.SerializerSettings);
         }
+
+        internal static string GetSchemaNameOrDefault(this IRelationalStoreConfiguration configuration, string schemaName)
+        {
+            return schemaName 
+                ?? configuration.DefaultSchema 
+                ?? NevermoreDefaults.FallbackDefaultSchemaName;
+        }
+
+        internal static string GetSchemaNameOrDefault(this IRelationalStoreConfiguration configuration, DocumentMap documentMap)
+            => GetSchemaNameOrDefault(configuration, documentMap.SchemaName);
+
+        internal static string GetSchemaNameOrDefault(this IRelationalStoreConfiguration configuration, RelatedDocumentsMapping relatedDocumentsMapping)
+            => GetSchemaNameOrDefault(configuration, relatedDocumentsMapping.SchemaName);
     }
 }

--- a/source/Nevermore/Mapping/DocumentMapRegistry.cs
+++ b/source/Nevermore/Mapping/DocumentMapRegistry.cs
@@ -9,12 +9,10 @@ namespace Nevermore.Mapping
 {
     public class DocumentMapRegistry : IDocumentMapRegistry
     {
-        readonly string defaultSchema;
         readonly ConcurrentDictionary<Type, DocumentMap> mappings = new ConcurrentDictionary<Type, DocumentMap>();
 
-        public DocumentMapRegistry(string defaultSchema)
+        public DocumentMapRegistry()
         {
-            this.defaultSchema = defaultSchema;
         }
         
         public List<DocumentMap> GetAll()
@@ -25,15 +23,6 @@ namespace Nevermore.Mapping
         public void Register(DocumentMap map)
         {
             map.Validate();
-            if (map.SchemaName == null)
-                map.SchemaName = defaultSchema;
-
-            foreach (var related in map.RelatedDocumentsMappings)
-            {
-                if (related.SchemaName == null)
-                    related.SchemaName = defaultSchema;
-            }
-            
             mappings[map.Type] = map;
         }
 

--- a/source/Nevermore/Mapping/RelatedDocumentsMapping.cs
+++ b/source/Nevermore/Mapping/RelatedDocumentsMapping.cs
@@ -16,7 +16,7 @@ namespace Nevermore.Mapping
         }
         
         public string TableName { get; }
-        public string SchemaName { get; set; }
+        public string SchemaName { get; }
         public string IdColumnName => "Id";
         public string IdTableColumnName => "Table";
         public string RelatedDocumentIdColumnName => "RelatedDocumentId";

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -29,7 +29,7 @@ namespace Nevermore
         public RelationalStoreConfiguration(Func<string> connectionStringFunc)
         {
             CommandFactory = new SqlCommandFactory();
-            DocumentMaps = new DocumentMapRegistry(NevermoreDefaults.FallbackDefaultSchemaName);
+            DocumentMaps = new DocumentMapRegistry();
             KeyBlockSize = NevermoreDefaults.DefaultKeyBlockSize;
             InstanceTypeResolvers = new InstanceTypeRegistry();
             RelatedDocumentStore = new EmptyRelatedDocumentStore();


### PR DESCRIPTION
I noticed that when simply setting the default schema name on the configuration like this, it wouldn't work.
```csharp
var config = new RelationalStoreConfiguration(ConnectionString);
config.DefaultSchema = "TestSchema";
```

That's because the configuration was propagated down from `DocumentMapRegistry`, overwriting values on map and related map.
Instead I would vote for leaving schema name on maps as they are, and evaluate actual schema name when building the queries. That way we can use the `DefaultSchema` property on the configuration, and don't need to create a new `DocumentMapRegistry` before adding mappings.