### PR TITLE
Remove project from build.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -114,11 +114,7 @@ Task("Publish")
 		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
 		ApiKey = EnvironmentVariable("FeedzIoApiKey")
 	});
-	NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
-		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json",
-		ApiKey = EnvironmentVariable("FeedzIoApiKey")
-	});
-	
+
     if (gitVersionInfo.PreReleaseTag == "")
     {
         NuGetPush($"{artifactsDir}Nevermore.{nugetVersion}.nupkg", new NuGetPushSettings {
@@ -129,12 +125,7 @@ Task("Publish")
             Source = "https://api.nuget.org/v3/index.json",
             ApiKey = EnvironmentVariable("NuGetApiKey")
         });
-        NuGetPush($"{artifactsDir}Nevermore.Extensions.DependencyInjection.{nugetVersion}.nupkg", new NuGetPushSettings {
-            Source = "https://api.nuget.org/v3/index.json",
-            ApiKey = EnvironmentVariable("NuGetApiKey")
-        });
     }
-	
 });
 
 


### PR DESCRIPTION
The `Nevermore.Extensions.DependencyInjection` project introduced in #118 is breaking the CI builds because the cake file expects the project to be packaged into a `nupkg`, but it's not being packaged. 

As a tactical fix to unblock the CI builds, this PR changes the `build.cake` file so that it no longer attempts to upload the `Nevermore.Extensions.DependencyInjection` nupkg file.