### PR TITLE
Add code to handle disposal of db connections on exception during open.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -114,6 +114,10 @@ Task("Publish")
 		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
 		ApiKey = EnvironmentVariable("FeedzIoApiKey")
 	});
+	NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
+		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
+		ApiKey = EnvironmentVariable("FeedzIoApiKey")
+	});
 	
     if (gitVersionInfo.PreReleaseTag == "")
     {
@@ -122,6 +126,10 @@ Task("Publish")
             ApiKey = EnvironmentVariable("NuGetApiKey")
         });
         NuGetPush($"{artifactsDir}Nevermore.Analyzers.{nugetVersion}.nupkg", new NuGetPushSettings {
+            Source = "https://api.nuget.org/v3/index.json",
+            ApiKey = EnvironmentVariable("NuGetApiKey")
+        });
+        NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
             Source = "https://api.nuget.org/v3/index.json",
             ApiKey = EnvironmentVariable("NuGetApiKey")
         });

--- a/build.cake
+++ b/build.cake
@@ -114,11 +114,7 @@ Task("Publish")
 		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
 		ApiKey = EnvironmentVariable("FeedzIoApiKey")
 	});
-	NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
-		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
-		ApiKey = EnvironmentVariable("FeedzIoApiKey")
-	});
-	
+
     if (gitVersionInfo.PreReleaseTag == "")
     {
         NuGetPush($"{artifactsDir}Nevermore.{nugetVersion}.nupkg", new NuGetPushSettings {
@@ -129,12 +125,7 @@ Task("Publish")
             Source = "https://api.nuget.org/v3/index.json",
             ApiKey = EnvironmentVariable("NuGetApiKey")
         });
-        NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
-            Source = "https://api.nuget.org/v3/index.json",
-            ApiKey = EnvironmentVariable("NuGetApiKey")
-        });
     }
-	
 });
 
 

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using NUnit.Framework;
+
+namespace Nevermore.Analyzers.Tests
+{
+	public class NevermoreSqlInjectionAnalyzerFixture
+    {
+        [Test]
+        public void ShouldDetectSqlInjectionInInterpolatedStream()
+        {
+	        var code = @"
+				var name = 'Robert';
+				var args = new CommandParameterValues(
+                    new
+                    {
+                        name,
+                        age = 71
+                    });
+				transaction.Stream<Customer>($'select * from dbo.Customer where Name = {name}', args).ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertError(results, "This expression uses string concatenation");
+        }
+        
+        [Test]
+        public void ShouldDetectSqlInjectionInInterpolatedWhere()
+        {
+	        var code = @"
+				var name = 'Robert';
+				transaction.Query<Customer>().Where($'Name = {name}').ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertError(results, "This expression uses string concatenation");
+        }
+        
+        [Test]
+        public void ShouldDetectSqlInjectionInConcatenatedWhere()
+        {
+	        var code = @"
+				var name = 'Robert';
+				transaction.Query<Customer>().Where('Name = ' + name).ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertError(results, "This expression uses string concatenation");
+        }
+        
+        [Test]
+        public void ShouldCompileIfPragmaIgnore()
+        {
+	        var code = @"
+				#pragma warning disable NV0007
+				// This call is safe from SQL injection because...
+				var name = 'Robert';
+				transaction.Query<Customer>().Where('Name = ' + name).ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
+
+        void AssertError(List<Diagnostic> results, string error)
+        {
+	        results.Count.Should().Be(1);
+	        results[0].GetMessage().Should().Contain(error);
+        }
+
+        void AssertPassed(List<Diagnostic> results)
+        {
+	        if (results.Count == 0)
+		        return;
+
+	        var errors = results.Select(r => r.GetMessage());
+	        Assert.Fail(string.Join(Environment.NewLine, errors));
+        }
+    }
+}

--- a/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Nevermore.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class NevermoreSqlInjectionAnalyzer : DiagnosticAnalyzer
+    {
+        readonly HashSet<string> methodsWeCareAbout = new HashSet<string> {"Where", "Stream"};
+        
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(AnalyzeCompilation);
+        }
+        
+        void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(context =>
+            {
+                var ignoreThisBlock = false;
+
+                var errors = new List<Diagnostic>();
+                
+                context.RegisterSyntaxNodeAction(invocationContext =>
+                {
+                    var invocation = (InvocationExpressionSyntax)invocationContext.Node;
+                    ProcessInvocation(invocation, invocationContext, errors);
+                }, SyntaxKind.InvocationExpression);
+
+                context.RegisterCodeBlockEndAction(c =>
+                {
+                    if (ignoreThisBlock)
+                        return;
+                    
+                    foreach (var error in errors)
+                    {
+                        c.ReportDiagnostic(error);
+                    }
+                });
+            });
+        }
+
+        void ProcessInvocation(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext context, List<Diagnostic> errors)
+        {
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+            if (symbolInfo.Symbol?.Kind != SymbolKind.Method)
+                return;
+
+            var methodSymbol = (IMethodSymbol)symbolInfo.Symbol;
+            
+            if (!methodsWeCareAbout.Contains(methodSymbol.Name))
+                return;
+            
+            if (methodSymbol.ContainingType == null)
+                return;
+
+            if (!(methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore") || methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Querying")  || methodSymbol.ContainingType.Name.StartsWith("IQueryBuilder") || methodSymbol.ContainingType.Name == "QueryBuilderWhereExtensions" || methodSymbol.ContainingType.Name == "DeleteQueryBuilderExtensions"))
+                return;
+
+            if (methodSymbol.Name == null)
+                return;
+
+            if (invocation.ArgumentList.Arguments.Count < 1)
+                return;
+            
+            var location = CheckForSqlInjection(invocation.ArgumentList.Arguments[0].Expression, context.SemanticModel);
+            if (location != Location.None)
+            {
+                errors.Add(Diagnostic.Create(ErrorDescriptor, location, "This expression uses string concatenation, which creates a risk of a SQL Injection vulnerability. Pass parameters or arguments instead. If you're absolutely sure it's safe, use '#pragma warning disable NV0007' plus a comment explaining why."));
+            }
+        }
+
+        static Location CheckForSqlInjection(ExpressionSyntax expression, SemanticModel model)
+        {
+            if (expression is BinaryExpressionSyntax binaryExpressionSyntax)
+            {
+                if (binaryExpressionSyntax.OperatorToken.Text == "+")
+                {
+                    return expression.GetLocation();
+                }
+            }
+            
+            if (expression is InterpolatedStringExpressionSyntax interpolatedStringExpressionSyntax)
+            {
+                return expression.GetLocation();
+            }
+
+            return Location.None;
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ErrorDescriptor);
+        
+        static readonly DiagnosticDescriptor ErrorDescriptor = new DiagnosticDescriptor("NV0007", "Nevermore SQL injection", "{0}", "Nevermore", DiagnosticSeverity.Error, true, helpLinkUri: "https://github.com/OctopusDeploy/Nevermore/wiki/Querying");
+    }
+}

--- a/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
+++ b/source/Nevermore.Benchmarks/LoadManyBenchmark.cs
@@ -31,7 +31,7 @@ namespace Nevermore.Benchmarks
         [Benchmark]
         public List<Customer> LoadMany()
         {
-            var result = transaction.Load<Customer>(allIdsRandomlySorted.Take(NumberToLoad));
+            var result = transaction.LoadMany<Customer>(allIdsRandomlySorted.Take(NumberToLoad));
             if (result.Count != NumberToLoad)
                 throw new Exception();
             return result;

--- a/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
+++ b/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nevermore\Nevermore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/source/Nevermore.Extensions.DependencyInjection/NevermoreServiceCollectionExtensions.cs
+++ b/source/Nevermore.Extensions.DependencyInjection/NevermoreServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Nevermore
+{
+    public static class NevermoreServiceCollectionExtensions
+    {
+        public static void AddNevermore(this IServiceCollection services, RelationalStoreConfiguration options)
+        {
+            services.AddSingleton<IRelationalStoreConfiguration>(options);
+            services.AddSingleton<IRelationalStore, RelationalStore>();
+
+            services.AddScoped(s => s.GetRequiredService<IRelationalStore>().BeginReadTransaction());
+            services.AddScoped(s => s.GetRequiredService<IRelationalStore>().BeginWriteTransaction());
+            services.AddScoped(s => s.GetRequiredService<IRelationalStore>().BeginTransaction());
+        }
+
+        public static void AddNevermore(this IServiceCollection services, string connectionString)
+        {
+            var options = new RelationalStoreConfiguration(connectionString);
+            AddNevermore(services, options);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -67,8 +67,8 @@ namespace Nevermore.IntegrationTests.Advanced
             public void AfterInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterInsert));
             public void BeforeUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeUpdate));
             public void AfterUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterUpdate));
-            public void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeDelete));
-            public void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterDelete));
+            public void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeDelete));
+            public void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterDelete));
             public void BeforeCommit(IWriteTransaction transaction) => log.AppendLine(nameof(BeforeCommit));
             public void AfterCommit(IWriteTransaction transaction) => log.AppendLine(nameof(AfterCommit));
         }

--- a/source/Nevermore.IntegrationTests/Model/Message.cs
+++ b/source/Nevermore.IntegrationTests/Model/Message.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class Message
+    {
+        public Guid Id { get; set; }
+
+        public string Sender { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageMap : DocumentMap<Message>
+    {
+        public MessageMap()
+        {
+            Id(x => x.Id);
+            Column(x => x.Sender);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
@@ -11,6 +11,8 @@ using Nevermore.Querying;
 using NUnit.Framework;
 using TestStack.BDDfy;
 
+#pragma warning disable NV0007
+
 namespace Nevermore.IntegrationTests
 {
     public class RelatedDocumentTableFixture : FixtureWithRelationalStore

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections;
+using System.Linq;
 using FluentAssertions;
 using Nevermore.IntegrationTests.Model;
 using Nevermore.IntegrationTests.SetUp;
@@ -23,7 +25,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using (var trn = Store.BeginTransaction())
             {
-                trn.Load<Product>(new[] { "A", "B" });
+                trn.LoadMany<Product>(new[] { "A", "B" });
             }
         }
 
@@ -32,7 +34,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using (var trn = Store.BeginTransaction())
             {
-                trn.Load<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
+                trn.LoadMany<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
             }
         }
 
@@ -285,6 +287,49 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
             {
                 var lineItem = new LineItem { ProductId = product.Id, Name = "Some line item", Quantity = quantity };
                 trn.Insert(lineItem);
+            }
+        }
+
+        [Test]
+        public void StoreAndLoadAnyIdTypes()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var messageA = new Message { Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A" };
+
+                trn.Insert<Message>(messageA);
+                trn.Commit();
+
+                var loadedMessageA = trn.Load<Message>(messageA.Id);
+
+                loadedMessageA.Sender.Should().Be(messageA.Sender);
+                loadedMessageA.Body.Should().Be(messageA.Body);
+            }
+        }
+
+        [Test]
+        public void StoreAndLoadManyAnyIdTypes()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                var messageA = new Message { Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A" };
+                var messageB = new Message { Id = Guid.NewGuid(), Sender = "Sender B", Body = "Body of Message B" };
+
+                trn.Insert(messageA);
+                trn.Insert(messageB);
+                trn.Commit();
+                
+                var loadedMessages = trn.LoadMany<Message>(messageA.Id, messageB.Id);
+                loadedMessages.Count.Should().Be(2);
+
+                var loadedMessageA = loadedMessages.Single(x => x.Id == messageA.Id);
+                var loadedMessageB = loadedMessages.Single(x => x.Id == messageB.Id);
+
+                loadedMessageA.Sender.Should().Be(messageA.Sender);
+                loadedMessageA.Body.Should().Be(messageA.Body);
+
+                loadedMessageB.Sender.Should().Be(messageB.Sender);
+                loadedMessageB.Body.Should().Be(messageB.Body);
             }
         }
     }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/TypeSupportFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/TypeSupportFixture.cs
@@ -76,12 +76,15 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         {
             using var transaction = Store.BeginReadTransaction();
 
+#pragma warning disable NV0007
+            // Safe from SQL injection because the selectColumn is passed from code only
             var resultFromPrimitive = transaction.Stream<T>($"select ({selectColumn}) as Column1").First();
             Assert.AreEqual(resultFromPrimitive, expected);
             
             var resultFromTuple = transaction.Stream<(T Val1, int Val2)>($"select ({selectColumn}) as Val1, 7 as Val2").First();
             Assert.AreEqual(resultFromTuple.Val1, expected);
             Assert.AreEqual(resultFromTuple.Val2, 7);
+#pragma warning restore NV0007
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -26,7 +26,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new ProductMap(),
                 new LineItemMap(),
                 new MachineMap(),
-                new OrderMap());
+                new OrderMap(),
+                new MessageMap());
             
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
@@ -43,7 +44,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new CustomerMap(), 
                 new LineItemMap(), 
                 new BrandMap(), 
-                new MachineMap());
+                new MachineMap(),
+                new MessageMap());
             
             Store = new RelationalStore(config);
         }

--- a/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
@@ -12,7 +12,7 @@ namespace Nevermore.IntegrationTests.SetUp
         {
             var tableName = tableNameOverride ?? mapping.TableName;
             result.AppendLine("CREATE TABLE [TestSchema].[" + tableName + "] (");
-            result.AppendFormat("  [Id] NVARCHAR(50) NOT NULL CONSTRAINT [PK_{0}_Id] PRIMARY KEY CLUSTERED, ", tableName).AppendLine();
+            result.Append($"  [Id] {GetDatabaseType(mapping.IdColumn)} NOT NULL CONSTRAINT [PK_{tableName}_Id] PRIMARY KEY CLUSTERED, ").AppendLine();
 
             foreach (var column in mapping.WritableIndexedColumns())
             {

--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -62,6 +62,7 @@ ORDER BY [Id]");
         {
             return new TableSourceQueryBuilder<Record>("Records", 
                 "dbo",
+                "Id",
                 Substitute.For<IRelationalTransaction>(), 
                 new TableAliasGenerator(), 
                 new UniqueParameterNameGenerator(), 

--- a/source/Nevermore.Tests/Linq/LinqTestBase.cs
+++ b/source/Nevermore.Tests/Linq/LinqTestBase.cs
@@ -27,7 +27,7 @@ namespace Nevermore.Tests.Linq
             var parameters = new Parameters();
             var captures = new CommandParameterValues();
             var builder = new QueryBuilder<Foo, TableSelectBuilder>(
-                new TableSelectBuilder(new SimpleTableSource("Foo", "dbo")),
+                new TableSelectBuilder(new SimpleTableSource("Foo", "dbo"), new Querying.AST.Column("Id")),
                 Substitute.For<IRelationalTransaction>(),
                 new TableAliasGenerator(),
                 uniqueParameterNameGenerator ?? CreateSubstituteParameterNameGenerator(), 

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -26,9 +26,9 @@ namespace Nevermore.Tests.QueryBuilderFixture
             transaction.ClearReceivedCalls();
         }
         
-        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo") where TDocument : class
+        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo", string idColumnName = "Id") where TDocument : class
         {
-            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, idColumnName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
         
         [Test]
@@ -89,6 +89,19 @@ ORDER BY [Id]";
 FROM [dbo].[Orders]
 WHERE ([Price] > 5)
 ORDER BY [Id]";
+
+            actual.Should().Be(expected);
+        }
+
+        [Test]
+        public void ShouldGenerateSelectWithCustomIdColum()
+        {
+            var actual = CreateQueryBuilder<object>("Orders", idColumnName: "CorrelationId")
+                .DebugViewRawQuery();
+
+            const string expected = @"SELECT *
+FROM [dbo].[Orders]
+ORDER BY [CorrelationId]";
 
             actual.Should().Be(expected);
         }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -8,6 +8,8 @@ using NSubstitute;
 using NUnit.Framework;
 // ReSharper disable ReturnValueOfPureMethodIsNotUsed
 
+#pragma warning disable NV0007
+
 namespace Nevermore.Tests.QueryBuilderFixture
 {
     public class QueryBuilderFixture

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -236,7 +236,7 @@ ORDER BY [Id]");
 
         ITableSourceQueryBuilder<object> TableQueryBuilder(string tableName)
         {
-            return new TableSourceQueryBuilder<object>(tableName, "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(tableName, "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -28,7 +28,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
         IQueryBuilder<object> CreateQueryBuilder()
         {
-            return new TableSourceQueryBuilder<object>("Order", "dbo", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>("Order", "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore.sln
+++ b/source/Nevermore.sln
@@ -16,11 +16,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Git", "Git", "{8FCDD3A3-1FF
 		..\.gitignore = ..\.gitignore
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nevermore.Benchmarks", "Nevermore.Benchmarks\Nevermore.Benchmarks.csproj", "{BE37C675-CA40-466D-B5F1-71199C7A0D31}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nevermore.Benchmarks", "Nevermore.Benchmarks\Nevermore.Benchmarks.csproj", "{BE37C675-CA40-466D-B5F1-71199C7A0D31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nevermore.Analyzers", "Nevermore.Analyzers\Nevermore.Analyzers.csproj", "{47EA1F4A-49A7-4691-A455-2A96FDDB2276}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nevermore.Analyzers", "Nevermore.Analyzers\Nevermore.Analyzers.csproj", "{47EA1F4A-49A7-4691-A455-2A96FDDB2276}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nevermore.Analyzers.Tests", "Nevermore.Analyzers.Tests\Nevermore.Analyzers.Tests.csproj", "{76F1F747-68DB-4461-8DF9-76BCA1A455C5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nevermore.Analyzers.Tests", "Nevermore.Analyzers.Tests\Nevermore.Analyzers.Tests.csproj", "{76F1F747-68DB-4461-8DF9-76BCA1A455C5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nevermore.Extensions.DependencyInjection", "Nevermore.Extensions.DependencyInjection\Nevermore.Extensions.DependencyInjection.csproj", "{C2C6F46A-3760-40DC-A4FA-CC71DD1D3C58}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +54,10 @@ Global
 		{76F1F747-68DB-4461-8DF9-76BCA1A455C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76F1F747-68DB-4461-8DF9-76BCA1A455C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76F1F747-68DB-4461-8DF9-76BCA1A455C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2C6F46A-3760-40DC-A4FA-CC71DD1D3C58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2C6F46A-3760-40DC-A4FA-CC71DD1D3C58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2C6F46A-3760-40DC-A4FA-CC71DD1D3C58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2C6F46A-3760-40DC-A4FA-CC71DD1D3C58}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Nevermore/Advanced/Hooks/HookRegistry.cs
+++ b/source/Nevermore/Advanced/Hooks/HookRegistry.cs
@@ -33,12 +33,12 @@ namespace Nevermore.Advanced.Hooks
             foreach (var hook in hooks) hook.AfterUpdate(document, map, transaction);
         }
 
-        public void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) hook.BeforeDelete<TDocument>(id, map, transaction);
         }
 
-        public void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) hook.AfterDelete<TDocument>(id, map, transaction);
         }
@@ -73,12 +73,12 @@ namespace Nevermore.Advanced.Hooks
             foreach (var hook in hooks) await hook.AfterUpdateAsync(document, map, transaction);
         }
 
-        public async Task BeforeDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public async Task BeforeDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) await hook.BeforeDeleteAsync<TDocument>(id, map, transaction);
         }
 
-        public async Task AfterDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
+        public async Task AfterDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) await hook.AfterDeleteAsync<TDocument>(id, map, transaction);
         }

--- a/source/Nevermore/Advanced/Hooks/IHook.cs
+++ b/source/Nevermore/Advanced/Hooks/IHook.cs
@@ -10,8 +10,8 @@ namespace Nevermore.Advanced.Hooks
         void AfterInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void BeforeUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void AfterUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
-        void BeforeDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
-        void AfterDelete<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
+        void BeforeDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
+        void AfterDelete<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class {}
         void BeforeCommit(IWriteTransaction transaction) {}
         void AfterCommit(IWriteTransaction transaction) {}
 
@@ -19,8 +19,8 @@ namespace Nevermore.Advanced.Hooks
         Task AfterInsertAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task BeforeUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task AfterUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
-        Task BeforeDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
-        Task AfterDeleteAsync<TDocument>(string id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
+        Task BeforeDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
+        Task AfterDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class => Task.CompletedTask;
         Task BeforeCommitAsync(IWriteTransaction transaction) => Task.CompletedTask;
         Task AfterCommitAsync(IWriteTransaction transaction) => Task.CompletedTask;
     }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -625,40 +625,9 @@ namespace Nevermore.Advanced
 
         public void Dispose()
         {
-            ExecuteAllAndAggregateExceptionsIfRequired(
-                () => Transaction?.Dispose(),
-                () => connection?.Dispose(),
-                () => registry.Remove(this)
-            );
-        }
-
-        void ExecuteAllAndAggregateExceptionsIfRequired(params Action[] actions)
-        {
-            var exceptions = new List<Exception>();
-
-            foreach (var action in actions)
-            {
-                try
-                {
-                    action();
-                }
-                catch (Exception e)
-                {
-                    exceptions.Add(e);
-                }
-            }
-
-            switch (exceptions.Count)
-            {
-                case 0:
-                    return;
-                
-                case 1:
-                    throw exceptions[0];
-                
-                default:
-                    throw new AggregateException(exceptions);
-            }
+            Transaction?.Dispose();
+            connection?.Dispose();
+            registry.Remove(this);
         }
     }
 }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -176,7 +176,7 @@ namespace Nevermore.Advanced
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
-            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), map.IdColumn.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -81,27 +81,79 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public TDocument Load<TDocument>(string id) where TDocument : class
+        private TDocument Load<TDocument, TKey>(TKey id) where TDocument : class
         {
-            return Stream<TDocument>(PrepareLoad<TDocument>(id)).FirstOrDefault();
+            return Stream<TDocument>(PrepareLoad<TDocument, TKey>(id)).FirstOrDefault();
         }
 
-        public async Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+        [Pure]
+        public TDocument Load<TDocument>(string id) where TDocument : class => Load<TDocument, string>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(int id) where TDocument : class => Load<TDocument, int>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(long id) where TDocument : class => Load<TDocument, long>(id);
+
+        [Pure]
+        public TDocument Load<TDocument>(Guid id) where TDocument : class => Load<TDocument, Guid>(id);
+
+        private async Task<TDocument> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var results = StreamAsync<TDocument>(PrepareLoad<TDocument>(id), cancellationToken);
+            var results = StreamAsync<TDocument>(PrepareLoad<TDocument, TKey>(id), cancellationToken);
             await foreach (var row in results.WithCancellation(cancellationToken))
                 return row;
             return null;
         }
 
-        public List<TDocument> Load<TDocument>(IEnumerable<string> ids) where TDocument : class
-            => LoadStream<TDocument>(ids).ToList();
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, string>(id, cancellationToken);
 
         [Pure]
-        public async Task<List<TDocument>> LoadAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, int>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, long>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadAsync<TDocument, Guid>(id, cancellationToken);
+
+        private List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+            => LoadStream<TDocument, TKey>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params string[] ids) where TDocument : class
+            => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params int[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params long[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(params Guid[] ids) where TDocument : class
+          => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<string> ids) where TDocument : class
+            => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<int> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<long> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        public List<TDocument> LoadMany<TDocument>(IEnumerable<Guid> ids) where TDocument : class
+           => LoadStream<TDocument>(ids).ToList();
+
+        [Pure]
+        private async Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = new List<TDocument>();
-            await foreach (var item in LoadStreamAsync<TDocument>(ids, cancellationToken))
+            await foreach (var item in LoadStreamAsync<TDocument, TKey>(ids, cancellationToken))
             {
                 results.Add(item);
             }
@@ -110,68 +162,200 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, string>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, int>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, long>(ids, cancellationToken);
+
+        [Pure]
+        public Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyAsync<TDocument, Guid>(ids, cancellationToken);
+
+        [Pure]
+        private TDocument LoadRequired<TDocument, TKey>(TKey id) where TDocument : class
+        {
+            var result = Load<TDocument, TKey>(id);
+            if (result == null)
+                throw new ResourceNotFoundException(id);
+            return result;
+        }
+
+        [Pure]
         public TDocument LoadRequired<TDocument>(string id) where TDocument : class
+            => LoadRequired<TDocument, string>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(int id) where TDocument : class
+            => LoadRequired<TDocument, int>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(long id) where TDocument : class
+            => LoadRequired<TDocument, long>(id);
+
+        [Pure]
+        public TDocument LoadRequired<TDocument>(Guid id) where TDocument : class
+            => LoadRequired<TDocument, Guid>(id);
+
+        [Pure]
+        private async Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var result = Load<TDocument>(id);
+            var result = await LoadAsync<TDocument, TKey>(id, cancellationToken);
             if (result == null)
                 throw new ResourceNotFoundException(id);
             return result;
         }
 
         [Pure]
-        public async Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
-        {
-            var result = await LoadAsync<TDocument>(id, cancellationToken);
-            if (result == null)
-                throw new ResourceNotFoundException(id);
-            return result;
-        }
+        public Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, string>(id, cancellationToken);
 
-        public List<TDocument> LoadRequired<TDocument>(IEnumerable<string> ids) where TDocument : class
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, int>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, long>(id, cancellationToken);
+
+        [Pure]
+        public Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadRequiredAsync<TDocument, Guid>(id, cancellationToken);
+
+        private List<TDocument> LoadManyRequired<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Distinct().ToList();
-            var results = Load<TDocument>(idList);
+            var results = LoadMany<TDocument, TKey>(idList);
             if (results.Count != idList.Count)
             {
-                var firstMissing = idList.FirstOrDefault(id => results.All(record => configuration.DocumentMaps.GetId(record) != id));
+                var firstMissing = idList.FirstOrDefault(id => results.All(record => !((TKey)configuration.DocumentMaps.GetId(record)).Equals(id)));
                 throw new ResourceNotFoundException(firstMissing);
             }
 
             return results;
         }
 
-        public async Task<List<TDocument>> LoadRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+        public List<TDocument> LoadManyRequired<TDocument>(params string[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, string>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params int[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, int>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params long[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, long>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(params Guid[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, Guid>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<string> ids) where TDocument : class
+           => LoadManyRequired<TDocument, string>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<int> ids) where TDocument : class
+          => LoadManyRequired<TDocument, int>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<long> ids) where TDocument : class
+          => LoadManyRequired<TDocument, long>(ids);
+
+        public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<Guid> ids) where TDocument : class
+          => LoadManyRequired<TDocument, Guid>(ids);
+
+        private async Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var idList = ids.Distinct().ToList();
-            var results = await LoadAsync<TDocument>(idList, cancellationToken);
-            if (results.Count != idList.Count)
+            var idList = ids.Distinct().ToArray();
+            var results = await LoadManyAsync<TDocument, TKey>(idList, cancellationToken);
+            if (results.Count != idList.Length)
             {
-                var firstMissing = idList.FirstOrDefault(id => results.All(record => configuration.DocumentMaps.GetId(record) != id));
+                var firstMissing = idList.FirstOrDefault(id => results.All(record => !((TKey)configuration.DocumentMaps.GetId(record)).Equals(id)));
                 throw new ResourceNotFoundException(firstMissing);
             }
 
             return results;
         }
 
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, string>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, int>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, long>(ids, cancellationToken);
+
+        public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
+            => LoadManyRequiredAsync<TDocument, Guid>(ids, cancellationToken);
+
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class
+        private IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
-            var idList = ids.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct().ToList();
-            return idList.Count == 0 ? new List<TDocument>() : Stream<TDocument>(PrepareLoadMany<TDocument>(idList));
+            var idList = ids.Where(id => id != null).Distinct().ToList();
+            return idList.Count == 0 ? new List<TDocument>() : Stream<TDocument>(PrepareLoadMany<TDocument, TKey>(idList));
         }
 
         [Pure]
-        public async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class 
+            => LoadStream<TDocument, string>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class 
+            => LoadStream<TDocument, int>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class 
+            => LoadStream<TDocument, long>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class 
+            => LoadStream<TDocument, Guid>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class 
+            => LoadStream<TDocument, string>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params int[] ids) where TDocument : class
+            => LoadStream<TDocument, int>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class 
+            => LoadStream<TDocument, long>(ids);
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument>(params Guid[] ids) where TDocument : class
+            => LoadStream<TDocument, Guid>(ids);
+
+        [Pure]
+        private async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument, TKey>(IEnumerable<TKey> ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
         {
-            var idList = ids.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct().ToList();
+            var idList = ids.Where(id => id != null).Distinct().ToList();
             if (idList.Count == 0)
                 yield break;
 
-            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument>(idList), cancellationToken))
+            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument, TKey>(idList), cancellationToken))
             {
                 yield return item;
             }
         }
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, string>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, int>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, long>(ids, cancellationToken);
+
+        [Pure]
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class 
+            => LoadStreamAsync<TDocument, Guid>(ids, cancellationToken);
 
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
@@ -339,15 +523,19 @@ namespace Nevermore.Advanced
             return await command.ExecuteReaderAsync(cancellationToken);
         }
 
-        PreparedCommand PrepareLoad<TDocument>(string id)
+        PreparedCommand PrepareLoad<TDocument, TKey>(TKey id)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
+
+            if (mapping.IdColumn.Type != typeof(TKey))
+                throw new ArgumentException($"Provided Id of type '{id.GetType().FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
+
             var tableName = mapping.TableName;
             var args = new CommandParameterValues {{"Id", id}};
             return new PreparedCommand($"SELECT TOP 1 * FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 
-        PreparedCommand PrepareLoadMany<TDocument>(IEnumerable<string> idList)
+        PreparedCommand PrepareLoadMany<TDocument, TKey>(IEnumerable<TKey> idList)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
             var tableName = mapping.TableName;

--- a/source/Nevermore/Advanced/SelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilder.cs
@@ -74,30 +74,32 @@ namespace Nevermore.Advanced
 
     public class TableSelectBuilder : SelectBuilderBase<ITableSource>
     {
-        public TableSelectBuilder(ITableSource from) 
-            : this(from, new List<IWhereClause>(), new List<OrderByField>())
+        public TableSelectBuilder(ITableSource from, IColumn idColumn) 
+            : this(from, idColumn, new List<IWhereClause>(), new List<OrderByField>())
         {
         }
 
-        TableSelectBuilder(ITableSource from, List<IWhereClause> whereClauses,
+        TableSelectBuilder(ITableSource from, IColumn idColumn, List<IWhereClause> whereClauses,
             List<OrderByField> orderByClauses, ISelectColumns columnSelection = null, 
             IRowSelection rowSelection = null)
             : base(whereClauses, orderByClauses, columnSelection, rowSelection)
         {
             From = from;
+            IdColumn = idColumn;
         }
 
         protected override ITableSource From { get; }
         protected override ISelectColumns DefaultSelect => new SelectAllSource();
+        protected IColumn IdColumn { get; }
 
         protected override IEnumerable<OrderByField> GetDefaultOrderByFields()
         {
-            yield return new OrderByField(new Column("Id"));
+            yield return new OrderByField(IdColumn);
         }
 
         public override ISelectBuilder Clone()
         {
-            return new TableSelectBuilder(From, new List<IWhereClause>(WhereClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new TableSelectBuilder(From, IdColumn, new List<IWhereClause>(WhereClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
         }
     }
     

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Querying;
@@ -197,9 +198,11 @@ namespace Nevermore.Advanced
         string tableOrViewName;
         string alias;
         string schemaName;
+        string idColumnName;
 
         public TableSourceQueryBuilder(string tableOrViewName,
             string schemaName,
+            string idColumnName,
             IReadTransaction readQueryExecutor,
             ITableAliasGenerator tableAliasGenerator,
             IUniqueParameterNameGenerator uniqueParameterNameGenerator,
@@ -210,11 +213,12 @@ namespace Nevermore.Advanced
         {
             this.schemaName = schemaName;
             this.tableOrViewName = tableOrViewName;
+            this.idColumnName = idColumnName;
         }
 
         protected override ISelectBuilder CreateSelectBuilder()
         {
-            return new TableSelectBuilder(CreateSimpleTableSource());
+            return new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
         }
 
         public override IJoinSourceQueryBuilder<TRecord> Join(IAliasedSelectSource source, JoinType joinType, CommandParameterValues parameterValues, Parameters parameters, ParameterDefaults parameterDefaults)
@@ -256,7 +260,7 @@ namespace Nevermore.Advanced
         public IQueryBuilder<TRecord> Hint(string tableHint)
         {
             var source = new TableSourceWithHint(CreateSimpleTableSource(), tableHint);
-            return CreateQueryBuilder(new TableSelectBuilder(source));
+            return CreateQueryBuilder(new TableSelectBuilder(source, new Column(idColumnName)));
         }
 
         ISimpleTableSource CreateSimpleTableSource()

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -123,7 +123,7 @@ namespace Nevermore.Advanced
             return DeleteAsync<TDocument>(id, options, cancellationToken);
         }
 
-        public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
+        public void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             configuration.Hooks.BeforeDelete<TDocument>(id, command.Mapping, this);
@@ -131,12 +131,12 @@ namespace Nevermore.Advanced
             configuration.Hooks.AfterDelete<TDocument>(id, command.Mapping, this);
         }
 
-        public Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class
         {
             return DeleteAsync(id, null, cancellationToken);
         }
 
-        public async Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        public async Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             await configuration.Hooks.BeforeDeleteAsync<TDocument>(id, command.Mapping, this);

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -178,7 +178,7 @@ namespace Nevermore
                 && mapping.IdColumn != null
                 && mapping.IdColumn.MaxLength > 0
                 && columnType == DbType.String
-                && string.Equals(name, "Id", StringComparison.OrdinalIgnoreCase))
+                && string.Equals(name, mapping.IdColumn.ColumnName, StringComparison.OrdinalIgnoreCase))
             {
                 if (mapping.IdColumn.MaxLength != null)
                 {

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,11 +56,11 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable(string name, IEnumerable<string> ids)
+        public void AddTable<T>(string name, IEnumerable<T> ids)
         {
-            var idColumnMetadata = new SqlMetaData("ParameterValue", SqlDbType.NVarChar, 300);
+            var idColumnMetadata = SqlMetaData.InferFromValue(ids.First(), "ParameterValue");
 
-            var dataRecords = ids.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v =>
+            var dataRecords = ids.Where(v => v != null).Select(v =>
             {
                 var record = new SqlDataRecord(idColumnMetadata);
                 record.SetValue(0, v);

--- a/source/Nevermore/IReadQueryExecutor.cs
+++ b/source/Nevermore/IReadQueryExecutor.cs
@@ -7,289 +7,670 @@ using System.Threading.Tasks;
 using Nevermore.Advanced;
 
 namespace Nevermore
- {
-     /// <summary>
-     /// A transaction that provides the ability to read data from the database.
-     /// </summary>
-     public interface IReadQueryExecutor
-     {
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument Load<TDocument>(string id) where TDocument : class;
+{
+    /// <summary>
+    /// A transaction that provides the ability to read data from the database.
+    /// </summary>
+    public interface IReadQueryExecutor
+    {
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(string id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents.</returns>
-         [Pure] List<TDocument> Load<TDocument>(IEnumerable<string> ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(int id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(long id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
-         /// the results may contain less items than the number of ID's queried for).
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents as a lazy loaded stream.</returns>
-         [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] TDocument LoadRequired<TDocument>(string id) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument Load<TDocument>(Guid id) where TDocument : class;
 
-         /// <summary>
-         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="id">The <c>Id</c> of the document to find.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-         [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Loads a set of documents by their ID's. If any of the documents are not found, a
-         /// <see cref="ResourceNotFoundException" /> will be thrown.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <returns>The documents.</returns>
-         [Pure] List<TDocument> LoadRequired<TDocument>(IEnumerable<string> ids) where TDocument : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Loads a set of documents by their ID's. If any of the documents are not found, a
-         /// <see cref="ResourceNotFoundException" /> will be thrown.
-         /// </summary>
-         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="ids">A collection of ID's to query by.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>The documents.</returns>
-         [Pure] Task<List<TDocument>> LoadRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
- 
-         /// <summary>
-         /// Begins building a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class;
- 
-         /// <summary>
-         /// Returns strongly typed documents from the specified raw SQL query.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <returns>A builder to further customize the query.</returns>
-         [Obsolete("We are thinking of removing this method. Do you use it? What do you use it for? Let us know.")]
-         [Pure] ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class;
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents. 
-         /// </summary>
-         /// <param name="preparedCommand">Everything needed to run the query.</param>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params string[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents. 
-         /// </summary>
-         /// <param name="preparedCommand">Everything needed to run the query.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
-         
-         /// <summary>
-         /// Executes a query that returns strongly typed documents using a custom mapper function.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<string> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns strongly typed documents using a custom mapper function.
-         /// </summary>
-         /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A stream of resulting documents.</returns>
-         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params int[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results.
-         /// </summary>
-         /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>The number of rows affected.</returns>
-         int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<int> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params long[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         int ExecuteNonQuery(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<long> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns no results, typically one that will write to the database. It can also be
-         /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-         Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
- 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A scalar value.</returns>
-         TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(params Guid[] ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A scalar value.</returns>
-         Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return. The DB result will be cast to this type. If the result is null, it will return the default value for the type..</typeparam>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>A scalar value.</returns>
-         TResult ExecuteScalar<TResult>(PreparedCommand preparedCommand);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
-         /// </summary>
-         /// <typeparam name="TResult">The scalar value type to return.</typeparam>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A scalar value.</returns>
-         Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="query">The query to execute.</param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="query">The query to execute.</param>
-         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
-         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] DbDataReader ExecuteReader(PreparedCommand preparedCommand);
-         
-         /// <summary>
-         /// Executes a query that returns a data reader that you can process manually.
-         /// </summary>
-         /// <param name="preparedCommand">The command to execute.</param>
-         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-         /// <returns>A data reader.</returns>
-         [Pure] Task<DbDataReader> ExecuteReaderAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
-     }
- }
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params int[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(params Guid[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(string id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(int id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(long id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument>(Guid id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params string[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<string> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params int[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<int> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params long[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<long> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(params Guid[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument>(IEnumerable<Guid> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Begins building a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class;
+
+        /// <summary>
+        /// Returns strongly typed documents from the specified raw SQL query.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <returns>A builder to further customize the query.</returns>
+        [Obsolete("We are thinking of removing this method. Do you use it? What do you use it for? Let us know.")]
+        [Pure] ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class;
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents. 
+        /// </summary>
+        /// <param name="preparedCommand">Everything needed to run the query.</param>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents. 
+        /// </summary>
+        /// <param name="preparedCommand">Everything needed to run the query.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents using a custom mapper function.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns strongly typed documents using a custom mapper function.
+        /// </summary>
+        /// <typeparam name="TRecord">The type of object being returned from the query. Results from the database will be mapped to this type using the projection mapper.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT * FROM Release...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="projectionMapper">The mapper function to use to convert each record into the strongly typed document.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A stream of resulting documents.</returns>
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args, Func<IProjectionMapper, TRecord> projectionMapper, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns no results.
+        /// </summary>
+        /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>The number of rows affected.</returns>
+        int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="query">The SQL query to execute. Example: <c>DROP TABLE...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        int ExecuteNonQuery(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns no results, typically one that will write to the database. It can also be
+        /// used when reading data though, so it's included on <see cref="IReadQueryExecutor"/>.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>Depends on the query, but typically the number of rows affected.</returns>
+        Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A scalar value.</returns>
+        TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="query">The SQL query to execute. Example: <c>SELECT COUNT(*) FROM...</c></param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A scalar value.</returns>
+        Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return. The DB result will be cast to this type. If the result is null, it will return the default value for the type..</typeparam>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>A scalar value.</returns>
+        TResult ExecuteScalar<TResult>(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
+        /// </summary>
+        /// <typeparam name="TResult">The scalar value type to return.</typeparam>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A scalar value.</returns>
+        Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="args">Any arguments to pass to the query as command parameters.</param>
+        /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] DbDataReader ExecuteReader(PreparedCommand preparedCommand);
+
+        /// <summary>
+        /// Executes a query that returns a data reader that you can process manually.
+        /// </summary>
+        /// <param name="preparedCommand">The command to execute.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>A data reader.</returns>
+        [Pure] Task<DbDataReader> ExecuteReaderAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default);
+    }
+}

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -123,7 +123,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class;
+        void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -131,7 +131,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -140,7 +140,7 @@ namespace Nevermore
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
         
         /// <summary>
         /// Creates a deletion query for a strongly typed document.

--- a/source/Nevermore/InsertOptions.cs
+++ b/source/Nevermore/InsertOptions.cs
@@ -11,7 +11,7 @@ namespace Nevermore
         /// Gets or sets a specific ID to assign to the document being inserted. If null (the default) it will assign
         /// an ID automatically using the <see cref="T:IKeyAllocator"/>.
         /// </summary>
-        public string CustomAssignedId { get; set; }
+        public object CustomAssignedId { get; set; }
 
         /// <summary>
         /// Gets or sets whether to include the [Id] and [Json] columns (defaults to true). If false, these columns

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -331,13 +331,13 @@ namespace Nevermore.Mapping
             }
         }
 
-        public string GetId(object document)
+        public object GetId(object document)
         {
             if (document == null)
                 return null;
             
             var readerWriter = IdColumn.PropertyHandler;
-            return (string)readerWriter.Read(document);
+            return readerWriter.Read(document);
         }
     }
 }

--- a/source/Nevermore/Mapping/DocumentMapRegistry.cs
+++ b/source/Nevermore/Mapping/DocumentMapRegistry.cs
@@ -91,7 +91,7 @@ namespace Nevermore.Mapping
             return mapping;
         }
         
-        public string GetId(object instance)
+        public object GetId(object instance)
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));

--- a/source/Nevermore/Mapping/IDocumentMapRegistry.cs
+++ b/source/Nevermore/Mapping/IDocumentMapRegistry.cs
@@ -15,6 +15,6 @@ namespace Nevermore.Mapping
         DocumentMap Resolve<TDocument>();
         DocumentMap Resolve(object instance);
 
-        string GetId(object instance);
+        object GetId(object instance);
     }
 }

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -7,6 +7,7 @@ using Microsoft.Data.SqlClient;
 #endif
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
 using Nevermore.Mapping;
@@ -37,43 +38,97 @@ namespace Nevermore
         public IReadTransaction BeginReadTransaction(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open();
-            return txn;
+
+            try
+            {
+                txn.Open();
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync();
-            return txn;
+
+            try
+            {
+                await txn.OpenAsync();
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IReadTransaction BeginReadTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IWriteTransaction BeginWriteTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+            
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)

--- a/source/Nevermore/ResourceNotFoundException.cs
+++ b/source/Nevermore/ResourceNotFoundException.cs
@@ -10,8 +10,8 @@ namespace Nevermore
 
         }
 
-        public ResourceNotFoundException(string resourceId)
-            : base("The resource '" + resourceId + "' was not found.")
+        public ResourceNotFoundException(object resourceId)
+           : base("The resource '" + resourceId + "' was not found.")
         {
         }
     }

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -95,17 +95,17 @@ namespace Nevermore.Util
         public PreparedCommand PrepareDelete(object document, DeleteOptions options = null)
         {
             var mapping = mappings.Resolve(document.GetType());
-            var id = (string) mapping.IdColumn.PropertyHandler.Read(document);
+            var id = mapping.IdColumn.PropertyHandler.Read(document);
             return PrepareDelete(mapping, id, options);
         }
 
-        public PreparedCommand PrepareDelete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
+        public PreparedCommand PrepareDelete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var mapping = mappings.Resolve(typeof(TDocument));
             return PrepareDelete(mapping, id, options);
         }
 
-        private PreparedCommand PrepareDelete(DocumentMap mapping, string id, DeleteOptions options = null)
+        private PreparedCommand PrepareDelete(DocumentMap mapping, object id, DeleteOptions options = null)
         {
             options ??= DeleteOptions.Default;
 
@@ -221,7 +221,7 @@ namespace Nevermore.Util
             }
         }
 
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, string customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping)
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping)
         {
             if (documents.Count == 1)
                 return GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue, documents[0], mapping, "");
@@ -241,17 +241,17 @@ namespace Nevermore.Util
             ThrowIfIdAlreadySetToDifferentValue,
             IgnoreCustomIdIfIdAlreadySet
         }
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, string customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, string prefix = null)
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, string prefix = null)
         {
-            var id = (string) mapping.IdColumn.PropertyHandler.Read(document);
+            var id = mapping.IdColumn.PropertyHandler.Read(document);
             
             if (customIdAssignmentBehavior == CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue &&
                 customAssignedId != null && id != null && customAssignedId != id)
                 throw new ArgumentException("Do not pass a different Id when one is already set on the document");
 
-            if (string.IsNullOrWhiteSpace(id))
+            if (mapping.IdColumn.Type == typeof(string) && string.IsNullOrWhiteSpace((string)id))
             {
-                id = string.IsNullOrWhiteSpace(customAssignedId) ? allocateId(mapping) : customAssignedId;
+                id = string.IsNullOrWhiteSpace(customAssignedId as string) ? allocateId(mapping) : customAssignedId;
                 mapping.IdColumn.PropertyHandler.Write(document, id);
             }
 


### PR DESCRIPTION
In some conditions Nevermore isn't closing DB connections, which can lead to exhaustion of the connection pool. We've identified some places where connections aren't disposed. This PR fixes some of those places.

Build history: https://build.octopushq.com/buildConfiguration/OctopusDeploy_LIbraries_Nevermore?mode=builds#all-projects

The crux of this PR is this flow:

1. Calling code calls `BeginReadTransaction` or `BeginWriteTransaction`
2. A new `ReadTransaction` or `WriteTransaction` is created
3. The new transaction is added to the `RelationalTransactionRegistry` during the constructor
4. An exception is thrown during the call to `ReadTransaction.Open()` or `ReadTransaction.OpenAsync()`

Before this PR, the transaction would remain in the registry. After this PR, the transaction will be removed and disposed.