### PR TITLE
Calling the PopulateRelatedDocuments hook in our UpdateAsync method

### DIFF
--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -123,6 +123,7 @@ namespace Nevermore.Advanced
             ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
 
             await configuration.Hooks.AfterUpdateAsync(document, command.Mapping, this);
+            configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
         }
 
         public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class


### PR DESCRIPTION
When we introduced async methods, we did not include the PopulateRelatedDocuments hook. This PR fills that gap so we can use async in our consumers.