### PR TITLE
#111 Use Id column mapping for default order by clause

### DIFF
--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -62,6 +62,7 @@ ORDER BY [Id]");
         {
             return new TableSourceQueryBuilder<Record>("Records", 
                 "dbo",
+                "Id",
                 Substitute.For<IRelationalTransaction>(), 
                 new TableAliasGenerator(), 
                 new UniqueParameterNameGenerator(), 

--- a/source/Nevermore.Tests/Linq/LinqTestBase.cs
+++ b/source/Nevermore.Tests/Linq/LinqTestBase.cs
@@ -27,7 +27,7 @@ namespace Nevermore.Tests.Linq
             var parameters = new Parameters();
             var captures = new CommandParameterValues();
             var builder = new QueryBuilder<Foo, TableSelectBuilder>(
-                new TableSelectBuilder(new SimpleTableSource("Foo", "dbo")),
+                new TableSelectBuilder(new SimpleTableSource("Foo", "dbo"), new Querying.AST.Column("Id")),
                 Substitute.For<IRelationalTransaction>(),
                 new TableAliasGenerator(),
                 uniqueParameterNameGenerator ?? CreateSubstituteParameterNameGenerator(), 

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -26,9 +26,9 @@ namespace Nevermore.Tests.QueryBuilderFixture
             transaction.ClearReceivedCalls();
         }
         
-        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo") where TDocument : class
+        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo", string idColumnName = "Id") where TDocument : class
         {
-            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, idColumnName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
         
         [Test]
@@ -89,6 +89,19 @@ ORDER BY [Id]";
 FROM [dbo].[Orders]
 WHERE ([Price] > 5)
 ORDER BY [Id]";
+
+            actual.Should().Be(expected);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectWithCustomIdColum()
+        {
+            var actual = CreateQueryBuilder<object>("Orders", idColumnName: "CorrelationId")
+                .DebugViewRawQuery();
+
+            const string expected = @"SELECT *
+FROM [dbo].[Orders]
+ORDER BY [CorrelationId]";
 
             actual.Should().Be(expected);
         }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -236,7 +236,7 @@ ORDER BY [Id]");
 
         ITableSourceQueryBuilder<object> TableQueryBuilder(string tableName)
         {
-            return new TableSourceQueryBuilder<object>(tableName, "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(tableName, "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -28,7 +28,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
         IQueryBuilder<object> CreateQueryBuilder()
         {
-            return new TableSourceQueryBuilder<object>("Order", "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>("Order", "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -176,7 +176,7 @@ namespace Nevermore.Advanced
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
-            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), map.IdColumn.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class

--- a/source/Nevermore/Advanced/SelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilder.cs
@@ -74,30 +74,32 @@ namespace Nevermore.Advanced
 
     public class TableSelectBuilder : SelectBuilderBase<ITableSource>
     {
-        public TableSelectBuilder(ITableSource from) 
-            : this(from, new List<IWhereClause>(), new List<OrderByField>())
+        public TableSelectBuilder(ITableSource from, IColumn idColumn) 
+            : this(from, idColumn, new List<IWhereClause>(), new List<OrderByField>())
         {
         }
 
-        TableSelectBuilder(ITableSource from, List<IWhereClause> whereClauses,
+        TableSelectBuilder(ITableSource from, IColumn idColumn, List<IWhereClause> whereClauses,
             List<OrderByField> orderByClauses, ISelectColumns columnSelection = null, 
             IRowSelection rowSelection = null)
             : base(whereClauses, orderByClauses, columnSelection, rowSelection)
         {
             From = from;
+            IdColumn = idColumn;
         }
 
         protected override ITableSource From { get; }
         protected override ISelectColumns DefaultSelect => new SelectAllSource();
+        protected IColumn IdColumn { get; }
 
         protected override IEnumerable<OrderByField> GetDefaultOrderByFields()
         {
-            yield return new OrderByField(new Column("Id"));
+            yield return new OrderByField(IdColumn);
         }
 
         public override ISelectBuilder Clone()
         {
-            return new TableSelectBuilder(From, new List<IWhereClause>(WhereClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new TableSelectBuilder(From, IdColumn, new List<IWhereClause>(WhereClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
         }
     }
     

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Querying;
@@ -197,9 +198,11 @@ namespace Nevermore.Advanced
         string tableOrViewName;
         string alias;
         string schemaName;
+        string idColumnName;
 
         public TableSourceQueryBuilder(string tableOrViewName,
             string schemaName,
+            string idColumnName,
             IReadTransaction readQueryExecutor,
             ITableAliasGenerator tableAliasGenerator,
             IUniqueParameterNameGenerator uniqueParameterNameGenerator,
@@ -210,11 +213,12 @@ namespace Nevermore.Advanced
         {
             this.schemaName = schemaName;
             this.tableOrViewName = tableOrViewName;
+            this.idColumnName = idColumnName;
         }
 
         protected override ISelectBuilder CreateSelectBuilder()
         {
-            return new TableSelectBuilder(CreateSimpleTableSource());
+            return new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
         }
 
         public override IJoinSourceQueryBuilder<TRecord> Join(IAliasedSelectSource source, JoinType joinType, CommandParameterValues parameterValues, Parameters parameters, ParameterDefaults parameterDefaults)
@@ -256,7 +260,7 @@ namespace Nevermore.Advanced
         public IQueryBuilder<TRecord> Hint(string tableHint)
         {
             var source = new TableSourceWithHint(CreateSimpleTableSource(), tableHint);
-            return CreateQueryBuilder(new TableSelectBuilder(source));
+            return CreateQueryBuilder(new TableSelectBuilder(source, new Column(idColumnName)));
         }
 
         ISimpleTableSource CreateSimpleTableSource()

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -178,7 +178,7 @@ namespace Nevermore
                 && mapping.IdColumn != null
                 && mapping.IdColumn.MaxLength > 0
                 && columnType == DbType.String
-                && string.Equals(name, "Id", StringComparison.OrdinalIgnoreCase))
+                && string.Equals(name, mapping.IdColumn.ColumnName, StringComparison.OrdinalIgnoreCase))
             {
                 if (mapping.IdColumn.MaxLength != null)
                 {


### PR DESCRIPTION
This fixes #111 
I didn't change `GetDefaultOrderByFields` in `JoinSelectBuilder`, `UnionSelectBuilder` and `SubquerySelectBuilder` as it seems the order by clause is omitted there.

Could there be cases when `DocumentMap.IdColumn` is `null`? But I figure then it is a wrong document mapping anyway?