### PR TITLE
Query Logging for v12

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -86,8 +86,8 @@ Task("CopyToArtifacts")
     .IsDependentOn("Test")
     .Does(() => {
 		CreateDirectory(artifactsDir);
-		CopyFiles($"./source/**/*.nupkg", artifactsDir);
-		CopyFiles($"./source/**/*.snupkg", artifactsDir);
+		CopyFiles($"./source/**/Nevermore*.nupkg", artifactsDir);
+		CopyFiles($"./source/**/Nevermore*.snupkg", artifactsDir);
 	});
 
 Task("CopyToLocalPackages")
@@ -95,8 +95,8 @@ Task("CopyToLocalPackages")
     .WithCriteria(BuildSystem.IsLocalBuild)
     .Does(() => {
 		CreateDirectory(localPackagesDir);
-		CopyFiles($"./source/**/*.nupkg", localPackagesDir);
-		CopyFiles($"./source/**/*.snupkg", localPackagesDir);
+		CopyFiles($"{artifactsDir}*.nupkg", localPackagesDir);
+		CopyFiles($"{artifactsDir}*.snupkg", localPackagesDir);
 	});
 
 	

--- a/source/Nevermore/Diagnostics/DefaultQueryLogger.cs
+++ b/source/Nevermore/Diagnostics/DefaultQueryLogger.cs
@@ -1,0 +1,44 @@
+using Nevermore.Advanced;
+using Nevermore.Diagnositcs;
+
+namespace Nevermore.Diagnostics
+{
+    public class DefaultQueryLogger : IQueryLogger
+    {
+        static readonly ILog Log = LogProvider.For<DefaultQueryLogger>();
+
+        readonly long infoThreshold;
+
+        public DefaultQueryLogger(long infoThreshold = 300)
+        {
+            this.infoThreshold = infoThreshold;
+        }
+
+        public virtual void Insert(long duration, string transactionName, string statement)
+            => Write(duration, $"Insert took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void Update(long duration, string transactionName, string statement)
+            => Write(duration, $"Update took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void Delete(long duration, string transactionName, string statement)
+            => Write(duration, $"Delete took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void NonQuery(long duration, string transactionName, string statement)
+            => Write(duration, $"Execute non query took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void ProcessReader(long duration, string transactionName, string statement)
+            => Write(duration, $"Process reader took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void ExecuteReader(long duration, string transactionName, string statement)
+            => Write(duration, $"Execute reader took {duration}ms in transaction '{transactionName}': {statement}");
+
+        public virtual void Scalar(long duration, string transactionName, string statement)
+            => Write(duration, $"Execute scalar took {duration}ms in transaction '{transactionName}': {statement}");
+
+        void Write(long duration, string message)
+        {
+            var level = duration >= infoThreshold ? LogLevel.Info : LogLevel.Debug;
+            Log.Log(level, () => message);
+        }
+    }
+}

--- a/source/Nevermore/Diagnostics/IQueryLogger.cs
+++ b/source/Nevermore/Diagnostics/IQueryLogger.cs
@@ -1,0 +1,13 @@
+namespace Nevermore.Diagnostics
+{
+    public interface IQueryLogger
+    {
+        void Insert(long duration, string transactionName, string statement);
+        void Update(long duration, string transactionName, string statement);
+        void Delete(long duration, string transactionName, string statement);
+        void NonQuery(long duration, string transactionName, string statement);
+        void ProcessReader(long duration, string transactionName, string statement);
+        void ExecuteReader(long duration, string transactionName, string statement);
+        void Scalar(long duration, string transactionName, string statement);
+    }
+}

--- a/source/Nevermore/Diagnostics/TimedSection.cs
+++ b/source/Nevermore/Diagnostics/TimedSection.cs
@@ -6,18 +6,12 @@ namespace Nevermore.Diagnostics
 {
     internal class TimedSection : IDisposable
     {
+        readonly Action<long> callback;
         readonly Stopwatch stopwatch;
-        readonly ILog log;
-        readonly long infoThreshold;
-        readonly long warningThreshold;
-        readonly Func<long, string> formatMessage;
 
-        internal TimedSection(ILog log, Func<long, string> formatMessage, long infoThreshold, long warningThreshold = long.MaxValue)
+        internal TimedSection(Action<long> callback)
         {
-            this.log = log;
-            this.infoThreshold = infoThreshold;
-            this.formatMessage = formatMessage;
-            this.warningThreshold = warningThreshold;
+            this.callback = callback;
             stopwatch = Stopwatch.StartNew();
         }
 
@@ -27,14 +21,7 @@ namespace Nevermore.Diagnostics
         {
             stopwatch.Stop();
             var ms = stopwatch.ElapsedMilliseconds;
-            var level = ms >= warningThreshold
-                ? LogLevel.Warn
-                : ms >= infoThreshold
-                    ? LogLevel.Info
-                    : LogLevel.Debug;
-
-            var message = formatMessage(ms);
-            log.Log(level, () => message);
+            callback(ms);
         }
     }
 }

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -33,6 +33,7 @@ namespace Nevermore
         ITypeHandlerRegistry TypeHandlers { get; }
         IInstanceTypeRegistry InstanceTypeResolvers { get; }
         IRelatedDocumentStore RelatedDocumentStore { get; set; }
+        IQueryLogger QueryLogger { get; set; }
         
         /// <summary>
         /// Hooks can be used to apply general logic when documents are inserted, updated or deleted.

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -11,6 +11,7 @@ using Nevermore.Advanced.ReaderStrategies.Primitives;
 using Nevermore.Advanced.ReaderStrategies.ValueTuples;
 using Nevermore.Advanced.Serialization;
 using Nevermore.Advanced.TypeHandlers;
+using Nevermore.Diagnostics;
 using Nevermore.Mapping;
 using Nevermore.RelatedDocuments;
 using Newtonsoft.Json;
@@ -50,6 +51,8 @@ namespace Nevermore
 
             AllowSynchronousOperations = true;
 
+            QueryLogger = new DefaultQueryLogger();
+
             connectionString = new Lazy<string>(() =>
             {
                 var result = connectionStringFunc();
@@ -70,6 +73,8 @@ namespace Nevermore
         public IDocumentSerializer DocumentSerializer { get; set; }
         
         public IRelatedDocumentStore RelatedDocumentStore { get; set; }
+        
+        public IQueryLogger QueryLogger { get; set; }
 
         public IHookRegistry Hooks { get; }
         public int KeyBlockSize { get; set; }


### PR DESCRIPTION
Brings #108 to Nevermore 12

One notable change is that each Read query will now generate two log entries, the execution of the reader and the read of the result.