### PR TITLE
Add overloaded methods for Delete and DeleteAsync

### DIFF
--- a/source/Nevermore.IntegrationTests/Model/MessageWithGuidId.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithGuidId.cs
@@ -2,7 +2,7 @@
 
 namespace Nevermore.IntegrationTests.Model
 {
-    public class Message
+    public class MessageWithGuidId
     {
         public Guid Id { get; set; }
 

--- a/source/Nevermore.IntegrationTests/Model/MessageWithGuidIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithGuidIdMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithGuidIdMap: DocumentMap<MessageWithGuidId>
+    {
+        public MessageWithGuidIdMap()
+        {
+            Id(x => x.Id);
+            Column(x => x.Sender);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithIntId.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithIntId.cs
@@ -1,0 +1,11 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithIntId
+    {
+        public int Id { get; set; }
+
+        public string Sender { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithIntIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithIntIdMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithIntIdMap : DocumentMap<MessageWithIntId>
+    {
+        public MessageWithIntIdMap()
+        {
+            Id(x => x.Id);
+            Column(x => x.Sender);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithLongId.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithLongId.cs
@@ -1,0 +1,12 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithLongId
+    {
+        public long Id { get; set; }
+
+        public string Sender { get; set; }
+
+        public string Body { get; set; }
+
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithLongIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithLongIdMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithLongIdMap : DocumentMap<MessageWithLongId>
+    {
+        public MessageWithLongIdMap()
+        {
+            Id(x => x.Id);
+            Column(x => x.Sender);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithStringId.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithStringId.cs
@@ -1,0 +1,11 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class MessageWithStringId
+    {
+        public string Id { get; set; }
+
+        public string Sender { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/MessageWithStringIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/MessageWithStringIdMap.cs
@@ -2,9 +2,9 @@
 
 namespace Nevermore.IntegrationTests.Model
 {
-    public class MessageMap : DocumentMap<Message>
+    public class MessageWithStringIdMap : DocumentMap<MessageWithStringId>
     {
-        public MessageMap()
+        public MessageWithStringIdMap()
         {
             Id(x => x.Id);
             Column(x => x.Sender);

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
@@ -1,4 +1,5 @@
-﻿using Nevermore.IntegrationTests.Model;
+﻿using System;
+using Nevermore.IntegrationTests.Model;
 using NUnit.Framework;
 using FluentAssertions;
 using Nevermore.IntegrationTests.SetUp;
@@ -38,6 +39,16 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 trn.Load<Product>(id).Should().BeNull();
         }
 
+        [Test]
+        public void DeleteByWrongIdType_ShouldThrowArgumentException()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                Action target = () => trn.Delete<Product>(Guid.NewGuid());
+
+                target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.Guid' does not match configured type of 'System.String'.");
+            }
+        }
 
         string AddTestProduct()
         {

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -340,6 +340,17 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         }
 
         [Test]
+        public void LoadByWrongIdType_ShouldThrowArgumentException()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                Action target = () => trn.Load<MessageWithGuidId>(1);
+
+                target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.Int32' does not match configured type of 'System.Guid'.");
+            }
+        }
+
+        [Test]
         public void StoreAndLoadManyForStringIdType()
         {
             using (var trn = Store.BeginTransaction())
@@ -428,6 +439,17 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 var loadedMessages = trn.LoadMany<MessageWithGuidId>(messages.Select(m => m.Id));
 
                 loadedMessages.ShouldAllBeEquivalentTo(messages);
+            }
+        }
+
+        [Test]
+        public void LoadManyByWrongIdType_ShouldThrowArgumentException()
+        {
+            using (var trn = Store.BeginTransaction())
+            {
+                Action target = () => trn.LoadMany<MessageWithGuidId>("Messages-1");
+
+                target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.String' does not match configured type of 'System.Guid'.");
             }
         }
     }

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text;
-using Nevermore.Advanced.Serialization;
 using Nevermore.IntegrationTests.Chaos;
 using Nevermore.IntegrationTests.Contracts;
 using Nevermore.IntegrationTests.Model;
@@ -27,7 +26,10 @@ namespace Nevermore.IntegrationTests.SetUp
                 new LineItemMap(),
                 new MachineMap(),
                 new OrderMap(),
-                new MessageMap());
+                new MessageWithStringIdMap(),
+                new MessageWithIntIdMap(),
+                new MessageWithLongIdMap(),
+                new MessageWithGuidIdMap());
             
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
@@ -45,7 +47,10 @@ namespace Nevermore.IntegrationTests.SetUp
                 new LineItemMap(), 
                 new BrandMap(), 
                 new MachineMap(),
-                new MessageMap());
+                new MessageWithStringIdMap(),
+                new MessageWithIntIdMap(),
+                new MessageWithLongIdMap(),
+                new MessageWithGuidIdMap());
             
             Store = new RelationalStore(config);
         }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -529,7 +529,7 @@ namespace Nevermore.Advanced
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
 
             if (mapping.IdColumn.Type != typeof(TKey))
-                throw new ArgumentException($"Provided Id of type '{id.GetType().FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
+                throw new ArgumentException($"Provided Id of type '{id.GetType().FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
 
             var tableName = mapping.TableName;
             var args = new CommandParameterValues {{"Id", id}};
@@ -541,7 +541,7 @@ namespace Nevermore.Advanced
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
 
             if (mapping.IdColumn.Type != typeof(TKey))
-                throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
+                throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
 
             var param = new CommandParameterValues();
             param.AddTable("criteriaTable", idList.ToList());

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -293,6 +293,7 @@ namespace Nevermore.Advanced
         private IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Where(id => id != null).Distinct().ToList();
+
             return idList.Count == 0 ? new List<TDocument>() : Stream<TDocument>(PrepareLoadMany<TDocument, TKey>(idList));
         }
 
@@ -538,11 +539,13 @@ namespace Nevermore.Advanced
         PreparedCommand PrepareLoadMany<TDocument, TKey>(IEnumerable<TKey> idList)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
-            var tableName = mapping.TableName;
+
+            if (mapping.IdColumn.Type != typeof(TKey))
+                throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
 
             var param = new CommandParameterValues();
-            param.AddTable("criteriaTable", idList);
-            var statement = $"SELECT s.* FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
+            param.AddTable("criteriaTable", idList.ToList());
+            var statement = $"SELECT s.* FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }
 

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -123,7 +123,19 @@ namespace Nevermore.Advanced
             return DeleteAsync<TDocument>(id, options, cancellationToken);
         }
 
-        public void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
+        public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
+            => Delete<TDocument>((object) id, options);
+
+        public void Delete<TDocument>(int id, DeleteOptions options = null) where TDocument : class
+            => Delete<TDocument>((object) id, options);
+
+        public void Delete<TDocument>(long id, DeleteOptions options = null) where TDocument : class
+            => Delete<TDocument>((object) id, options);
+
+        public void Delete<TDocument>(Guid id, DeleteOptions options = null) where TDocument : class
+            => Delete<TDocument>((object) id, options);
+
+        void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             configuration.Hooks.BeforeDelete<TDocument>(id, command.Mapping, this);
@@ -131,12 +143,31 @@ namespace Nevermore.Advanced
             configuration.Hooks.AfterDelete<TDocument>(id, command.Mapping, this);
         }
 
-        public Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class
-        {
-            return DeleteAsync(id, null, cancellationToken);
-        }
+        public Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>(id, null, cancellationToken);
 
-        public async Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        public Task DeleteAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>(id, null, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>(id, null, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>(id, null, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>((object) id, options, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(int id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>((object) id, options, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(long id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>((object) id, options, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(Guid id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsync<TDocument>((object) id, options, cancellationToken);
+
+        async Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             await configuration.Hooks.BeforeDeleteAsync<TDocument>(id, command.Mapping, this);

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -106,23 +106,6 @@ namespace Nevermore.Advanced
             await configuration.Hooks.AfterUpdateAsync(document, command.Mapping, this);
         }
 
-        public void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class
-        {
-            var id = configuration.DocumentMaps.GetId(document);
-            Delete<TDocument>(id, options);
-        }
-
-        public Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class
-        {
-            return DeleteAsync(document, null, cancellationToken);
-        }
-
-        public Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
-        {
-            var id = configuration.DocumentMaps.GetId(document);
-            return DeleteAsync<TDocument>(id, options, cancellationToken);
-        }
-
         public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class
             => Delete<TDocument>((object) id, options);
 
@@ -134,6 +117,12 @@ namespace Nevermore.Advanced
 
         public void Delete<TDocument>(Guid id, DeleteOptions options = null) where TDocument : class
             => Delete<TDocument>((object) id, options);
+
+        public void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class
+        {
+            var id = configuration.DocumentMaps.GetId(document);
+            Delete<TDocument>(id, options);
+        }
 
         void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
@@ -155,6 +144,11 @@ namespace Nevermore.Advanced
         public Task DeleteAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument>(id, null, cancellationToken);
 
+        public Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class
+        {
+            return DeleteAsync(document, null, cancellationToken);
+        }
+
         public Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument>((object) id, options, cancellationToken);
 
@@ -166,6 +160,12 @@ namespace Nevermore.Advanced
 
         public Task DeleteAsync<TDocument>(Guid id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument>((object) id, options, cancellationToken);
+
+        public Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        {
+            var id = configuration.DocumentMaps.GetId(document);
+            return DeleteAsync<TDocument>(id, options, cancellationToken);
+        }
 
         async Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -81,6 +81,8 @@ namespace Nevermore
             var notSupportedErrorMsg = $"'{valueType.Name}' is not a valid ID type, supported types are: {nameof(String)}, {nameof(Int32)}, {nameof(Int64)} and {nameof(Guid)}.";
             switch (Type.GetTypeCode(valueType))
             {
+                //TODO: May consider dynamically resolving the 'ParameterValue' column length for User-Defined Table Type 'ParameterList' based on each DocumentMap configuration later.
+                //TODO: The fixed length of 300 is a temporary solution which match our table schema in Script0002-ParameterList.sql
                 case TypeCode.String: return new SqlMetaData(name, SqlDbType.NVarChar, 300);
                 case TypeCode.Int32: return new SqlMetaData(name, SqlDbType.Int);
                 case TypeCode.Int64: return new SqlMetaData(name, SqlDbType.BigInt);

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -59,7 +59,7 @@ namespace Nevermore
         public void AddTable<T>(string name, IReadOnlyCollection<T> ids)
         {
             var idColumnMetadata = GetSqlMetaData(ids, "ParameterValue");
-            
+
             var dataRecords = ids.Where(v => v != null).Select(v =>
             {
                 var record = new SqlDataRecord(idColumnMetadata);

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,10 +56,10 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable<T>(string name, IEnumerable<T> ids)
+        public void AddTable<T>(string name, IReadOnlyCollection<T> ids)
         {
-            var idColumnMetadata = SqlMetaData.InferFromValue(ids.First(), "ParameterValue");
-
+            var idColumnMetadata = GetSqlMetaData(ids, "ParameterValue");
+            
             var dataRecords = ids.Where(v => v != null).Select(v =>
             {
                 var record = new SqlDataRecord(idColumnMetadata);
@@ -74,7 +74,29 @@ namespace Nevermore
         {
             Add(name, tvp);
         }
-        
+
+        static SqlMetaData GetSqlMetaData<T>(IReadOnlyCollection<T> ids, string name)
+        {
+            var valueType = typeof(T);
+            var notSupportedErrorMsg = $"'{valueType.Name}' is not a valid ID type, supported types are: {nameof(String)}, {nameof(Int32)}, {nameof(Int64)} and {nameof(Guid)}.";
+            switch (Type.GetTypeCode(valueType))
+            {
+                case TypeCode.String: return new SqlMetaData(name, SqlDbType.NVarChar, 300);
+                case TypeCode.Int32: return new SqlMetaData(name, SqlDbType.Int);
+                case TypeCode.Int64: return new SqlMetaData(name, SqlDbType.BigInt);
+                case TypeCode.Object:
+                {
+                    if (valueType == typeof(Guid)) 
+                    { 
+                        return new SqlMetaData(name, SqlDbType.UniqueIdentifier);
+                    }
+                    
+                    throw new NotSupportedException(notSupportedErrorMsg);
+                }
+                default: throw new NotSupportedException(notSupportedErrorMsg);
+            }
+        }
+
         void AddFromParametersObject(object args)
         {
             if (args == null)

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -123,7 +123,31 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument>(object id, DeleteOptions options = null) where TDocument : class;
+        void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        void Delete<TDocument>(int id, DeleteOptions options = null) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        void Delete<TDocument>(long id, DeleteOptions options = null) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        void Delete<TDocument>(Guid id, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -131,7 +155,31 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(object id, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -140,8 +188,35 @@ namespace Nevermore
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
-        
+        Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(int id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(long id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(Guid id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
         /// <summary>
         /// Creates a deletion query for a strongly typed document.
         /// </summary>

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -93,31 +93,6 @@ namespace Nevermore
         Task UpdateAsync<TDocument>(TDocument document, UpdateOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
-        /// Deletes an existing document from the database.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <param name="document">The document to delete.</param>
-        /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class;
-
-        /// <summary>
-        /// Deletes an existing document from the database.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <param name="document">The document to delete.</param>
-        /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
-
-        /// <summary>
-        /// Deletes an existing document from the database.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <param name="document">The document to delete.</param>
-        /// <param name="options">Advanced options for the delete operation.</param>
-        /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
-
-        /// <summary>
         /// Deletes an existing document from the database by its ID.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
@@ -150,6 +125,14 @@ namespace Nevermore
         void Delete<TDocument>(Guid id, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
+        /// Deletes an existing document from the database.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="document">The document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class;
+
+        /// <summary>
         /// Deletes an existing document from the database by its ID.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
@@ -180,6 +163,14 @@ namespace Nevermore
         /// <param name="id">The id of the document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         Task DeleteAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="document">The document to delete.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -216,6 +207,15 @@ namespace Nevermore
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         Task DeleteAsync<TDocument>(Guid id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <param name="document">The document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Creates a deletion query for a strongly typed document.

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -102,6 +102,11 @@ namespace Nevermore.Util
         public PreparedCommand PrepareDelete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var mapping = mappings.Resolve(typeof(TDocument));
+            
+            var idType = id.GetType();
+            if (mapping.IdColumn.Type != idType)
+                throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
+            
             return PrepareDelete(mapping, id, options);
         }
 

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -105,7 +105,7 @@ namespace Nevermore.Util
             
             var idType = id.GetType();
             if (mapping.IdColumn.Type != idType)
-                throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}");
+                throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
             
             return PrepareDelete(mapping, id, options);
         }


### PR DESCRIPTION
# Background
Upgrade Nevermore version to the latest in `Octopus.Server`

[Octopus Server PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7965)

## Issue(s) discovered
1. `LoadMany(IEnumerable<string> ids...)` failed when ids are of different lengths
**Solution:** Instead of using `SqlMetaData.InferFromValue`, we are using our own implementation to figure out the correct `SqlMetaData` to use
2. `Delete` and `DeleteAsync` support deletion by `object` id while we only support `string`, `int`, `long` and `Guid` types for ID column
**Solution:** Add the same overload methods for `Load` and `LoadAsync` to `Delete` and `DeleteAsync`, so we only support deletion by the supported ID types

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
Correctness ✔️ 
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites
- [x] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [x] I have considered whether this should be a patch or wait for a minor.
- [x] I have considered appropriate testing for my change.
    <!-- Describe what has been covered: Automated testing/ Exploratory testing/ Nothing required? 
         Is the build green? -->
      
