### PR TITLE
Contributing guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OctopusDeploy/team-core-platform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,3 @@ Create a PR and someone from Octopus Deploy will review it.
 ### New features / architectural changes
 
 Create a new issue first and describe all relevant details there. Someone from Octopus Deploy will review it and provide feedback.
-
-Applies to Octopus Deploy employees only. Post all issues under review to #topic-nevermore and ping [Paul Stovell](https://github.com/PaulStovell) who is overseeing the overall architectural direction of this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to Nevermore
+
+:+1::tada: First off, thanks for your contribution to Nevermore! :tada::+1:
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Octopus Deploy Code of Conduct](https://github.com/OctopusDeploy/Home/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior using the instructions in the code of conduct.
+
+## Contributions
+
+### Bug fixes
+
+Create a PR and someone from Octopus Deploy will review it.
+
+### New features / architectural changes
+
+Create a new issue first and describe all relevant details there. Someone from Octopus Deploy will review it and provide feedback.
+
+Applies to Octopus Deploy employees only. Post all issues under review to #topic-nevermore and ping Paul Stovell who is overseeing the overall architectural direction of this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Create a PR and someone from Octopus Deploy will review it.
 
 Create a new issue first and describe all relevant details there. Someone from Octopus Deploy will review it and provide feedback.
 
-Applies to Octopus Deploy employees only. Post all issues under review to #topic-nevermore and ping Paul Stovell who is overseeing the overall architectural direction of this project.
+Applies to Octopus Deploy employees only. Post all issues under review to #topic-nevermore and ping [Paul Stovell](https://github.com/PaulStovell) who is overseeing the overall architectural direction of this project.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ The Wiki is the best place to get familiar with Nevermore.
 
 <img alt="Nuget" src="https://img.shields.io/nuget/v/Nevermore?label=NuGet&logo=nuget&style=flat-square">
 <img alt="TeamCity" src="https://build.octopushq.com/app/rest/builds/buildType:(id:OctopusDeploy_LIbraries_Nevermore)/statusIcon">
+
+We accept [contributions](Contributing.md)!
+


### PR DESCRIPTION
Nevermore doesn't have a contributing guide and also it wasn't clear what role Paul plays in the future of Nevermore. 
This PR tries to fill both gaps. I assumed that we do want external contributions.

Details: https://octopusdeploy.slack.com/archives/C01MSG3LZ5M/p1619682265043100

This PR is my understanding of ^ conversation. Happy to change things if I got anything wrong.