### PR TITLE
#113 Improve support for non-string ID columns

### DIFF
--- a/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
+++ b/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
@@ -31,7 +31,7 @@ namespace Nevermore.Benchmarks
         [Benchmark]
         public List<Customer> LoadMany()
         {
-            var result = transaction.LoadMany<Customer>(allIdsRandomlySorted.Take(NumberToLoad).ToArray());
+            var result = transaction.LoadMany<Customer>(allIdsRandomlySorted.Take(NumberToLoad));
             if (result.Count != NumberToLoad)
                 throw new Exception();
             return result;

--- a/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
+++ b/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
@@ -31,7 +31,7 @@ namespace Nevermore.Benchmarks
         [Benchmark]
         public List<Customer> LoadMany()
         {
-            var result = transaction.Load<Customer>(allIdsRandomlySorted.Take(NumberToLoad));
+            var result = transaction.LoadMany<Customer>(allIdsRandomlySorted.Take(NumberToLoad).ToArray());
             if (result.Count != NumberToLoad)
                 throw new Exception();
             return result;

--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -67,8 +67,8 @@ namespace Nevermore.IntegrationTests.Advanced
             public void AfterInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterInsert));
             public void BeforeUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeUpdate));
             public void AfterUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterUpdate));
-            public void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeDelete));
-            public void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterDelete));
+            public void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeDelete));
+            public void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterDelete));
             public void BeforeCommit(IWriteTransaction transaction) => log.AppendLine(nameof(BeforeCommit));
             public void AfterCommit(IWriteTransaction transaction) => log.AppendLine(nameof(AfterCommit));
         }

--- a/source/Nevermore.IntegrationTests/Model/Message.cs
+++ b/source/Nevermore.IntegrationTests/Model/Message.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class Message
+    {
+        public Guid Id { get; set; }
+
+        public string Sender { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageMap : DocumentMap<Message>
+    {
+        public MessageMap()
+        {
+            Id(x => x.Id);
+            Column(x => x.Sender);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -25,7 +25,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using (var trn = Store.BeginTransaction())
             {
-                trn.LoadMany<Product>(new[] { "A", "B" }.ToArray());
+                trn.LoadMany<Product>(new[] { "A", "B" });
             }
         }
 
@@ -34,7 +34,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using (var trn = Store.BeginTransaction())
             {
-                trn.LoadMany<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n).ToArray());
+                trn.LoadMany<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
             }
         }
 
@@ -43,7 +43,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using (var trn = Store.BeginTransaction())
             {
-                trn.LoadStream<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n).ToArray());
+                trn.LoadStream<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
             }
         }
 
@@ -319,7 +319,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 trn.Insert(messageB);
                 trn.Commit();
                 
-                var loadedMessages = trn.LoadMany<Message>(new object[] { messageA.Id, messageB.Id });
+                var loadedMessages = trn.LoadMany<Message>(messageA.Id, messageB.Id);
                 loadedMessages.Count.Should().Be(2);
 
                 var loadedMessageA = loadedMessages.Single(x => x.Id == messageA.Id);

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -26,7 +26,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new ProductMap(),
                 new LineItemMap(),
                 new MachineMap(),
-                new OrderMap());
+                new OrderMap(),
+                new MessageMap());
             
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
@@ -43,7 +44,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new CustomerMap(), 
                 new LineItemMap(), 
                 new BrandMap(), 
-                new MachineMap());
+                new MachineMap(),
+                new MessageMap());
             
             Store = new RelationalStore(config);
         }

--- a/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
@@ -12,7 +12,7 @@ namespace Nevermore.IntegrationTests.SetUp
         {
             var tableName = tableNameOverride ?? mapping.TableName;
             result.AppendLine("CREATE TABLE [TestSchema].[" + tableName + "] (");
-            result.AppendFormat("  [Id] NVARCHAR(50) NOT NULL CONSTRAINT [PK_{0}_Id] PRIMARY KEY CLUSTERED, ", tableName).AppendLine();
+            result.Append($"  [Id] {GetDatabaseType(mapping.IdColumn)} NOT NULL CONSTRAINT [PK_{tableName}_Id] PRIMARY KEY CLUSTERED, ").AppendLine();
 
             foreach (var column in mapping.WritableIndexedColumns())
             {

--- a/source/Nevermore/Advanced/Hooks/HookRegistry.cs
+++ b/source/Nevermore/Advanced/Hooks/HookRegistry.cs
@@ -33,12 +33,12 @@ namespace Nevermore.Advanced.Hooks
             foreach (var hook in hooks) hook.AfterUpdate(document, map, transaction);
         }
 
-        public void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) hook.BeforeDelete<TDocument>(id, map, transaction);
         }
 
-        public void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) hook.AfterDelete<TDocument>(id, map, transaction);
         }
@@ -73,12 +73,12 @@ namespace Nevermore.Advanced.Hooks
             foreach (var hook in hooks) await hook.AfterUpdateAsync(document, map, transaction);
         }
 
-        public async Task BeforeDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public async Task BeforeDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) await hook.BeforeDeleteAsync<TDocument>(id, map, transaction);
         }
 
-        public async Task AfterDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public async Task AfterDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) await hook.AfterDeleteAsync<TDocument>(id, map, transaction);
         }

--- a/source/Nevermore/Advanced/Hooks/IHook.cs
+++ b/source/Nevermore/Advanced/Hooks/IHook.cs
@@ -10,8 +10,8 @@ namespace Nevermore.Advanced.Hooks
         void AfterInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void BeforeUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void AfterUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
-        void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
-        void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
+        void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
+        void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void BeforeCommit(IWriteTransaction transaction) {}
         void AfterCommit(IWriteTransaction transaction) {}
 
@@ -19,8 +19,8 @@ namespace Nevermore.Advanced.Hooks
         Task AfterInsertAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task BeforeUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task AfterUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
-        Task BeforeDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
-        Task AfterDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
+        Task BeforeDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
+        Task AfterDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task BeforeCommitAsync(IWriteTransaction transaction) => Task.CompletedTask;
         Task AfterCommitAsync(IWriteTransaction transaction) => Task.CompletedTask;
     }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -81,27 +81,79 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public TDocument Load<TDocument>(object id) where TDocument : class
+        private TDocument Load<TDocument, TKey>(TKey id) where TDocument : class
         {
-            return Stream<TDocument>(PrepareLoad<TDocument>(id)).FirstOrDefault();
+            return Stream<TDocument>(PrepareLoad<TDocument, TKey>(id)).FirstOrDefault();
         }
 
-        public async Task<TDocument> LoadAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class
+        [Pure]
+        public TDocument Load<TDocument>(string id) where TDocument : class => Load<TDocument, string>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(int id) where TDocument : class => Load<TDocument, int>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(long id) where TDocument : class => Load<TDocument, long>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(Guid id) where TDocument : class => Load<TDocument, Guid>(id);
+
+        private async Task<TDocument> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var results = StreamAsync<TDocument>(PrepareLoad<TDocument>(id), cancellationToken);
+            var results = StreamAsync<TDocument>(PrepareLoad<TDocument, TKey>(id), cancellationToken);
             await foreach (var row in results.WithCancellation(cancellationToken))
                 return row;
             return null;
         }
 
-        public List<TDocument> LoadMany<TDocument>(params object[] ids) where TDocument : class
-            => LoadStream<TDocument>(ids).ToList();
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, string>(id, cancellationToken);
 
         [Pure]
-        public async Task<List<TDocument>> LoadManyAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, int>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, long>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, Guid>(id, cancellationToken);
+
+        private List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+            => LoadStream<TDocument, TKey>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params string[] ids) where TDocument : class
+            => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params int[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params long[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params Guid[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<string> ids) where TDocument : class
+            => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<int> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<long> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<Guid> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        [Pure]
+        private async Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = new List<TDocument>();
-            await foreach (var item in LoadStreamAsync<TDocument>(ids, cancellationToken))
+            await foreach (var item in LoadStreamAsync<TDocument, TKey>(ids, cancellationToken))
             {
                 results.Add(item);
             }
@@ -110,68 +162,200 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public TDocument LoadRequired<TDocument>(object id) where TDocument : class
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, string>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, int>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, long>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, Guid>(ids, cancellationToken);
+
+        [Pure]
+        private TDocument LoadRequired<TDocument, TKey>(TKey id) where TDocument : class
         {
-            var result = Load<TDocument>(id);
+            var result = Load<TDocument, TKey>(id);
             if (result == null)
                 throw new ResourceNotFoundException(id);
             return result;
         }
 
         [Pure]
-        public async Task<TDocument> LoadRequiredAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class
+        public TDocument LoadRequired<TDocument>(string id) where TDocument : class
+            => LoadRequired<TDocument, string>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(int id) where TDocument : class
+            => LoadRequired<TDocument, int>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(long id) where TDocument : class
+            => LoadRequired<TDocument, long>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(Guid id) where TDocument : class
+            => LoadRequired<TDocument, Guid>(id);
+
+        [Pure]
+        private async Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var result = await LoadAsync<TDocument>(id, cancellationToken);
+            var result = await LoadAsync<TDocument, TKey>(id, cancellationToken);
             if (result == null)
                 throw new ResourceNotFoundException(id);
             return result;
         }
 
-        public List<TDocument> LoadManyRequired<TDocument>(params object[] ids) where TDocument : class
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, string>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, int>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, long>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, Guid>(id, cancellationToken);
+
+        private List<TDocument> LoadManyRequired<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Distinct().ToList();
-            var results = LoadMany<TDocument>(idList);
+            var results = LoadMany<TDocument, TKey>(idList);
             if (results.Count != idList.Count)
             {
-                var firstMissing = idList.FirstOrDefault(id => results.All(record => configuration.DocumentMaps.GetId(record) != id));
+                var firstMissing = idList.FirstOrDefault(id => results.All(record => !((TKey)configuration.DocumentMaps.GetId(record)).Equals(id)));
                 throw new ResourceNotFoundException(firstMissing);
             }
 
             return results;
         }
 
-        public async Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class
+        public List<TDocument> LoadManyRequired<TDocument>(params string[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, string>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params int[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, int>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params long[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, long>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params Guid[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, Guid>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<string> ids) where TDocument : class
+           => LoadManyRequired<TDocument, string>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<int> ids) where TDocument : class
+          => LoadManyRequired<TDocument, int>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<long> ids) where TDocument : class
+          => LoadManyRequired<TDocument, long>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<Guid> ids) where TDocument : class
+          => LoadManyRequired<TDocument, Guid>(ids);
+
+        private async Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var idList = ids.Distinct().ToArray();
-            var results = await LoadManyAsync<TDocument>(idList, cancellationToken);
+            var results = await LoadManyAsync<TDocument, TKey>(idList, cancellationToken);
             if (results.Count != idList.Length)
             {
-                var firstMissing = idList.FirstOrDefault(id => results.All(record => configuration.DocumentMaps.GetId(record) != id));
+                var firstMissing = idList.FirstOrDefault(id => results.All(record => !((TKey)configuration.DocumentMaps.GetId(record)).Equals(id)));
                 throw new ResourceNotFoundException(firstMissing);
             }
 
             return results;
         }
 
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, string>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, int>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, long>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, Guid>(ids, cancellationToken);
+
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(params object[] ids) where TDocument : class
+        private IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Where(id => id != null).Distinct().ToList();
-            return idList.Count == 0 ? new List<TDocument>() : Stream<TDocument>(PrepareLoadMany<TDocument>(idList));
+            return idList.Count == 0 ? new List<TDocument>() : Stream<TDocument>(PrepareLoadMany<TDocument, TKey>(idList));
         }
 
         [Pure]
-        public async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(object[] ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class 
+            => LoadStream<TDocument, string>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class 
+            => LoadStream<TDocument, int>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class 
+            => LoadStream<TDocument, long>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class 
+            => LoadStream<TDocument, Guid>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class 
+            => LoadStream<TDocument, string>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params int[] ids) where TDocument : class
+            => LoadStream<TDocument, int>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class 
+            => LoadStream<TDocument, long>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params Guid[] ids) where TDocument : class
+            => LoadStream<TDocument, Guid>(ids);
+
+        [Pure]
+        private async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument, TKey>(IEnumerable<TKey> ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
         {
             var idList = ids.Where(id => id != null).Distinct().ToList();
             if (idList.Count == 0)
                 yield break;
 
-            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument>(idList), cancellationToken))
+            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument, TKey>(idList), cancellationToken))
             {
                 yield return item;
             }
         }
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, string>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, int>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, long>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, Guid>(ids, cancellationToken);
 
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
@@ -339,11 +523,11 @@ namespace Nevermore.Advanced
             return await command.ExecuteReaderAsync(cancellationToken);
         }
 
-        PreparedCommand PrepareLoad<TDocument>(object id)
+        PreparedCommand PrepareLoad<TDocument, TKey>(TKey id)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
 
-            if (mapping.IdColumn.Type != id.GetType())
+            if (mapping.IdColumn.Type != typeof(TKey))
                 throw new ArgumentException($"Provided Id of type '{id.GetType().FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
 
             var tableName = mapping.TableName;
@@ -351,7 +535,7 @@ namespace Nevermore.Advanced
             return new PreparedCommand($"SELECT TOP 1 * FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 
-        PreparedCommand PrepareLoadMany<TDocument>(IEnumerable<object> idList)
+        PreparedCommand PrepareLoadMany<TDocument, TKey>(IEnumerable<TKey> idList)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
             var tableName = mapping.TableName;

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -123,7 +123,7 @@ namespace Nevermore.Advanced
             return DeleteAsync<TDocument>(id, options, cancellationToken);
         }
 
-        public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
+        public void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             configuration.Hooks.BeforeDelete<TDocument>(id, command.Mapping, this);
@@ -131,12 +131,12 @@ namespace Nevermore.Advanced
             configuration.Hooks.AfterDelete<TDocument>(id, command.Mapping, this);
         }
 
-        public Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class
         {
             return DeleteAsync(id, null, cancellationToken);
         }
 
-        public async Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        public async Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             await configuration.Hooks.BeforeDeleteAsync<TDocument>(id, command.Mapping, this);

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,7 +56,7 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable(string name, IEnumerable<object> ids)
+        public void AddTable<T>(string name, IEnumerable<T> ids)
         {
             var idColumnMetadata = SqlMetaData.InferFromValue(ids.First(), "ParameterValue");
 

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,11 +56,11 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable(string name, IEnumerable<string> ids)
+        public void AddTable(string name, IEnumerable<object> ids)
         {
-            var idColumnMetadata = new SqlMetaData("ParameterValue", SqlDbType.NVarChar, 300);
+            var idColumnMetadata = SqlMetaData.InferFromValue(ids.First(), "ParameterValue");
 
-            var dataRecords = ids.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v =>
+            var dataRecords = ids.Where(v => v != null).Select(v =>
             {
                 var record = new SqlDataRecord(idColumnMetadata);
                 record.SetValue(0, v);

--- a/source/Nevermore/IReadQueryExecutor.cs
+++ b/source/Nevermore/IReadQueryExecutor.cs
@@ -7,289 +7,670 @@ using System.Threading.Tasks;
 using Nevermore.Advanced;
 
 namespace Nevermore
- {
-     /// <summary>
-     /// A transaction that provides the ability to read data from the database.
-     /// </summary>
-     public interface IReadQueryExecutor
-     {
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument Load<TDocument>(object id) where TDocument : class;
+{
+    /// <summary>
+    /// A transaction that provides the ability to read data from the database.
+    /// </summary>
+    public interface IReadQueryExecutor
+    {
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(string id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents.</returns>
-         [Pure] List<TDocument> LoadMany<TDocument>(params object[] ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(int id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params object[] ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(long id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument LoadRequired<TDocument>(object id) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(Guid id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. If any of the documents are not found, a
-         /// <see cref="ResourceNotFoundException" /> will be thrown.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents.</returns>
-         [Pure] List<TDocument> LoadManyRequired<TDocument>(params object[] ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. If any of the documents are not found, a
-         /// <see cref="ResourceNotFoundException" /> will be thrown.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Begins building a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class;
- 
-         /// <summary>
-         /// Returns strongly typed documents from the specified raw SQL query.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <returns>A builder to further customize the query.</returns>
-         [Obsolete("We are thinking of removing this method. Do you use it? What do you use it for? Let us know.")]
-         [Pure] ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents. 
-         /// </summary>
-         /// <param name="preparedCommand">Everything needed to run the query.</param>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params string[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents. 
-         /// </summary>
-         /// <param name="preparedCommand">Everything needed to run the query.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
-         
-         /// <summary>
-         /// Executes a query that returns strongly typed documents using a custom mapper function.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<string> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents using a custom mapper function.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params int[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results.
-         /// </summary>
-         /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>The number of rows affected.</returns>
-         int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<int> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params long[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         int ExecuteNonQuery(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<long> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
- 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A scalar value.</returns>
-         TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params Guid[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A scalar value.</returns>
-         Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return. The DB result will be cast to this type. If the result is null, it will return the default value for the type..</typeparam>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>A scalar value.</returns>
-         TResult ExecuteScalar<TResult>(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A scalar value.</returns>
-         Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="query">The query to execute.</param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="query">The query to execute.</param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] DbDataReader ExecuteReader(PreparedCommand preparedCommand);
-         
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] Task<DbDataReader> ExecuteReaderAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
-     }
- }
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params int[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params Guid[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(string id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(int id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(long id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(Guid id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params string[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<string> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params int[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<int> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params long[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<long> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params Guid[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Begins building a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class;
+
+        /// <summary>
+        /// Returns strongly typed documents from the specified raw SQL query.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <returns>A builder to further customize the query.</returns>
+        [Obsolete("We are thinking of removing this method. Do you use it? What do you use it for? Let us know.")]
+        [Pure] ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class;
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents. 
+        /// </summary>
+        /// <param name="preparedCommand">Everything needed to run the query.</param>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents. 
+        /// </summary>
+        /// <param name="preparedCommand">Everything needed to run the query.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents using a custom mapper function.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents using a custom mapper function.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns no results.
+        /// </summary>
+        /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>The number of rows affected.</returns>
+        int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        int ExecuteNonQuery(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A scalar value.</returns>
+        TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A scalar value.</returns>
+        Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return. The DB result will be cast to this type. If the result is null, it will return the default value for the type..</typeparam>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>A scalar value.</returns>
+        TResult ExecuteScalar<TResult>(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A scalar value.</returns>
+        Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] DbDataReader ExecuteReader(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] Task<DbDataReader> ExecuteReaderAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+    }
+}

--- a/source/Nevermore/IReadQueryExecutor.cs
+++ b/source/Nevermore/IReadQueryExecutor.cs
@@ -19,7 +19,7 @@ namespace Nevermore
          /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
          /// <param name="id">The <c>Id</c> of the document to find.</param>
          /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument Load<TDocument>(string id) where TDocument : class;
+         [Pure] TDocument Load<TDocument>(object id) where TDocument : class;
 
          /// <summary>
          /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -28,7 +28,7 @@ namespace Nevermore
          /// <param name="id">The <c>Id</c> of the document to find.</param>
          /// <param name="cancellationToken">Token to use to cancel the command.</param>
          /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+         [Pure] Task<TDocument> LoadAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
  
          /// <summary>
          /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -37,7 +37,7 @@ namespace Nevermore
          /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <returns>The documents.</returns>
-         [Pure] List<TDocument> Load<TDocument>(IEnumerable<string> ids) where TDocument : class;
+         [Pure] List<TDocument> LoadMany<TDocument>(params object[] ids) where TDocument : class;
 
          /// <summary>
          /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -47,7 +47,7 @@ namespace Nevermore
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <param name="cancellationToken">Token to use to cancel the command.</param>
          /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+         [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
  
          /// <summary>
          /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -56,7 +56,7 @@ namespace Nevermore
          /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class;
+         [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params object[] ids) where TDocument : class;
 
          /// <summary>
          /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -66,7 +66,7 @@ namespace Nevermore
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <param name="cancellationToken">Token to use to cancel the command.</param>
          /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+         [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
  
          /// <summary>
          /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
@@ -74,7 +74,7 @@ namespace Nevermore
          /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
          /// <param name="id">The <c>Id</c> of the document to find.</param>
          /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument LoadRequired<TDocument>(string id) where TDocument : class;
+         [Pure] TDocument LoadRequired<TDocument>(object id) where TDocument : class;
 
          /// <summary>
          /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
@@ -83,7 +83,7 @@ namespace Nevermore
          /// <param name="id">The <c>Id</c> of the document to find.</param>
          /// <param name="cancellationToken">Token to use to cancel the command.</param>
          /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+         [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
  
          /// <summary>
          /// Loads a set of documents by their ID's. If any of the documents are not found, a
@@ -92,7 +92,7 @@ namespace Nevermore
          /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <returns>The documents.</returns>
-         [Pure] List<TDocument> LoadRequired<TDocument>(IEnumerable<string> ids) where TDocument : class;
+         [Pure] List<TDocument> LoadManyRequired<TDocument>(params object[] ids) where TDocument : class;
 
          /// <summary>
          /// Loads a set of documents by their ID's. If any of the documents are not found, a
@@ -102,7 +102,7 @@ namespace Nevermore
          /// <param name="ids">A collection of ID's to query by.</param>
          /// <param name="cancellationToken">Token to use to cancel the command.</param>
          /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+         [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(object[] ids, CancellationToken cancellationToken = default) where TDocument : class;
  
          /// <summary>
          /// Begins building a query that returns strongly typed documents.

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -123,7 +123,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class;
+        void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -131,7 +131,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -140,7 +140,7 @@ namespace Nevermore
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
         
         /// <summary>
         /// Creates a deletion query for a strongly typed document.

--- a/source/Nevermore/InsertOptions.cs
+++ b/source/Nevermore/InsertOptions.cs
@@ -11,7 +11,7 @@ namespace Nevermore
         /// Gets or sets a specific ID to assign to the document being inserted. If null (the default) it will assign
         /// an ID automatically using the <see cref="T:IKeyAllocator"/>.
         /// </summary>
-        public string CustomAssignedId { get; set; }
+        public object CustomAssignedId { get; set; }
 
         /// <summary>
         /// Gets or sets whether to include the [Id] and [Json] columns (defaults to true). If false, these columns

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -331,13 +331,13 @@ namespace Nevermore.Mapping
             }
         }
 
-        public string GetId(object document)
+        public object GetId(object document)
         {
             if (document == null)
                 return null;
             
             var readerWriter = IdColumn.PropertyHandler;
-            return (string)readerWriter.Read(document);
+            return readerWriter.Read(document);
         }
     }
 }

--- a/source/Nevermore/Mapping/DocumentMapRegistry.cs
+++ b/source/Nevermore/Mapping/DocumentMapRegistry.cs
@@ -91,7 +91,7 @@ namespace Nevermore.Mapping
             return mapping;
         }
         
-        public string GetId(object instance)
+        public object GetId(object instance)
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));

--- a/source/Nevermore/Mapping/IDocumentMapRegistry.cs
+++ b/source/Nevermore/Mapping/IDocumentMapRegistry.cs
@@ -15,6 +15,6 @@ namespace Nevermore.Mapping
         DocumentMap Resolve<TDocument>();
         DocumentMap Resolve(object instance);
 
-        string GetId(object instance);
+        object GetId(object instance);
     }
 }

--- a/source/Nevermore/ResourceNotFoundException.cs
+++ b/source/Nevermore/ResourceNotFoundException.cs
@@ -10,8 +10,8 @@ namespace Nevermore
 
         }
 
-        public ResourceNotFoundException(string resourceId)
-            : base("The resource '" + resourceId + "' was not found.")
+        public ResourceNotFoundException(object resourceId)
+           : base("The resource '" + resourceId + "' was not found.")
         {
         }
     }

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -95,17 +95,17 @@ namespace Nevermore.Util
         public PreparedCommand PrepareDelete(object document, DeleteOptions options = null)
         {
             var mapping = mappings.Resolve(document.GetType());
-            var id = (string) mapping.IdColumn.PropertyHandler.Read(document);
+            var id = mapping.IdColumn.PropertyHandler.Read(document);
             return PrepareDelete(mapping, id, options);
         }
 
-        public PreparedCommand PrepareDelete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
+        public PreparedCommand PrepareDelete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var mapping = mappings.Resolve(typeof(TDocument));
             return PrepareDelete(mapping, id, options);
         }
 
-        private PreparedCommand PrepareDelete(DocumentMap mapping, string id, DeleteOptions options = null)
+        private PreparedCommand PrepareDelete(DocumentMap mapping, object id, DeleteOptions options = null)
         {
             options ??= DeleteOptions.Default;
 
@@ -221,7 +221,7 @@ namespace Nevermore.Util
             }
         }
 
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, string customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping)
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping)
         {
             if (documents.Count == 1)
                 return GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue, documents[0], mapping, "");
@@ -241,17 +241,17 @@ namespace Nevermore.Util
             ThrowIfIdAlreadySetToDifferentValue,
             IgnoreCustomIdIfIdAlreadySet
         }
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, string customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, string prefix = null)
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, string prefix = null)
         {
-            var id = (string) mapping.IdColumn.PropertyHandler.Read(document);
+            var id = mapping.IdColumn.PropertyHandler.Read(document);
             
             if (customIdAssignmentBehavior == CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue &&
                 customAssignedId != null && id != null && customAssignedId != id)
                 throw new ArgumentException("Do not pass a different Id when one is already set on the document");
 
-            if (string.IsNullOrWhiteSpace(id))
+            if (mapping.IdColumn.Type == typeof(string) && string.IsNullOrWhiteSpace((string)id))
             {
-                id = string.IsNullOrWhiteSpace(customAssignedId) ? allocateId(mapping) : customAssignedId;
+                id = string.IsNullOrWhiteSpace(customAssignedId as string) ? allocateId(mapping) : customAssignedId;
                 mapping.IdColumn.PropertyHandler.Write(document, id);
             }
 


### PR DESCRIPTION
This is an attempt to improve support for non-string ID columns as stated in #113.

Main changes (which need to be discussed):
- Change `Load` signatures to use `object`
- **[breaking]** Seperate `Load` methods which load multiple documents to `LoadMany`. Change signature to `object[]` or `params object[]` because `IEnumerable<object>` doesn't work for any type.

Please let me know if this is something you approve, or if we should solve this another way.