### PR TITLE
Fixed a race condition setting the retry manager. 

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/StoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/StoreFixture.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.Transient;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class StoreFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void TransactionsCanBeOpenedInParallel()
+        {
+            // Clear the retry manager as one of the things this test tests
+            // is a race condition setting the retry manager when RetryManager.Instance is called
+            RetryManager.SetDefault(null, false);
+
+            Enumerable.Range(0, 5)
+                .AsParallel()
+                .WithDegreeOfParallelism(10)
+                .ForAll(
+                    x =>
+                    {
+                        try
+                        {
+                            using var trn = Store.BeginTransaction(name: "Transaction " + x);
+                            Console.WriteLine($"Transaction {x}: Opened");
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine($"Transaction {x}: Failed {e.Message}");
+                            throw;
+                        }
+                    }
+                );
+        }
+    }
+}

--- a/source/Nevermore/Transient/RetryManager.cs
+++ b/source/Nevermore/Transient/RetryManager.cs
@@ -12,6 +12,8 @@ namespace Nevermore.Transient
     public class RetryManager
     {
         static RetryManager defaultRetryManager;
+        static object setDefaultRetryManagerMutex = new object();
+
         readonly IDictionary<string, RetryStrategy> retryStrategies;
         readonly IDictionary<string, RetryStrategy> defaultRetryStrategiesMap;
         string defaultRetryStrategyName;
@@ -73,9 +75,10 @@ namespace Nevermore.Transient
             get
             {
                 if (defaultRetryManager == null)
-                {
-                    TransientFaultHandling.InitializeRetryManager();
-                }
+                    lock (setDefaultRetryManagerMutex)
+                        if (defaultRetryManager == null)
+                            TransientFaultHandling.InitializeRetryManager();
+
                 return defaultRetryManager;
             }
         }


### PR DESCRIPTION
This occurs when many connections are opened right after the store is created. The RetryManager will throw if one has already been set.