### PR TITLE
Dispose of transactions when they fail to open.

### DIFF
--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -48,7 +48,6 @@ namespace Nevermore.Advanced
             this.name = name ?? Thread.CurrentThread.Name;
             if (string.IsNullOrEmpty(name))
                 this.name = "<unknown>";
-            registry.Add(this);
         }
 
         protected DbTransaction Transaction { get; private set; }
@@ -60,12 +59,16 @@ namespace Nevermore.Advanced
 
             connection = new SqlConnection(registry.ConnectionString);
             connection.OpenWithRetry();
+
+            registry.Add(this);
         }
 
         public async Task OpenAsync()
         {
             connection = new SqlConnection(registry.ConnectionString);
             await connection.OpenWithRetryAsync();
+
+            registry.Add(this);
         }
 
         public void Open(IsolationLevel isolationLevel)

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -7,6 +7,7 @@ using Microsoft.Data.SqlClient;
 #endif
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
 using Nevermore.Mapping;
@@ -37,43 +38,97 @@ namespace Nevermore
         public IReadTransaction BeginReadTransaction(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open();
-            return txn;
+
+            try
+            {
+                txn.Open();
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync();
-            return txn;
+
+            try
+            {
+                await txn.OpenAsync();
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IReadTransaction BeginReadTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IWriteTransaction BeginWriteTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+            
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch (Exception)
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)


### PR DESCRIPTION
In some conditions Nevermore isn't closing DB connections, which can lead to exhaustion of the connection pool. We've identified some places where connections aren't disposed. This PR fixes some of those places.

Build history: https://build.octopushq.com/buildConfiguration/OctopusDeploy_LIbraries_Nevermore?mode=builds#all-projects

The crux of this PR is this flow:

1. Calling code calls `BeginReadTransaction` or `BeginWriteTransaction`
2. A new `ReadTransaction` or `WriteTransaction` is created
3. The new transaction is added to the `RelationalTransactionRegistry` during the constructor
4. An exception is thrown during the call to `ReadTransaction.Open()` or `ReadTransaction.OpenAsync()`

Before this PR, the transaction would remain in the registry. After this PR, the transaction will be removed and disposed.