### PR TITLE
Add nuget properties to csproj file.

### DIFF
--- a/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
+++ b/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
@@ -2,6 +2,19 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <PackageId>Nevermore.Extensions.DependencyInjection</PackageId>
+    <Version>1.0.0.0</Version>
+    <Authors>Octopus Deploy and contributors</Authors>
+    <PackageProjectUrl>https://github.com/OctopusDeploy/Nevermore</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicense>LICENSE.txt</PackageLicense>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageTags>nevermore;orm;sql;micro-orm;ioc;di</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
+    <ContinuousIntegrationBuild Condition="'$(Configuration)' == 'Release'">True</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,4 +25,8 @@
     <ProjectReference Include="..\Nevermore\Nevermore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Visible="false" Include="..\..\assets\logo.png" Pack="True" PackagePath="" />
+    <None Visible="false" Include="..\..\LICENSE.txt" Pack="True" PackagePath="" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Nevermore CI builds were failing because we were trying to publish a `nupkg` that wasn't being generated. This PR adds some extra properties to the csproj file so that it will get packaged and published.