### PR TITLE
Fix SQL generation when paging with specified columns

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithMultipleSpecifiedColumns.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithMultipleSpecifiedColumns.approved.txt
@@ -1,0 +1,12 @@
+SELECT *
+FROM (
+    SELECT [Foo],
+    [Bar],
+    [Elephant],
+    ROW_NUMBER() OVER (ORDER BY [Foo]) AS RowNum
+    FROM [dbo].[Orders]
+    WHERE ([Price] > 5)
+) ALIAS_GENERATED_1
+WHERE ([RowNum] >= @_minrow)
+AND ([RowNum] <= @_maxrow)
+ORDER BY [RowNum]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithSpecifiedColumn.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithSpecifiedColumn.approved.txt
@@ -1,0 +1,10 @@
+SELECT *
+FROM (
+    SELECT [Foo],
+    ROW_NUMBER() OVER (ORDER BY [Foo]) AS RowNum
+    FROM [dbo].[Orders]
+    WHERE ([Price] > 5)
+) ALIAS_GENERATED_1
+WHERE ([RowNum] >= @_minrow)
+AND ([RowNum] <= @_maxrow)
+ORDER BY [RowNum]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithSpecifiedColumnAndNoSort.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGeneratePaginateWithSpecifiedColumnAndNoSort.approved.txt
@@ -1,0 +1,10 @@
+SELECT *
+FROM (
+    SELECT [Foo],
+    ROW_NUMBER() OVER (ORDER BY [Id]) AS RowNum
+    FROM [dbo].[Orders]
+    WHERE ([Price] > 5)
+) ALIAS_GENERATED_1
+WHERE ([RowNum] >= @_minrow)
+AND ([RowNum] <= @_maxrow)
+ORDER BY [RowNum]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -342,7 +342,49 @@ GROUP BY Agg.[SpaceId]";
             
             this.Assent(actual);
         }
-
+        
+        [Test]
+        public void ShouldGeneratePaginateWithSpecifiedColumn()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+            CreateQueryBuilder<object>("Orders")
+                .Column("Foo")
+                .Where("[Price] > 5")
+                .OrderBy("Foo")
+                .ToList(10, 20);
+            
+            this.Assent(actual);
+        }
+        
+        [Test]
+        public void ShouldGeneratePaginateWithMultipleSpecifiedColumns()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+            CreateQueryBuilder<object>("Orders")
+                .Column("Foo")
+                .Column("Bar")
+                .Column("Elephant")
+                .Where("[Price] > 5")
+                .OrderBy("Foo")
+                .ToList(10, 20);
+            
+            this.Assent(actual);
+        }
+        
+        [Test]
+        public void ShouldGeneratePaginateWithSpecifiedColumnAndNoSort()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+            CreateQueryBuilder<object>("Orders")
+                .Column("Foo")
+                .Where("[Price] > 5")
+                .ToList(10, 20);
+            
+            this.Assent(actual);
+        }
 
         [Test]
         public void ShouldGeneratePaginateForJoin()

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -424,8 +424,10 @@ namespace Nevermore.Advanced
             var maxRowParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("_maxrow"));
 
             var clonedSelectBuilder = selectBuilder.Clone();
-
-            clonedSelectBuilder.AddDefaultColumnSelection();
+            
+            if(!clonedSelectBuilder.HasCustomColumnSelection)
+                clonedSelectBuilder.AddDefaultColumnSelection();
+            
             clonedSelectBuilder.AddRowNumberColumn(rowNumberColumnName, new List<Column>());
 
             var subqueryBuilder = CreateSubqueryBuilder(clonedSelectBuilder);

--- a/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
@@ -59,6 +59,8 @@ namespace Nevermore.Advanced.SelectBuilders
         }
 
         public abstract ISelectBuilder Clone();
+        
+        public bool HasCustomColumnSelection => ColumnSelection != null;
 
         Where GetWhere()
         {

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -33,5 +33,6 @@ namespace Nevermore
         ISelect GenerateSelectWithoutDefaultOrderBy();
 
         ISelectBuilder Clone();
+        bool HasCustomColumnSelection { get; }
     }
 }


### PR DESCRIPTION
Fixes a bug with SQL generation when using specified columns.

For instance
```              
 var ids = await read.Query<Table>()
                    .Column(t => t.Id)
                    .AsType<string>()
                    .ToListAsync(skip, batchSize);
```
resulted in a SQL of 
```
SELECT *
FROM (
    SELECT [Id],
    *,
    ROW_NUMBER() OVER (ORDER BY [Id]) AS RowNum
    FROM [dbo].[Table]
) ALIAS_GENERATED_1
WHERE ([RowNum] >= @_minrow)
AND ([RowNum] <= @_maxrow)
ORDER BY [RowNum]
```
which would throw an error of
> The column 'Id' was specified multiple times for 'ALIAS_GENERATED_1'.

because we were including `*` in the subquery.

The fix is to only add the default columns if there is not already specified columns.