### PR TITLE
Correctly disposed transactions if there was an error opening them

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/RelationalTransactionRegistryFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/RelationalTransactionRegistryFixture.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class RelationalTransactionRegistryFixture : FixtureWithDatabase
+    {
+        public static IEnumerable<TestCaseData> TransactionsAreRemovedFromTheRegistryWhenThePoolIsExhaustedSource()
+        {
+
+            TestCaseData CreateAsyncCase(string testName, Func<IRelationalStore, string, Task<IDisposable>> beginTransaction)
+                => new TestCaseData(beginTransaction) {TestName = testName};
+
+            TestCaseData CreateCase(string testName, Func<IRelationalStore, string, IDisposable> beginTransaction)
+                => CreateAsyncCase(testName, (store, name) => Task.Run(() => beginTransaction(store, name)));
+
+            yield return CreateCase("BeginTransaction", (store, name) => store.BeginTransaction(name: name));
+            yield return CreateCase("BeginReadTransaction IsolationLevel overload", (store, name) => store.BeginReadTransaction(IsolationLevel.ReadUncommitted, name: name));
+            yield return CreateCase("BeginReadTransaction RetriableOperation overload", (store, name) => store.BeginReadTransaction(RetriableOperation.None, name));
+            yield return CreateCase("BeginWriteTransaction", (store, name) => store.BeginWriteTransaction(name: name));
+            yield return CreateAsyncCase("BeginReadTransactionAsync IsolationLevel overload", async (store, name) => await store.BeginReadTransactionAsync(IsolationLevel.ReadUncommitted, name: name));
+            yield return CreateAsyncCase("BeginReadTransactionAsync RetriableOperation overload", async (store, name) => await store.BeginReadTransactionAsync(RetriableOperation.None, name));
+            yield return CreateAsyncCase("BeginWriteTransaction", async (store, name) => await store.BeginWriteTransactionAsync(name: name));
+
+        }
+
+        [TestCaseSource(nameof(TransactionsAreRemovedFromTheRegistryWhenThePoolIsExhaustedSource))]
+        public async Task ExecuteTransactionsAreRemovedFromTheRegistryWhenThePoolIsExhausted(Func<RelationalStore, string, Task<IDisposable>> beingTransaction)
+        {
+            var csBuilder = new SqlConnectionStringBuilder(ConnectionString)
+            {
+                ConnectTimeout = 1,
+                MaxPoolSize = 2
+            };
+
+            var store = new RelationalStore(new RelationalStoreConfiguration(csBuilder.ConnectionString));
+
+
+            async Task<IDisposable> TryOpenConnection(int seq)
+            {
+                try
+                {
+                    var trn = await beingTransaction(store, "Transaction " + seq);
+                    Console.WriteLine($"Transaction {seq}: Opened");
+                    return trn;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Transaction {seq}: Failed {e.Message}");
+                    return null;
+                }
+            }
+
+            var transactions = await Task.WhenAll(
+                Enumerable.Range(0, 4)
+                    .Select(TryOpenConnection)
+            );
+
+            foreach (var trn in transactions)
+                trn?.Dispose();
+
+            var sb = new StringBuilder();
+            store.WriteCurrentTransactions(sb);
+            sb.ToString().Should().BeEmpty();
+        }
+    }
+}

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -33,59 +33,110 @@ namespace Nevermore
         {
             keyAllocator.Value.Reset();
         }
-        
+
         public IReadTransaction BeginReadTransaction(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open();
-            return txn;
+            try
+
+            {
+                txn.Open();
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync();
-            return txn;
+
+            try
+            {
+                await txn.OpenAsync();
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IReadTransaction BeginReadTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IWriteTransaction BeginWriteTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            txn.Open(isolationLevel);
-            return txn;
+            try
+            {
+                txn.Open(isolationLevel);
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public async Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
-            await txn.OpenAsync(isolationLevel);
-            return txn;
+            try
+            {
+                await txn.OpenAsync(isolationLevel);
+                return txn;
+            }
+            catch
+            {
+                txn.Dispose();
+                throw;
+            }
         }
 
         public IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
         {
-            return (IRelationalTransaction)BeginWriteTransaction(isolationLevel, retriableOperation, name);
+            return (IRelationalTransaction) BeginWriteTransaction(isolationLevel, retriableOperation, name);
         }
 
         ReadTransaction CreateReadTransaction(RetriableOperation retriableOperation, string name)
         {
             return new ReadTransaction(registry.Value, retriableOperation, Configuration, name);
         }
-        
+
         WriteTransaction CreateWriteTransaction(RetriableOperation retriableOperation, string name)
         {
             return new WriteTransaction(registry.Value, retriableOperation, Configuration, keyAllocator.Value, name);


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Nevermore/issues/130

This was fixed in 12.1 in #124 but not merged to `13.x`. I don't [like the change](https://github.com/OctopusDeploy/Nevermore/pull/124/files#diff-cb574f356346d8539d664d75fd6253faf8ab060fb248df62fd320b0f5842214fL51) to where the transaction is added to the registry so I intend to roll that back when I merge that branch.