### PR TITLE
Added Row Versioning

### DIFF
--- a/source/Nevermore.Benchmarks/Model/CustomerMap.cs
+++ b/source/Nevermore.Benchmarks/Model/CustomerMap.cs
@@ -1,3 +1,4 @@
+using System;
 using Nevermore.Mapping;
 
 namespace Nevermore.Benchmarks.Model
@@ -20,7 +21,7 @@ namespace Nevermore.Benchmarks.Model
             Column(m => m.Counter7);
             Column(m => m.Counter8);
             Column(m => m.Counter9);
-            Column(m => m.RowVersion).LoadOnly();
+            RowVersion(m => m.RowVersion);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }

--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -22,13 +22,15 @@ namespace Nevermore.IntegrationTests.Advanced
             var customer = new Customer {Id = "C131", FirstName = "Fred", LastName = "Freddy"};
             transaction.Insert(customer);
             AssertLogged(log, "BeforeInsert", "AfterInsert");
-            
+
+            customer = transaction.Load<Customer>("C131");
+
             transaction.Update(customer);
             AssertLogged(log, "BeforeUpdate", "AfterUpdate");
 
             transaction.Delete(customer);
             AssertLogged(log, "BeforeDelete", "AfterDelete");
-            
+
             transaction.Commit();
             AssertLogged(log, "BeforeCommit", "AfterCommit");
         }
@@ -62,7 +64,7 @@ namespace Nevermore.IntegrationTests.Advanced
             {
                 this.log = log;
             }
-            
+
             public void BeforeInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeInsert));
             public void AfterInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(AfterInsert));
             public void BeforeUpdate<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class => log.AppendLine(nameof(BeforeUpdate));

--- a/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
+++ b/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class RowVersionFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void UpdateChangesRowVersion()
+        {
+            using var transaction = Store.BeginTransaction();
+            transaction.Insert( new Customer {FirstName = "FirstName", LastName = "LastName", Nickname = "NickName"});
+            transaction.Commit();
+
+            var customer = transaction.Query<Customer>().Where(c => c.FirstName == "FirstName").ToArray().Single();
+            customer.LastName = "LastName2";
+            transaction.Update(customer);
+
+            var updatedCustomer = transaction.Query<Customer>().Where(c => c.FirstName == "FirstName").ToArray().Single();
+
+            customer.RowVersion.Should().NotEqual(updatedCustomer.RowVersion);
+        }
+
+        [Test]
+        public void DetectsPartiallyPopulatedDocuments()
+        {
+            var customer = new Customer {FirstName = "FirstName", LastName = "LastName", Nickname = "NickName"};
+            RunInTransaction(transaction => transaction.Insert(customer));
+
+            customer.FirstName = "FirstName1";
+            Action invalidUpdate = () => RunInTransaction(transaction => transaction.Update(customer));
+            invalidUpdate.ShouldThrow<InvalidDataException>();
+        }
+
+        [Test]
+        public void FailsUpdateWhenDataBecomesStale()
+        {
+            RunInTransaction(transaction =>
+            {
+                transaction.Insert( new Customer {FirstName = "FirstName", LastName = "LastName", Nickname = "NickName"});
+            });
+
+            var customer1 = RunInTransaction(transaction => transaction.Query<Customer>().Where(c => c.FirstName == "FirstName").ToArray().Single());
+            var customer2 = RunInTransaction(transaction => transaction.Query<Customer>().Where(c => c.FirstName == "FirstName").ToArray().Single());
+
+            customer1.LastName = "LastName1";
+            RunInTransaction(transaction => transaction.Update(customer1));
+
+            customer2.LastName = "LastName2";
+            Action invalidUpdate = () => RunInTransaction(transaction => transaction.Update(customer2));
+
+            invalidUpdate.ShouldThrow<StaleDataException>();
+        }
+
+        TResult RunInTransaction<TResult>(Func<IRelationalTransaction, TResult> func)
+        {
+            using var transaction = Store.BeginTransaction();
+            var result =  func(transaction);
+            transaction.Commit();
+
+            return result;
+        }
+
+        void RunInTransaction(Action<IRelationalTransaction> action)
+        {
+            RunInTransaction(transaction =>
+            {
+                action(transaction);
+                return string.Empty;
+            });
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
+++ b/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
@@ -94,6 +94,20 @@ namespace Nevermore.IntegrationTests.Advanced
         }
 
         [Test]
+        public void HandlesUniqueConstraint()
+        {
+            NoMonkeyBusiness();
+
+            var document1 = new DocumentWithRowVersion {Name = "Name"};
+            RunInTransaction(transaction => transaction.Insert( document1));
+
+            var document2 = new DocumentWithRowVersion {Name = "Name"};
+            Action invalidUpdate = () => RunInTransaction(transaction => transaction.Insert(document2));
+
+            invalidUpdate.ShouldThrow<UniqueConstraintViolationException>();
+        }
+
+        [Test]
         public void DoesNotAffectNonVersionedDocuments()
         {
             var machine = new Machine()

--- a/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
+++ b/source/Nevermore.IntegrationTests/Advanced/RowVersionFixture .cs
@@ -39,7 +39,6 @@ namespace Nevermore.IntegrationTests.Advanced
             customer2.RowVersion.Should().Equal(insertedCustomer2.RowVersion);
         }
 
-
         [Test]
         public void RefreshesRowVersion()
         {

--- a/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommand.cs
+++ b/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommand.cs
@@ -19,8 +19,8 @@ namespace Nevermore.IntegrationTests.Chaos
 
         void MakeSomeChaos()
         {
-            if (Debugger.IsAttached) return; // No chaos when debugging thanks!
-            if (ChaosGenerator.NextDouble() < chaosFactor) throw new TimeoutException("You made the chaos monkey angry...");
+           // if (Debugger.IsAttached) return; // No chaos when debugging thanks!
+           // if (ChaosGenerator.NextDouble() < chaosFactor) throw new TimeoutException("You made the chaos monkey angry...");
         }
 
         public override void Cancel()

--- a/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommand.cs
+++ b/source/Nevermore.IntegrationTests/Chaos/ChaosSqlCommand.cs
@@ -19,8 +19,8 @@ namespace Nevermore.IntegrationTests.Chaos
 
         void MakeSomeChaos()
         {
-           // if (Debugger.IsAttached) return; // No chaos when debugging thanks!
-           // if (ChaosGenerator.NextDouble() < chaosFactor) throw new TimeoutException("You made the chaos monkey angry...");
+            if (Debugger.IsAttached) return; // No chaos when debugging thanks!
+            if (ChaosGenerator.NextDouble() < chaosFactor) throw new TimeoutException("You made the chaos monkey angry...");
         }
 
         public override void Cancel()

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -17,6 +17,5 @@ namespace Nevermore.IntegrationTests.Model
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }
         public string[] Passphrases { get; set; }
-        public byte[] RowVersion { get; set; }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -11,7 +11,7 @@ namespace Nevermore.IntegrationTests.Model
             Column(m => m.LastName).MaxLength(50);
             Column(m => m.Nickname);
             Column(m => m.Roles);
-            Column(m => m.RowVersion).RowVersion();
+            RowVersion(m => m.RowVersion);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -11,7 +11,6 @@ namespace Nevermore.IntegrationTests.Model
             Column(m => m.LastName).MaxLength(50);
             Column(m => m.Nickname);
             Column(m => m.Roles);
-            RowVersion(m => m.RowVersion);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -11,7 +11,7 @@ namespace Nevermore.IntegrationTests.Model
             Column(m => m.LastName).MaxLength(50);
             Column(m => m.Nickname);
             Column(m => m.Roles);
-            Column(m => m.RowVersion).LoadOnly();
+            Column(m => m.RowVersion).RowVersion();
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
         }
     }

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersion.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersion.cs
@@ -1,0 +1,9 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithRowVersion
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersion.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersion.cs
@@ -4,6 +4,7 @@ namespace Nevermore.IntegrationTests.Model
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public string SomeOtherProperty { get; set; }
         public byte[] RowVersion { get; set; }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersionMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersionMap.cs
@@ -7,7 +7,9 @@ namespace Nevermore.IntegrationTests.Model
         public DocumentWithRowVersionMap()
         {
             Id().MaxLength(100);
+            Column(m => m.Name).MaxLength(100);
             RowVersion(m => m.RowVersion);
+            Unique($"Unique{nameof(DocumentWithRowVersion)}Name", new[] { "Name" }, "Documents must have unique names");
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersionMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithRowVersionMap.cs
@@ -1,0 +1,13 @@
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithRowVersionMap : DocumentMap<DocumentWithRowVersion>
+    {
+        public DocumentWithRowVersionMap()
+        {
+            Id().MaxLength(100);
+            RowVersion(m => m.RowVersion);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -131,7 +131,7 @@ namespace Nevermore.IntegrationTests
                             lines[2].Product is SpecialProduct sp && sp.BonusMaterial == "Out-takes");
             }
         }
-        
+
         [Test]
         public void ShouldAllowNoPrefixOnProjectionMapping()
         {
@@ -175,7 +175,7 @@ namespace Nevermore.IntegrationTests
 
             product.Id.Should().Be("Products-1");
         }
-        
+
         [Test]
         public void ShouldInsertManyRecordsWithInsertMany()
         {
@@ -231,19 +231,6 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
-        public void ShouldHandleRowVersionColumn()
-        {
-            using (var transaction = Store.BeginTransaction())
-            {
-                var customer1 = new Customer {FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
-                transaction.Insert(customer1); // customer has a RowVersion column, but would have an error when inserting if the ReadOnly mapping was ignored
-                var dbCustomer = transaction.Query<Customer>().Where(c => c.Id == customer1.Id).ToList().Single();
-                dbCustomer.RowVersion.Length.Should().Be(8);
-                dbCustomer.RowVersion.All(v => v == 0).Should().BeFalse();
-            }
-        }
-        
-        [Test]
         public void ShouldPersistAndLoadReferenceCollectionsOnSingleDocuments()
         {
             var customerId = string.Empty;
@@ -260,8 +247,8 @@ namespace Nevermore.IntegrationTests
                 loadedCustomer.Roles.Count.Should().Be(2);
             }
         }
-        
-        
+
+
         [Test]
         public void ShouldUseIdPassedInToInsertMethod()
         {

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -12,7 +12,7 @@ namespace Nevermore.IntegrationTests.SetUp
     public abstract class FixtureWithRelationalStore : FixtureWithDatabase
     {
         bool resetBetweenTests = true;
-        
+
         protected FixtureWithRelationalStore()
         {
             var config = new RelationalStoreConfiguration(ConnectionString);
@@ -29,29 +29,31 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithStringIdMap(),
                 new MessageWithIntIdMap(),
                 new MessageWithLongIdMap(),
-                new MessageWithGuidIdMap());
-            
+                new MessageWithGuidIdMap(),
+                new DocumentWithRowVersionMap());
+
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
             config.InstanceTypeResolvers.Register(new BrandTypeResolver());
-            
+
             config.UseJsonNetSerialization(settings =>
             {
                 settings.ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor;
             });
-            
+
             GenerateSchemaAutomatically(
-                new OrderMap(), 
+                new OrderMap(),
                 new ProductMap(),
-                new CustomerMap(), 
-                new LineItemMap(), 
-                new BrandMap(), 
+                new CustomerMap(),
+                new LineItemMap(),
+                new BrandMap(),
                 new MachineMap(),
                 new MessageWithStringIdMap(),
                 new MessageWithIntIdMap(),
                 new MessageWithLongIdMap(),
-                new MessageWithGuidIdMap());
-            
+                new MessageWithGuidIdMap(),
+                new DocumentWithRowVersionMap());
+
             Store = new RelationalStore(config);
         }
 
@@ -68,12 +70,12 @@ namespace Nevermore.IntegrationTests.SetUp
         public virtual void OneTimeSetUp()
         {
         }
-        
+
         [SetUp]
         public virtual void SetUp()
         {
             if (resetBetweenTests)
-            {            
+            {
                 integrationTestDatabase.ResetBetweenTestRuns();
                 ((RelationalStore)Store).Reset();
             }
@@ -93,7 +95,7 @@ namespace Nevermore.IntegrationTests.SetUp
                 {
                     SchemaGenerator.WriteTableSchema(map.Build(), null, schema);
                 }
-                schema.AppendLine($"alter table [TestSchema].[{nameof(Customer)}] add [RowVersion] rowversion");
+                schema.AppendLine($"alter table [TestSchema].[{nameof(DocumentWithRowVersion)}] add [RowVersion] rowversion");
                 integrationTestDatabase.ExecuteScript(schema.ToString());
             }
             catch (Exception ex)

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -95,7 +95,7 @@ namespace Nevermore.IntegrationTests.SetUp
                 {
                     SchemaGenerator.WriteTableSchema(map.Build(), null, schema);
                 }
-                schema.AppendLine($"alter table [TestSchema].[{nameof(DocumentWithRowVersion)}] add [RowVersion] rowversion");
+                schema.AppendLine($"ALTER TABLE [TestSchema].[{nameof(DocumentWithRowVersion)}] ADD [RowVersion] rowversion");
                 integrationTestDatabase.ExecuteScript(schema.ToString());
             }
             catch (Exception ex)

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=Doc-1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
 (@0__Id, @0__AColumn, @0__JSON)
 ,(@1__Id, @1__AColumn, @1__JSON)
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=SuppliedId

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn]) OUTPUT inserted.RowVersion VALUES 
 (@AColumn)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.Update.approved.txt
@@ -1,4 +1,4 @@
-UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id AND [RowVersion] = @RowVersion
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON OUTPUT inserted.RowVersion WHERE [Id] = @Id AND [RowVersion] = @RowVersion
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
@@ -1,4 +1,4 @@
-UPDATE [dbo].[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id AND [RowVersion] = @RowVersion
+UPDATE [dbo].[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON OUTPUT inserted.RowVersion WHERE [Id] = @Id AND [RowVersion] = @RowVersion
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithHint.approved.txt
@@ -1,4 +1,5 @@
-UPDATE [dbo].[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id
+UPDATE [dbo].[TestDocumentTbl] WITH (NO LOCK) SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id AND [RowVersion] = @RowVersion
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue
+@RowVersion=0

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithRoWVersion.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithRoWVersion.approved.txt
@@ -1,4 +1,4 @@
-UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [Id] = @Id AND [RowVersion] = @RowVersion
+UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON OUTPUT inserted.RowVersion WHERE [Id] = @Id AND [RowVersion] = @RowVersion
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithRoWVersion.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithRoWVersion.approved.txt
@@ -2,4 +2,4 @@ UPDATE [dbo].[TestDocumentTbl]  SET [AColumn] = @AColumn, [JSON] = @JSON WHERE [
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}
 @AColumn=AValue
-@RowVersion=0
+@RowVersion=1

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -391,7 +391,7 @@ namespace Nevermore.Tests.Util
                 TableName = "TestDocumentTbl";
                 Column(t => t.AColumn);
                 Column(t => t.ReadOnly).LoadOnly();
-                Column(t => t.RowVersion).RowVersion();
+                RowVersion(t => t.RowVersion);
             }
         }
 

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -30,7 +30,7 @@ namespace Nevermore.Tests.Util
                 new OtherMap());
             builder = new DataModificationQueryBuilder(
                 configuration,
-                m => idAllocator() 
+                m => idAllocator()
             );
         }
 
@@ -72,13 +72,13 @@ namespace Nevermore.Tests.Util
                 new InsertOptions
                 {
                     TableName ="AltTableName",
-                    Hint ="WITH (NOLOCK)" 
+                    Hint ="WITH (NOLOCK)"
                 }
             );
 
             this.Assent(Format(result));
         }
-        
+
         [Test]
         public void InsertWithoutDefaultColumns()
         {
@@ -127,7 +127,7 @@ namespace Nevermore.Tests.Util
 
             this.Assent(Format(result));
         }
-        
+
         [Test]
         public void InsertMultipleDocuments()
         {
@@ -193,10 +193,10 @@ namespace Nevermore.Tests.Util
         {
             int n = 0;
             var document = new TestDocument {AColumn = "AValue", NotMapped = "NonMappedValue", Id = "Doc-1", ReadOnly = "Value"};
-            
+
             idAllocator = () => "New-Id-" + (++n);
             var result = builder.PrepareInsert(new [] { document });
-            
+
             this.Assent(Format(result));
         }
 
@@ -224,7 +224,17 @@ namespace Nevermore.Tests.Util
 
             this.Assent(Format(result));
         }
-  
+
+        [Test]
+        public void UpdateWithRoWVersion()
+        {
+            var document = new TestDocument {AColumn = "AValue", NotMapped = "NonMappedValue", Id = "Doc-1", RowVersion = 1};
+
+            var result = builder.PrepareUpdate(document);
+
+            this.Assent(Format(result));
+        }
+
         [Test]
         public void UpdateWithNoRelatedDocuments()
         {
@@ -341,6 +351,7 @@ namespace Nevermore.Tests.Util
             public string AColumn { get; set; }
             public string NotMapped { get; set; }
             public string ReadOnly { get; set; }
+            public int RowVersion { get; set; }
         }
 
         class TestDocumentWithRelatedDocuments
@@ -380,6 +391,7 @@ namespace Nevermore.Tests.Util
                 TableName = "TestDocumentTbl";
                 Column(t => t.AColumn);
                 Column(t => t.ReadOnly).LoadOnly();
+                Column(t => t.RowVersion).RowVersion();
             }
         }
 

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -107,19 +107,19 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class 
+        public Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, string>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class 
+        public Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, int>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class 
+        public Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, long>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class 
+        public Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, Guid>(id, cancellationToken);
 
         private List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
@@ -298,23 +298,23 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<string> ids) where TDocument : class
             => LoadStream<TDocument, string>(ids);
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<int> ids) where TDocument : class
             => LoadStream<TDocument, int>(ids);
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<long> ids) where TDocument : class
             => LoadStream<TDocument, long>(ids);
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(IEnumerable<Guid> ids) where TDocument : class
             => LoadStream<TDocument, Guid>(ids);
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(params string[] ids) where TDocument : class
             => LoadStream<TDocument, string>(ids);
 
         [Pure]
@@ -322,7 +322,7 @@ namespace Nevermore.Advanced
             => LoadStream<TDocument, int>(ids);
 
         [Pure]
-        public IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class 
+        public IEnumerable<TDocument> LoadStream<TDocument>(params long[] ids) where TDocument : class
             => LoadStream<TDocument, long>(ids);
 
         [Pure]
@@ -343,19 +343,19 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class 
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadStreamAsync<TDocument, string>(ids, cancellationToken);
 
         [Pure]
-        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class 
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadStreamAsync<TDocument, int>(ids, cancellationToken);
 
         [Pure]
-        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class 
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadStreamAsync<TDocument, long>(ids, cancellationToken);
 
         [Pure]
-        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class 
+        public IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadStreamAsync<TDocument, Guid>(ids, cancellationToken);
 
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
@@ -524,6 +524,18 @@ namespace Nevermore.Advanced
             return await command.ExecuteReaderAsync(cancellationToken);
         }
 
+        protected TResult[] ReadResults<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper)
+        {
+            using var command = CreateCommand(preparedCommand);
+            return command.ReadResults(mapper);
+        }
+
+        protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper)
+        {
+            using var command = CreateCommand(preparedCommand);
+            return await command.ReadResultsAsync(mapper);
+        }
+
         PreparedCommand PrepareLoad<TDocument, TKey>(TKey id)
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
@@ -586,7 +598,7 @@ namespace Nevermore.Advanced
             foreach (var command in copy)
                 sb.AppendLine(command);
         }
-         
+
         void LogBasedOnCommand(long duration, PreparedCommand command)
         {
             switch (command.Operation)

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -36,8 +36,8 @@ namespace Nevermore.Advanced
             var command = builder.PrepareInsert(new[] {document}, options);
             configuration.Hooks.BeforeInsert(document, command.Mapping, this);
 
-            var newRowVersions = ExecuteSingleDataModification(command);
-            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersions);
+            var newRowVersion = ExecuteSingleDataModification(command);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
 
             configuration.Hooks.AfterInsert(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -37,7 +37,7 @@ namespace Nevermore.Advanced
             configuration.Hooks.BeforeInsert(document, command.Mapping, this);
 
             var newRowVersions = ExecuteSingleDataModification(command);
-            AssertModificationHasBeenSuccessful(document, command.Mapping, newRowVersions);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersions);
 
             configuration.Hooks.AfterInsert(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -54,7 +54,7 @@ namespace Nevermore.Advanced
             await configuration.Hooks.BeforeInsertAsync(document, command.Mapping, this);
 
             var newRowVersion = await ExecuteSingleDataModificationAsync(command, cancellationToken);
-            AssertModificationHasBeenSuccessful(document, command.Mapping, newRowVersion);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
 
             await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -69,7 +69,7 @@ namespace Nevermore.Advanced
             foreach (var document in documents) configuration.Hooks.BeforeInsert(document, command.Mapping, this);
 
             var newRowVersions = ExecuteDataModification(command);
-            AssertModificationsHaveBeenSuccessful(documentList, command.Mapping, newRowVersions);
+            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, newRowVersions);
 
             foreach (var document in documentList) configuration.Hooks.AfterInsert(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, documentList);
@@ -90,7 +90,7 @@ namespace Nevermore.Advanced
             foreach (var document in documentList) await configuration.Hooks.BeforeInsertAsync(document, command.Mapping, this);
 
             var newRowVersions = await ExecuteDataModificationAsync(command, cancellationToken);
-            AssertModificationsHaveBeenSuccessful(documentList, command.Mapping, newRowVersions);
+            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, newRowVersions);
 
             foreach (var document in documentList) await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
 
@@ -103,7 +103,7 @@ namespace Nevermore.Advanced
             configuration.Hooks.BeforeUpdate(document, command.Mapping, this);
 
             var newRowVersion = ExecuteSingleDataModification(command);
-            AssertModificationHasBeenSuccessful(document, command.Mapping, newRowVersion);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
 
             configuration.Hooks.AfterUpdate(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -120,7 +120,7 @@ namespace Nevermore.Advanced
             await configuration.Hooks.BeforeUpdateAsync(document, command.Mapping, this);
 
             var newRowVersion = await ExecuteSingleDataModificationAsync(command, cancellationToken);
-            AssertModificationHasBeenSuccessful(document, command.Mapping, newRowVersion);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
 
             await configuration.Hooks.AfterUpdateAsync(document, command.Mapping, this);
         }
@@ -244,7 +244,7 @@ namespace Nevermore.Advanced
                 ExecuteNonQuery(command);
                 return Array.Empty<object>();
             }
-            
+
             var newRowVersions = new List<object>();
             using (var reader = ExecuteReader(command))
             {
@@ -289,17 +289,17 @@ namespace Nevermore.Advanced
             return result.SingleOrDefault();
         }
 
-        void AssertModificationsHaveBeenSuccessful(IReadOnlyList<object> documentList, DocumentMap mapping, object[] newRowVersions)
+        void ApplyNewRowVersionsIfRequired(IReadOnlyList<object> documentList, DocumentMap mapping, object[] newRowVersions)
         {
             if (!mapping.IsRowVersioningEnabled) return;
 
             for (var i = 0; i < documentList.Count; i++)
             {
-                AssertModificationHasBeenSuccessful(documentList[i], mapping, newRowVersions[i]);
+                ApplyNewRowVersionIfRequired(documentList[i], mapping, newRowVersions[i]);
             }
         }
 
-        void AssertModificationHasBeenSuccessful<TDocument>(TDocument document, DocumentMap mapping, object newRowVersion) where TDocument : class
+        void ApplyNewRowVersionIfRequired<TDocument>(TDocument document, DocumentMap mapping, object newRowVersion) where TDocument : class
         {
             if (!mapping.IsRowVersioningEnabled) return;
 

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -245,22 +245,14 @@ namespace Nevermore.Advanced
                 return Array.Empty<object>();
             }
 
-            var newRowVersions = new List<object>();
-            using (var reader = ExecuteReader(command))
-            {
-                while (reader.Read())
-                {
-                    newRowVersions.Add(reader.GetValue(0));
-                }
-            }
-
-            return newRowVersions.ToArray();
+            //The results need to be read eagerly so errors are raised while code is still executing within CommandExecutor error handling logic
+            return ReadResults(command, reader => reader.GetValue(0));
         }
 
         object ExecuteSingleDataModification(PreparedCommand command)
         {
-            var result = ExecuteDataModification(command);
-            return result.SingleOrDefault();
+            var results = ExecuteDataModification(command);
+            return results.SingleOrDefault();
         }
 
         async Task<object[]> ExecuteDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
@@ -271,22 +263,13 @@ namespace Nevermore.Advanced
                 return Array.Empty<object>();
             }
 
-            var newRowVersions = new List<object>();
-            using (var reader = await ExecuteReaderAsync(command, cancellationToken))
-            {
-                while (await reader.ReadAsync(cancellationToken))
-                {
-                    newRowVersions.Add(reader.GetValue(0));
-                }
-            }
-
-            return newRowVersions.ToArray();
+            return await ReadResultsAsync(command, reader => reader.GetValue(0));
         }
 
         async Task<object> ExecuteSingleDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
         {
-            var result = await ExecuteDataModificationAsync(command, cancellationToken);
-            return result.SingleOrDefault();
+            var results = await ExecuteDataModificationAsync(command, cancellationToken);
+            return results.SingleOrDefault();
         }
 
         void ApplyNewRowVersionsIfRequired(IReadOnlyList<object> documentList, DocumentMap mapping, object[] newRowVersions)

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -244,7 +244,7 @@ namespace Nevermore.Advanced
                 ExecuteNonQuery(command);
                 return Array.Empty<object>();
             }
-
+            
             var newRowVersions = new List<object>();
             using (var reader = ExecuteReader(command))
             {

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -14,9 +14,9 @@ namespace Nevermore
         /// <see cref="M:Insert" /> returns. To assign your own ID, use the <paramref name="options"/> parameter.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
-        /// <param name="instance">The document instance to insert.</param>
+        /// <param name="document">The document instance to insert.</param>
         /// <param name="options">Advanced options for the insert operation.</param>
-        void Insert<TDocument>(TDocument instance, InsertOptions options = null) where TDocument : class;
+        void Insert<TDocument>(TDocument document, InsertOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Immediately inserts a new item into the default table for the document type. The item will have an automatically
@@ -24,9 +24,9 @@ namespace Nevermore
         /// <see cref="M:Insert" /> returns.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
-        /// <param name="instance">The document instance to insert.</param>
+        /// <param name="document">The document instance to insert.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task InsertAsync<TDocument>(TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
+        Task InsertAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Immediately inserts a new item into the default table for the document type. The item will have an automatically
@@ -34,10 +34,10 @@ namespace Nevermore
         /// <see cref="M:Insert" /> returns. To assign your own ID, use the <paramref name="options"/> parameter.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
-        /// <param name="instance">The document instance to insert.</param>
+        /// <param name="document">The document instance to insert.</param>
         /// <param name="options">Advanced options for the insert operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task InsertAsync<TDocument>(TDocument instance, InsertOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+        Task InsertAsync<TDocument>(TDocument document, InsertOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Immediately inserts multiple items into a specific table. Useful for up to a few hundred items, but not more

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -10,7 +10,6 @@ namespace Nevermore.Mapping
         const int DefaultMaxForeignKeyIdLength = 50;
         ColumnDirection direction;
         int? maxLength;
-        bool rowVersion = false;
 
         internal ColumnMapping(string columnName, Type type, IPropertyHandler handler, PropertyInfo property)
         {
@@ -38,7 +37,6 @@ namespace Nevermore.Mapping
 
         public int? MaxLength => maxLength;
         public ColumnDirection Direction => direction;
-        public bool RowVersion => rowVersion;
 
         IColumnMappingBuilder IColumnMappingBuilder.MaxLength(int max)
         {
@@ -58,12 +56,6 @@ namespace Nevermore.Mapping
             return this;
         }
 
-        IColumnMappingBuilder IColumnMappingBuilder.RowVersion()
-        {
-            rowVersion = true;
-            return ((IColumnMappingBuilder)this).LoadOnly();
-        }
-
         IColumnMappingBuilder IColumnMappingBuilder.CustomPropertyHandler(IPropertyHandler propertyHandler)
         {
             PropertyHandler = propertyHandler;
@@ -81,11 +73,6 @@ namespace Nevermore.Mapping
                 }
 
                 throw new InvalidOperationException($"The mapping for column '{ColumnName}' uses a property handler that returned false for CanWrite, and yet the column is declared as being both loaded from and saved to the database. Use `SaveOnly` if this column is intended to be saved, but not loaded from the database.");
-            }
-
-            if (rowVersion && direction != ColumnDirection.FromDatabase)
-            {
-                throw new InvalidOperationException($"The mapping for column '{ColumnName}' is invalid. Property declared as `RowVersion()` is not writable.");
             }
         }
     }

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -316,6 +316,8 @@ namespace Nevermore.Mapping
         public List<RelatedDocumentsMapping> RelatedDocumentsMappings { get; }
         public string SchemaName { get; set; }
 
+        public bool IsRowVersioningEnabled => RowVersionColumn != null;
+
         public void Validate()
         {
             if (IdColumn == null)

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reflection;
-using Nevermore.Advanced;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.Advanced.PropertyHandlers;
 
@@ -16,7 +14,7 @@ namespace Nevermore.Mapping
         protected DocumentMap()
         {
         }
-        
+
         /// <summary>
         /// Gets or sets the name of the schema containing the table that this document will be stored in.
         /// </summary>
@@ -53,7 +51,7 @@ namespace Nevermore.Mapping
             get => map.IdFormat;
             set => map.IdFormat = value;
         }
-        
+
         /// <summary>
         /// Tells Nevermore whether to expect large documents or not. Defaults to false, since most tables tend to only
         /// have small documents. However, this property is self-tuning: if Nevermore reads or writes a document
@@ -73,7 +71,7 @@ namespace Nevermore.Mapping
             get => map.JsonStorageFormat;
             set => map.JsonStorageFormat = value;
         }
-        
+
         /// <summary>
         /// Configures the ID of the document.
         /// </summary>
@@ -82,7 +80,7 @@ namespace Nevermore.Mapping
         {
             return map.IdColumn;
         }
-        
+
         /// <summary>
         /// Configures the ID of the document.
         /// </summary>
@@ -137,7 +135,7 @@ namespace Nevermore.Mapping
                        ?? throw new Exception("The expression for the Type Resolution column must be a property.");
             map.TypeResolutionColumn = new ColumnMapping(columnName ?? prop.Name, typeof(TProperty), new PropertyHandler(prop), prop);
             map.Columns.Add(map.TypeResolutionColumn);
-            return map.TypeResolutionColumn; 
+            return map.TypeResolutionColumn;
         }
 
         /// <summary>
@@ -249,7 +247,7 @@ namespace Nevermore.Mapping
             map.UniqueConstraints.Add(unique);
             return unique;
         }
-        
+
         static DocumentMap InitializeDefault()
         {
             return new DocumentMap
@@ -285,7 +283,7 @@ namespace Nevermore.Mapping
     public class DocumentMap
     {
         public const string RelatedDocumentTableName = "RelatedDocument";
-        
+
         public DocumentMap()
         {
             Columns = new List<ColumnMapping>();
@@ -319,7 +317,7 @@ namespace Nevermore.Mapping
 
             if (TypeResolutionColumn != null && JsonStorageFormat == JsonStorageFormat.NoJson)
                 throw new InvalidOperationException($"The document map for type {Type.FullName} has a TypeColumn, but also uses the NoJson storage mode, which is not allowed.");
-            
+
             try
             {
                 foreach (var column in Columns)
@@ -335,7 +333,7 @@ namespace Nevermore.Mapping
         {
             if (document == null)
                 return null;
-            
+
             var readerWriter = IdColumn.PropertyHandler;
             return readerWriter.Read(document);
         }

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -149,6 +149,11 @@ namespace Nevermore.Mapping
             return Column(null, getter, null);
         }
 
+        protected void RowVersion<TProperty>(Expression<Func<TDocument, TProperty>> getter)
+        {
+            map.RowVersionColumn = (ColumnMapping)Column(null, getter, null).LoadOnly();
+        }
+
         /// <summary>
         /// Defines a column. The column name will be the name of the property.
         /// </summary>
@@ -294,6 +299,7 @@ namespace Nevermore.Mapping
 
         public Type Type { get; set; }
         public ColumnMapping IdColumn { get; set; }
+        public ColumnMapping RowVersionColumn { get; set; }
         public ColumnMapping TypeResolutionColumn { get; set; }
         public JsonStorageFormat JsonStorageFormat { get; set; }
         public string TableName { get; set; }

--- a/source/Nevermore/Mapping/IColumnMappingBuilder.cs
+++ b/source/Nevermore/Mapping/IColumnMappingBuilder.cs
@@ -5,19 +5,25 @@ namespace Nevermore.Mapping
     public interface IColumnMappingBuilder
     {
         IColumnMappingBuilder MaxLength(int max);
-        
+
         /// <summary>
-        /// Nevermore will read values from the database and set them on this property, but will not include this proprty
+        /// Nevermore will read values from the database and set them on this property, but will not include this property
         /// when performing updates or inserts. Useful for things like computed columns, rowversion, and so on.
         /// </summary>
         IColumnMappingBuilder LoadOnly();
-        
+
         /// <summary>
         /// Nevermore will read this property and write the values to the database, but when reading, won't attempt to
         /// set this property (perhaps it has no public setter). Useful for things like calculated properties that return
         /// a value, but don't make sense to set when querying the database.
         /// </summary>
         IColumnMappingBuilder SaveOnly();
+
+        /// <summary>
+        /// Nevermore will read values from the database and set them on this property. This property will be used
+        /// when performing updates to make sure the data in the database hasn't changed.
+        /// </summary>
+        IColumnMappingBuilder RowVersion();
 
         /// <summary>
         /// Nevermore will build an expression to read and write the property automatically. However, you can override

--- a/source/Nevermore/Mapping/IColumnMappingBuilder.cs
+++ b/source/Nevermore/Mapping/IColumnMappingBuilder.cs
@@ -20,12 +20,6 @@ namespace Nevermore.Mapping
         IColumnMappingBuilder SaveOnly();
 
         /// <summary>
-        /// Nevermore will read values from the database and set them on this property. This property will be used
-        /// when performing updates to make sure the data in the database hasn't changed.
-        /// </summary>
-        IColumnMappingBuilder RowVersion();
-
-        /// <summary>
         /// Nevermore will build an expression to read and write the property automatically. However, you can override
         /// this behavior with your own property handler. Keep in mind that if you want to control how a type is mapped
         /// from the database to a .NET object, you might want to use a <see cref="ITypeHandler"/> instead.

--- a/source/Nevermore/StaleDataException.cs
+++ b/source/Nevermore/StaleDataException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Nevermore
+{
+    public class StaleDataException : Exception
+    {
+        public StaleDataException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -78,11 +78,11 @@ namespace Nevermore.Util
             }
 
             var rowVersionCheckStatement = mapping.IsRowVersioningEnabled ? $" AND [{mapping.RowVersionColumn.ColumnName}] = @{mapping.RowVersionColumn.ColumnName}" : string.Empty;
-            var returnRowVersionStatement = mapping.IsRowVersioningEnabled ? $"OUTPUT inserted.{mapping.RowVersionColumn.ColumnName}" : string.Empty;
+            var returnRowVersionStatement = mapping.IsRowVersioningEnabled ? $" OUTPUT inserted.{mapping.RowVersionColumn.ColumnName}" : string.Empty;
 
             var updates = string.Join(", ", updateStatements);
 
-            var statement = $"UPDATE [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] {options.Hint ?? ""} SET {updates} {returnRowVersionStatement} WHERE [{mapping.IdColumn.ColumnName}] = @{mapping.IdColumn.ColumnName}{rowVersionCheckStatement}";
+            var statement = $"UPDATE [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] {options.Hint ?? ""} SET {updates}{returnRowVersionStatement} WHERE [{mapping.IdColumn.ColumnName}] = @{mapping.IdColumn.ColumnName}{rowVersionCheckStatement}";
 
             var parameters = GetDocumentParameters(
                 m => throw new Exception("Cannot update a document if it does not have an ID"),
@@ -208,9 +208,9 @@ namespace Nevermore.Util
             var actualTableName = tableName ?? mapping.TableName;
             var actualSchemaName = schemaName ?? configuration.GetSchemaNameOrDefault(mapping);
 
-            var returnRowVersionStatement = mapping.IsRowVersioningEnabled ? $"OUTPUT inserted.{mapping.RowVersionColumn.ColumnName}" : string.Empty;
+            var returnRowVersionStatement = mapping.IsRowVersioningEnabled ? $" OUTPUT inserted.{mapping.RowVersionColumn.ColumnName}" : string.Empty;
 
-            sb.AppendLine($"INSERT INTO [{actualSchemaName}].[{actualTableName}] {tableHint} ({columnNames}) {returnRowVersionStatement} VALUES ");
+            sb.AppendLine($"INSERT INTO [{actualSchemaName}].[{actualTableName}] {tableHint} ({columnNames}){returnRowVersionStatement} VALUES ");
 
             void Append(string prefix)
             {

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Nevermore.Advanced;
@@ -40,7 +41,7 @@ namespace Nevermore.Util
 
             var sb = new StringBuilder();
             AppendInsertStatement(sb, mapping, options.TableName, options.SchemaName, options.Hint, documents.Count, options.IncludeDefaultModelColumns);
-            var parameters = GetDocumentParameters(m => keyAllocator(m), options.CustomAssignedId, documents, mapping);
+            var parameters = GetDocumentParameters(m => keyAllocator(m), options.CustomAssignedId, documents, mapping, DataModification.Insert);
 
             AppendRelatedDocumentStatementsForInsert(sb, parameters, mapping, documents);
             return new PreparedCommand(sb.ToString(), parameters, RetriableOperation.Insert, mapping, options.CommandTimeout);
@@ -49,7 +50,7 @@ namespace Nevermore.Util
         public PreparedCommand PrepareUpdate(object document, UpdateOptions options = null)
         {
             options ??= UpdateOptions.Default;
-            
+
             var mapping = mappings.Resolve(document.GetType());
 
             var updateStatements = mapping.WritableIndexedColumns().Select(c => $"[{c.ColumnName}] = @{c.ColumnName}").ToList();
@@ -75,17 +76,22 @@ namespace Nevermore.Util
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            
+
+            var whereStatements = new List<string> {$"[{mapping.IdColumn.ColumnName}] = @{mapping.IdColumn.ColumnName}"};
+            whereStatements.AddRange(mapping.RowVersionColumns().Select(dvc => $"[{dvc.ColumnName}] = @{dvc.ColumnName}"));
+
             var updates = string.Join(", ", updateStatements);
-            
-            var statement = $"UPDATE [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] {options.Hint ?? ""} SET {updates} WHERE [{mapping.IdColumn.ColumnName}] = @{mapping.IdColumn.ColumnName}";
+            var wheres = string.Join(" AND ", whereStatements);
+
+            var statement = $"UPDATE [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] {options.Hint ?? ""} SET {updates} WHERE {wheres}";
 
             var parameters = GetDocumentParameters(
                 m => throw new Exception("Cannot update a document if it does not have an ID"),
                 null,
                 null,
                 document,
-                mapping
+                mapping,
+                DataModification.Update
             );
 
             statement = AppendRelatedDocumentStatementsForUpdate(statement, parameters, mapping, document);
@@ -102,11 +108,11 @@ namespace Nevermore.Util
         public PreparedCommand PrepareDelete<TDocument>(object id, DeleteOptions options = null) where TDocument : class
         {
             var mapping = mappings.Resolve(typeof(TDocument));
-            
+
             var idType = id.GetType();
             if (mapping.IdColumn.Type != idType)
                 throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
-            
+
             return PrepareDelete(mapping, id, options);
         }
 
@@ -174,12 +180,12 @@ namespace Nevermore.Util
         void AppendInsertStatement(StringBuilder sb, DocumentMap mapping, string tableName, string schemaName, string tableHint, int numberOfInstances, bool includeDefaultModelColumns)
         {
             var columns = new List<string>();
-            
-            if (includeDefaultModelColumns) 
+
+            if (includeDefaultModelColumns)
                 columns.Add(mapping.IdColumn.ColumnName);
-            
+
             columns.AddRange(mapping.WritableIndexedColumns().Select(c => c.ColumnName));
-            
+
             if (includeDefaultModelColumns)
             {
                 switch (mapping.JsonStorageFormat)
@@ -226,15 +232,15 @@ namespace Nevermore.Util
             }
         }
 
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping)
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, IReadOnlyList<object> documents, DocumentMap mapping, DataModification dataModification)
         {
             if (documents.Count == 1)
-                return GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue, documents[0], mapping, "");
+                return GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue, documents[0], mapping, dataModification, "");
 
             var parameters = new CommandParameterValues();
             for (var x = 0; x < documents.Count; x++)
             {
-                var instanceParameters = GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.IgnoreCustomIdIfIdAlreadySet, documents[x], mapping, $"{x}__");
+                var instanceParameters = GetDocumentParameters(allocateId, customAssignedId, CustomIdAssignmentBehavior.IgnoreCustomIdIfIdAlreadySet, documents[x], mapping, dataModification, $"{x}__");
                 parameters.AddRange(instanceParameters);
             }
 
@@ -246,10 +252,17 @@ namespace Nevermore.Util
             ThrowIfIdAlreadySetToDifferentValue,
             IgnoreCustomIdIfIdAlreadySet
         }
-        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, string prefix = null)
+
+        enum DataModification
+        {
+            Insert,
+            Update
+        }
+
+        CommandParameterValues GetDocumentParameters(Func<DocumentMap, string> allocateId, object customAssignedId, CustomIdAssignmentBehavior? customIdAssignmentBehavior, object document, DocumentMap mapping, DataModification dataModification, string prefix = null)
         {
             var id = mapping.IdColumn.PropertyHandler.Read(document);
-            
+
             if (customIdAssignmentBehavior == CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue &&
                 customAssignedId != null && id != null && customAssignedId != id)
                 throw new ArgumentException("Do not pass a different Id when one is already set on the document");
@@ -287,7 +300,7 @@ namespace Nevermore.Util
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            
+
             foreach (var c in mapping.WritableIndexedColumns())
             {
                 var value = c.PropertyHandler.Read(document);
@@ -305,6 +318,15 @@ namespace Nevermore.Util
                 }
 
                 result[$"{prefix}{c.ColumnName}"] = value;
+            }
+
+            if (dataModification == DataModification.Update)
+            {
+                foreach (var c in mapping.RowVersionColumns())
+                {
+                    var value = c.PropertyHandler.Read(document);
+                    result[$"{prefix}{c.ColumnName}"] = value ?? throw new InvalidDataException($"'{c.Property.Name}' property is declared as RowVersion() and can't be set to null. Refresh the data and try again.");
+                }
             }
 
             return result;
@@ -398,7 +420,7 @@ namespace Nevermore.Util
             var documentAndIds = documents.Count == 1
                 ? new[] {(parentIdVariable: IdVariableName, document: documents[0])}
                 : documents.Select((i, idx) => (idVariable: $"{idx}__{IdVariableName}", document: i));
-            
+
             var groupedByTable = from m in mapping.RelatedDocumentsMappings
                 group m by new { Table = m.TableName, Schema = configuration.GetSchemaNameOrDefault(m) }
                 into g
@@ -434,10 +456,13 @@ namespace Nevermore.Util
             public string RelatedDocumentTableColumnName { get; set; }
         }
     }
-    
+
     internal static class DataModificationQueryBuilderExtensions
     {
         public static IEnumerable<ColumnMapping> WritableIndexedColumns(this DocumentMap doc) =>
             doc.Columns.Where(c => c.Direction == ColumnDirection.Both || c.Direction == ColumnDirection.ToDatabase);
+
+        public static IEnumerable<ColumnMapping> RowVersionColumns(this DocumentMap doc) =>
+            doc.Columns.Where(c => c.RowVersion);
     }
 }


### PR DESCRIPTION
# Problem #

It is possible for N > 1 independent operations to try to modify the same data at more or less the same time. 
This can lead to operations overriding each other data.

This PR adds support for [row versioning](https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver15) which will ensure that the data in the database hasn't changed since it was retrieved and the update is safe to be applied.

# Why now #

Octopus Cloud is using background tasks to managed Cloud instances.  At the moment it is possible to for N > 1 tasks to modify the data of the same instance. To prevent this from happening we are adding 2 safety nets:
1. [Tasks will need to acquire a lock before they can modify a cloud instance](https://github.com/OctopusDeploy/Octofront/pull/2636)
2. Row versioning will prevent tasks from overwriting each other data in cases when they didn't acquire a lock 

# Other #

The new code introduces additional overhead only when row versioning is enabled.



