### PR TITLE
Fixed properties serialising when mapped to columns

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/MappingWithInheritanceFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MappingWithInheritanceFixture.cs
@@ -44,12 +44,13 @@ namespace Nevermore.IntegrationTests.Advanced
         }
 
         JObject GetJObject(IRelationalTransaction transaction, string id)
-        {   
-            var parameters = new CommandParameterValues();
-            parameters.Add("id", id);
+        {
             var json = transaction.Stream<string>(
-                "SELECT [JSON] FROM [TestSchema].[Aircraft] WHERE [Id] = @id",
-                parameters)
+                    "SELECT [JSON] FROM [TestSchema].[Aircraft] WHERE [Id] = @id",
+                    new CommandParameterValues
+                    {
+                        {"id", id}
+                    })
                 .Single();
             var jObject = JObject.Parse(json);
 

--- a/source/Nevermore.IntegrationTests/Advanced/MappingWithInheritanceFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MappingWithInheritanceFixture.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class MappingWithInheritanceFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void ShouldNotSerializeIfColumnExists()
+        {
+            // Arrange
+            using var transaction = Store.BeginTransaction();
+            var aircraft = new Aircraft(AircraftType.FixedWing, "VH-ABC");
+            
+            // Act
+            transaction.Insert(aircraft);
+            transaction.Commit();
+            
+            // Assert
+            var jObject = GetJObject(transaction, aircraft.Id);
+            var registrationToken = jObject[nameof(aircraft.Registration)];
+            Assert.IsNull(registrationToken);
+        }
+        
+        [Test]
+        public void ShouldSerializeIfColumnDoesNotExist()
+        {
+            // Arrange
+            using var transaction = Store.BeginTransaction();
+            var aircraft = new Aircraft(AircraftType.FixedWing, "VH-ABC");
+            
+            // Act
+            transaction.Insert(aircraft);
+            transaction.Commit();
+            
+            // Assert
+            var jObject = GetJObject(transaction, aircraft.Id);
+            var typeToken = jObject[nameof(aircraft.Type)];
+            Assert.NotNull(typeToken);
+            Assert.AreEqual(typeToken.Value<string>(), aircraft.Type.ToString());
+        }
+
+        JObject GetJObject(IRelationalTransaction transaction, string id)
+        {   
+            var parameters = new CommandParameterValues();
+            parameters.Add("id", id);
+            var json = transaction.Stream<string>(
+                "SELECT [JSON] FROM [TestSchema].[Aircraft] WHERE [Id] = @id",
+                parameters)
+                .Single();
+            var jObject = JObject.Parse(json);
+
+            return jObject;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/Aircraft.cs
+++ b/source/Nevermore.IntegrationTests/Model/Aircraft.cs
@@ -1,0 +1,18 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    public enum AircraftType
+    {
+        FixedWing,
+        RotaryWing
+    }
+    
+    public class Aircraft : Vehicle
+    {
+        public AircraftType Type { get; set; }
+
+        public Aircraft(AircraftType type, string registration) : base(registration)
+        {
+            Type = type;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/AircraftMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/AircraftMap.cs
@@ -1,0 +1,14 @@
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class AircraftMap : DocumentMap<Aircraft>
+    {
+        public AircraftMap()
+        {
+            Column(m => m.Registration);
+            Column(m => m.Weight);
+            Column(m => m.MaxSpeed);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/Boat.cs
+++ b/source/Nevermore.IntegrationTests/Model/Boat.cs
@@ -2,9 +2,10 @@ namespace Nevermore.IntegrationTests.Model
 {
     public class Boat : Vehicle
     {
-        public string Name { get; set; }
-        public Boat(string name, string registration) : base(registration)
+        public string PortOfRegistry { get; set; }
+        public Boat(string name, string portOfRegistry) : base(name)
         {
+            PortOfRegistry = portOfRegistry;
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/Boat.cs
+++ b/source/Nevermore.IntegrationTests/Model/Boat.cs
@@ -1,0 +1,10 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    public class Boat : Vehicle
+    {
+        public string Name { get; set; }
+        public Boat(string name, string registration) : base(registration)
+        {
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/BoatMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/BoatMap.cs
@@ -1,0 +1,14 @@
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class BoatMap : DocumentMap<Boat>
+    {
+        public BoatMap()
+        {
+            Column(m => m.Registration);
+            Column(m => m.Weight);
+            Column(m => m.MaxSpeed);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/Vehicle.cs
+++ b/source/Nevermore.IntegrationTests/Model/Vehicle.cs
@@ -1,0 +1,15 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    public abstract class Vehicle
+    {
+        public string Id { get; set; }
+        public int Weight { get; set; }
+        public int MaxSpeed { get; set; }
+        public string Registration { get; set; }
+
+        protected Vehicle(string registration)
+        {
+            Registration = registration;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -31,6 +31,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithLongIdMap(),
                 new MessageWithGuidIdMap(),
                 new DocumentWithRowVersionMap());
+                new AircraftMap(),
+                new BoatMap());
 
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
@@ -53,6 +55,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithLongIdMap(),
                 new MessageWithGuidIdMap(),
                 new DocumentWithRowVersionMap());
+                new AircraftMap(),
+                new BoatMap());
 
             Store = new RelationalStore(config);
         }

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -30,7 +30,7 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithIntIdMap(),
                 new MessageWithLongIdMap(),
                 new MessageWithGuidIdMap(),
-                new DocumentWithRowVersionMap());
+                new DocumentWithRowVersionMap(),
                 new AircraftMap(),
                 new BoatMap());
 
@@ -54,7 +54,7 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithIntIdMap(),
                 new MessageWithLongIdMap(),
                 new MessageWithGuidIdMap(),
-                new DocumentWithRowVersionMap());
+                new DocumentWithRowVersionMap(),
                 new AircraftMap(),
                 new BoatMap());
 

--- a/source/Nevermore/RelationalJsonContractResolver.cs
+++ b/source/Nevermore/RelationalJsonContractResolver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
-using Nevermore.Mapping;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Linq;
@@ -16,9 +16,20 @@ namespace Nevermore
             this.configuration = configuration;
         }
 
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {
-            configuration.DocumentMaps.ResolveOptional(member.DeclaringType, out var map);
+            var members = GetSerializableMembers(type);
+
+            return members.Select(member => CreateProperty(type, member, memberSerialization)).ToList();
+        }
+
+        JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)
+        {
+            // Todo: Newtonsoft derives the MemberInfo from the base class if that's where the member is defined,
+            //  so ReflectedType will always be the same as DeclaredType. Issue currently open to fix this:
+            //  https://github.com/JamesNK/Newtonsoft.Json/issues/2488
+            // configuration.DocumentMaps.ResolveOptional(member.ReflectedType, out var map);
+            configuration.DocumentMaps.ResolveOptional(type, out var map);
 
             var property = base.CreateProperty(member, memberSerialization);
 

--- a/source/Nevermore/RelationalJsonContractResolver.cs
+++ b/source/Nevermore/RelationalJsonContractResolver.cs
@@ -19,8 +19,25 @@ namespace Nevermore
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {
             var members = GetSerializableMembers(type);
+            if (members == null)
+            {
+                throw new JsonSerializationException("Null collection of serializable members returned.");
+            }
 
-            return members.Select(member => CreateProperty(type, member, memberSerialization)).ToList();
+            var properties = new JsonPropertyCollection(type);
+
+            foreach (var member in members)
+            {
+                var property = CreateProperty(type, member, memberSerialization);
+
+                if (property != null)
+                {
+                    properties.AddProperty(property);
+                }
+            }
+
+            var orderedProperties = properties.OrderBy(p => p.Order ?? -1).ToList();
+            return orderedProperties;
         }
 
         JsonProperty CreateProperty(Type type, MemberInfo member, MemberSerialization memberSerialization)


### PR DESCRIPTION
## Summary

In scenarios where derived classes have their own tables, the serialised JSON would include properties that were already mapped to columns. This is because the `RelationalJsonContractResolver` used the `DeclaringType` to determine what `Type` of model is being resolved.
The issue with this is that `DeclaringType` will get the `Type` that the property was declared on. In the below example, the `Registration` property is declared on `Vehicle`, so the `RelationalJsonContractResolver` would look for a mapping for the `Vehicle` class when the mapping is actually be defined for the `Car` class.

```csharp
public abstract class Vehicle 
{
  public string Registration { get; set; }
}

public class Car : Vehicle
{
}
```

## Ideal Solution
The ideal solution would be to change `DeclaringType` to `ReflectingType`, which should return the `Type` for `Car`, but this won't work as Netwonsoft.Json actually gets the `MemberInfo` from the declaring type (vehicle), so that it can access any potential private getters/setters. (Issue open on the Newtonsoft.Json repo for this https://github.com/JamesNK/Newtonsoft.Json/issues/2488)

## Chosen Solution
This PR addresses this issue by overriding the `CreateProperties` method (since the target `Type` is exposed as a parameter), then passing the target `Type` as a parameter to a private `CreateProperty` method.