### PR TITLE
Add default for TrustServerCertificate

### DIFF
--- a/source/Nevermore/Advanced/NevermoreDefaults.cs
+++ b/source/Nevermore/Advanced/NevermoreDefaults.cs
@@ -18,5 +18,7 @@ namespace Nevermore.Advanced
         public const int LargeDocumentCutoffSize = 1024;
 
         public const string FallbackDefaultSchemaName = "dbo";
+
+        public const bool DefaultTrustServerCertificate = true;
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -105,6 +105,7 @@ namespace Nevermore
             OverrideValueIfNotSet(builder, nameof(builder.ConnectTimeout), NevermoreDefaults.DefaultConnectTimeoutSeconds);
             OverrideValueIfNotSet(builder, nameof(builder.ConnectRetryCount), NevermoreDefaults.DefaultConnectRetryCount);
             OverrideValueIfNotSet(builder, nameof(builder.ConnectRetryInterval), NevermoreDefaults.DefaultConnectRetryInterval);
+            OverrideValueIfNotSet(builder, nameof(builder.TrustServerCertificate), NevermoreDefaults.DefaultTrustServerCertificate);
 
             return builder.ToString();
         }


### PR DESCRIPTION
Update to the sql client - https://github.com/OctopusDeploy/Nevermore/commit/e50e1ae73af4a4c0dec93259812965071592abf2 
introduced a [breaking change](https://github.com/dotnet/SqlClient/blob/main/release-notes/2.0/2.0.0.md#breaking-changes-1), see - [SqlClient PR]( https://github.com/dotnet/SqlClient/pull/391)

We should now set a default for `TrustServerCertificate` to `true` to address this issue - [Internal Link](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1621530394030900?thread_ts=1621530393.030800&cid=CNHBHV2BX)