### PR TITLE
Fix OverrideValueIfNotSet method and move to helpers

### DIFF
--- a/source/Nevermore.Tests/RelationalStoreConfigurationFixture.cs
+++ b/source/Nevermore.Tests/RelationalStoreConfigurationFixture.cs
@@ -16,13 +16,14 @@ namespace Nevermore.Tests
             connectionStringBuilder.ConnectTimeout.Should().Be(NevermoreDefaults.DefaultConnectTimeoutSeconds);
             connectionStringBuilder.ConnectRetryCount.Should().Be(NevermoreDefaults.DefaultConnectRetryCount);
             connectionStringBuilder.ConnectRetryInterval.Should().Be(NevermoreDefaults.DefaultConnectRetryInterval);
+            connectionStringBuilder.TrustServerCertificate.Should().Be(NevermoreDefaults.DefaultTrustServerCertificate);
         }
 
         [Test]
         public void ShouldNotOverrideExplicitConnectionStringOptions()
         {
             var config =
-                new RelationalStoreConfiguration("Server=(local);Connection Timeout=123;ConnectRetryCount=123;ConnectRetryInterval=59;")
+                new RelationalStoreConfiguration("Server=(local);Connection Timeout=123;ConnectRetryCount=123;ConnectRetryInterval=59;Trust Server Certificate=False")
                 {
                     ApplicationName = "Nevermore test"
                 };
@@ -32,6 +33,7 @@ namespace Nevermore.Tests
             connectionStringBuilder.ConnectTimeout.Should().Be(123);
             connectionStringBuilder.ConnectRetryCount.Should().Be(123);
             connectionStringBuilder.ConnectRetryInterval.Should().Be(59);
+            connectionStringBuilder.TrustServerCertificate.Should().BeFalse();
         }
     }
 }

--- a/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
+++ b/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
@@ -29,52 +29,52 @@ namespace Nevermore.Advanced
         // internal static readonly DbConnectionStringKeyword NamedConnection = new DbConnectionStringKeyword("Named Connection");
 
         // SqlClient
-        internal static readonly DbConnectionStringKeyword ApplicationIntent = new DbConnectionStringKeyword("Application Intent");
-        internal static readonly DbConnectionStringKeyword ApplicationName = new DbConnectionStringKeyword("Application Name");
-        internal static readonly DbConnectionStringKeyword AsynchronousProcessing = new DbConnectionStringKeyword("Asynchronous Processing");
-        internal static readonly DbConnectionStringKeyword AttachDBFilename = new DbConnectionStringKeyword("AttachDbFilename");
-        internal static readonly DbConnectionStringKeyword CommandTimeout = new DbConnectionStringKeyword("Command Timeout");
-        internal static readonly DbConnectionStringKeyword ConnectTimeout = new DbConnectionStringKeyword("Connect Timeout");
-        internal static readonly DbConnectionStringKeyword ConnectionReset = new DbConnectionStringKeyword("Connection Reset");
-        internal static readonly DbConnectionStringKeyword ContextConnection = new DbConnectionStringKeyword("Context Connection");
-        internal static readonly DbConnectionStringKeyword CurrentLanguage = new DbConnectionStringKeyword("Current Language");
-        internal static readonly DbConnectionStringKeyword Encrypt = new DbConnectionStringKeyword("Encrypt");
-        internal static readonly DbConnectionStringKeyword FailoverPartner = new DbConnectionStringKeyword("Failover Partner");
-        internal static readonly DbConnectionStringKeyword InitialCatalog = new DbConnectionStringKeyword("Initial Catalog");
-        internal static readonly DbConnectionStringKeyword MultipleActiveResultSets = new DbConnectionStringKeyword("Multiple Active Result Sets");
-        internal static readonly DbConnectionStringKeyword MultiSubnetFailover = new DbConnectionStringKeyword("Multi Subnet Failover");
-        internal static readonly DbConnectionStringKeyword NetworkLibrary = new DbConnectionStringKeyword("Network Library");
-        internal static readonly DbConnectionStringKeyword PacketSize = new DbConnectionStringKeyword("Packet Size");
-        internal static readonly DbConnectionStringKeyword Replication = new DbConnectionStringKeyword("Replication");
-        internal static readonly DbConnectionStringKeyword TransactionBinding = new DbConnectionStringKeyword("Transaction Binding");
-        internal static readonly DbConnectionStringKeyword TrustServerCertificate = new DbConnectionStringKeyword("Trust Server Certificate");
-        internal static readonly DbConnectionStringKeyword TypeSystemVersion = new DbConnectionStringKeyword("Type System Version");
-        internal static readonly DbConnectionStringKeyword UserInstance = new DbConnectionStringKeyword("User Instance");
-        internal static readonly DbConnectionStringKeyword WorkstationID = new DbConnectionStringKeyword("Workstation ID");
-        internal static readonly DbConnectionStringKeyword ConnectRetryCount = new DbConnectionStringKeyword("Connect Retry Count");
-        internal static readonly DbConnectionStringKeyword ConnectRetryInterval = new DbConnectionStringKeyword("Connect Retry Interval");
-        internal static readonly DbConnectionStringKeyword Authentication = new DbConnectionStringKeyword("Authentication");
-        internal static readonly DbConnectionStringKeyword ColumnEncryptionSetting = new DbConnectionStringKeyword("Column Encryption Setting");
-        internal static readonly DbConnectionStringKeyword EnclaveAttestationUrl = new DbConnectionStringKeyword("Enclave Attestation Url");
-        internal static readonly DbConnectionStringKeyword AttestationProtocol = new DbConnectionStringKeyword("Attestation Protocol");
-        internal static readonly DbConnectionStringKeyword IPAddressPreference = new DbConnectionStringKeyword("IP Address Preference");
+        public static readonly DbConnectionStringKeyword ApplicationIntent = new DbConnectionStringKeyword("Application Intent");
+        public static readonly DbConnectionStringKeyword ApplicationName = new DbConnectionStringKeyword("Application Name");
+        public static readonly DbConnectionStringKeyword AsynchronousProcessing = new DbConnectionStringKeyword("Asynchronous Processing");
+        public static readonly DbConnectionStringKeyword AttachDBFilename = new DbConnectionStringKeyword("AttachDbFilename");
+        public static readonly DbConnectionStringKeyword CommandTimeout = new DbConnectionStringKeyword("Command Timeout");
+        public static readonly DbConnectionStringKeyword ConnectTimeout = new DbConnectionStringKeyword("Connect Timeout");
+        public static readonly DbConnectionStringKeyword ConnectionReset = new DbConnectionStringKeyword("Connection Reset");
+        public static readonly DbConnectionStringKeyword ContextConnection = new DbConnectionStringKeyword("Context Connection");
+        public static readonly DbConnectionStringKeyword CurrentLanguage = new DbConnectionStringKeyword("Current Language");
+        public static readonly DbConnectionStringKeyword Encrypt = new DbConnectionStringKeyword("Encrypt");
+        public static readonly DbConnectionStringKeyword FailoverPartner = new DbConnectionStringKeyword("Failover Partner");
+        public static readonly DbConnectionStringKeyword InitialCatalog = new DbConnectionStringKeyword("Initial Catalog");
+        public static readonly DbConnectionStringKeyword MultipleActiveResultSets = new DbConnectionStringKeyword("Multiple Active Result Sets");
+        public static readonly DbConnectionStringKeyword MultiSubnetFailover = new DbConnectionStringKeyword("Multi Subnet Failover");
+        public static readonly DbConnectionStringKeyword NetworkLibrary = new DbConnectionStringKeyword("Network Library");
+        public static readonly DbConnectionStringKeyword PacketSize = new DbConnectionStringKeyword("Packet Size");
+        public static readonly DbConnectionStringKeyword Replication = new DbConnectionStringKeyword("Replication");
+        public static readonly DbConnectionStringKeyword TransactionBinding = new DbConnectionStringKeyword("Transaction Binding");
+        public static readonly DbConnectionStringKeyword TrustServerCertificate = new DbConnectionStringKeyword("Trust Server Certificate");
+        public static readonly DbConnectionStringKeyword TypeSystemVersion = new DbConnectionStringKeyword("Type System Version");
+        public static readonly DbConnectionStringKeyword UserInstance = new DbConnectionStringKeyword("User Instance");
+        public static readonly DbConnectionStringKeyword WorkstationID = new DbConnectionStringKeyword("Workstation ID");
+        public static readonly DbConnectionStringKeyword ConnectRetryCount = new DbConnectionStringKeyword("Connect Retry Count");
+        public static readonly DbConnectionStringKeyword ConnectRetryInterval = new DbConnectionStringKeyword("Connect Retry Interval");
+        public static readonly DbConnectionStringKeyword Authentication = new DbConnectionStringKeyword("Authentication");
+        public static readonly DbConnectionStringKeyword ColumnEncryptionSetting = new DbConnectionStringKeyword("Column Encryption Setting");
+        public static readonly DbConnectionStringKeyword EnclaveAttestationUrl = new DbConnectionStringKeyword("Enclave Attestation Url");
+        public static readonly DbConnectionStringKeyword AttestationProtocol = new DbConnectionStringKeyword("Attestation Protocol");
+        public static readonly DbConnectionStringKeyword IPAddressPreference = new DbConnectionStringKeyword("IP Address Preference");
 
         // common keywords (OleDb, OracleClient, SqlClient)
-        internal static readonly DbConnectionStringKeyword DataSource = new DbConnectionStringKeyword("Data Source");
-        internal static readonly DbConnectionStringKeyword IntegratedSecurity = new DbConnectionStringKeyword("Integrated Security");
-        internal static readonly DbConnectionStringKeyword Password = new DbConnectionStringKeyword("Password");
-        internal static readonly DbConnectionStringKeyword Driver = new DbConnectionStringKeyword("Driver");
-        internal static readonly DbConnectionStringKeyword PersistSecurityInfo = new DbConnectionStringKeyword("Persist Security Info");
-        internal static readonly DbConnectionStringKeyword UserID = new DbConnectionStringKeyword("User ID");
+        public static readonly DbConnectionStringKeyword DataSource = new DbConnectionStringKeyword("Data Source");
+        public static readonly DbConnectionStringKeyword IntegratedSecurity = new DbConnectionStringKeyword("Integrated Security");
+        public static readonly DbConnectionStringKeyword Password = new DbConnectionStringKeyword("Password");
+        public static readonly DbConnectionStringKeyword Driver = new DbConnectionStringKeyword("Driver");
+        public static readonly DbConnectionStringKeyword PersistSecurityInfo = new DbConnectionStringKeyword("Persist Security Info");
+        public static readonly DbConnectionStringKeyword UserID = new DbConnectionStringKeyword("User ID");
 
         // managed pooling (OracleClient, SqlClient)
-        internal static readonly DbConnectionStringKeyword Enlist = new DbConnectionStringKeyword("Enlist");
-        internal static readonly DbConnectionStringKeyword LoadBalanceTimeout = new DbConnectionStringKeyword("Load Balance Timeout");
-        internal static readonly DbConnectionStringKeyword MaxPoolSize = new DbConnectionStringKeyword("Max Pool Size");
-        internal static readonly DbConnectionStringKeyword Pooling = new DbConnectionStringKeyword("Pooling");
-        internal static readonly DbConnectionStringKeyword MinPoolSize = new DbConnectionStringKeyword("Min Pool Size");
+        public static readonly DbConnectionStringKeyword Enlist = new DbConnectionStringKeyword("Enlist");
+        public static readonly DbConnectionStringKeyword LoadBalanceTimeout = new DbConnectionStringKeyword("Load Balance Timeout");
+        public static readonly DbConnectionStringKeyword MaxPoolSize = new DbConnectionStringKeyword("Max Pool Size");
+        public static readonly DbConnectionStringKeyword Pooling = new DbConnectionStringKeyword("Pooling");
+        public static readonly DbConnectionStringKeyword MinPoolSize = new DbConnectionStringKeyword("Min Pool Size");
 #if NETCOREAPP
-        internal static readonly DbConnectionStringKeyword PoolBlockingPeriod = new DbConnectionStringKeyword("Pool Blocking Period");
+        public static readonly DbConnectionStringKeyword PoolBlockingPeriod = new DbConnectionStringKeyword("Pool Blocking Period");
 #endif
     }
 }

--- a/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
+++ b/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
@@ -1,11 +1,11 @@
 using Microsoft.Data.SqlClient;
-using Octopus.TinyTypes;
 
 namespace Nevermore.Advanced
 {
     public static class SqlConnectionStringHelpers
     {
-        public static void OverrideValueIfNotSet(SqlConnectionStringBuilder connectionStringBuilder, DbConnectionStringKeyword propertyName, object overrideValue)
+        // Extension method for SqlConnectionStringBuilder to override values
+        public static void OverrideConnectionStringPropertyValueIfNotSet(this SqlConnectionStringBuilder connectionStringBuilder, DbConnectionStringKeyword propertyName, object overrideValue)
         {
             if (!connectionStringBuilder.ShouldSerialize(propertyName.Value))
             {
@@ -14,19 +14,18 @@ namespace Nevermore.Advanced
         }
     }
 
-    public class DbConnectionStringKeyword : TinyType<string>
+    public class DbConnectionStringKeyword
     {
-        public DbConnectionStringKeyword(string value) : base(value)
-        {
-        }
-    }
 
-    // https://github.com/dotnet/SqlClient/blob/5c5a15d5ac842b48c4e99bff951b026f07f1a5d3/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs#L885
-    // Updated to use TinyTypes
-    public static class DbConnectionStringKeywords
-    {
+        public string Value { get; }
+        public DbConnectionStringKeyword(string value)
+        {
+            Value = value;
+        }
+
+        // https://github.com/dotnet/SqlClient/blob/5c5a15d5ac842b48c4e99bff951b026f07f1a5d3/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs#L885
         // all
-        // internal static readonly DbConnectionStringKeyword NamedConnection = new DbConnectionStringKeyword("Named Connection");
+        // public static readonly DbConnectionStringKeyword NamedConnection = new DbConnectionStringKeyword("Named Connection");
 
         // SqlClient
         public static readonly DbConnectionStringKeyword ApplicationIntent = new DbConnectionStringKeyword("Application Intent");
@@ -77,4 +76,5 @@ namespace Nevermore.Advanced
         public static readonly DbConnectionStringKeyword PoolBlockingPeriod = new DbConnectionStringKeyword("Pool Blocking Period");
 #endif
     }
+
 }

--- a/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
+++ b/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
@@ -1,0 +1,80 @@
+using Microsoft.Data.SqlClient;
+using Octopus.TinyTypes;
+
+namespace Nevermore.Advanced
+{
+    public static class SqlConnectionStringHelpers
+    {
+        public static void OverrideValueIfNotSet(SqlConnectionStringBuilder connectionStringBuilder, DbConnectionStringKeyword propertyName, object overrideValue)
+        {
+            if (!connectionStringBuilder.ShouldSerialize(propertyName.Value))
+            {
+                connectionStringBuilder[propertyName.Value] = overrideValue;
+            }
+        }
+    }
+
+    public class DbConnectionStringKeyword : TinyType<string>
+    {
+        public DbConnectionStringKeyword(string value) : base(value)
+        {
+        }
+    }
+
+    // https://github.com/dotnet/SqlClient/blob/5c5a15d5ac842b48c4e99bff951b026f07f1a5d3/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs#L885
+    // Updated to use TinyTypes
+    public static class DbConnectionStringKeywords
+    {
+        // all
+        // internal static readonly DbConnectionStringKeyword NamedConnection = new DbConnectionStringKeyword("Named Connection");
+
+        // SqlClient
+        internal static readonly DbConnectionStringKeyword ApplicationIntent = new DbConnectionStringKeyword("Application Intent");
+        internal static readonly DbConnectionStringKeyword ApplicationName = new DbConnectionStringKeyword("Application Name");
+        internal static readonly DbConnectionStringKeyword AsynchronousProcessing = new DbConnectionStringKeyword("Asynchronous Processing");
+        internal static readonly DbConnectionStringKeyword AttachDBFilename = new DbConnectionStringKeyword("AttachDbFilename");
+        internal static readonly DbConnectionStringKeyword CommandTimeout = new DbConnectionStringKeyword("Command Timeout");
+        internal static readonly DbConnectionStringKeyword ConnectTimeout = new DbConnectionStringKeyword("Connect Timeout");
+        internal static readonly DbConnectionStringKeyword ConnectionReset = new DbConnectionStringKeyword("Connection Reset");
+        internal static readonly DbConnectionStringKeyword ContextConnection = new DbConnectionStringKeyword("Context Connection");
+        internal static readonly DbConnectionStringKeyword CurrentLanguage = new DbConnectionStringKeyword("Current Language");
+        internal static readonly DbConnectionStringKeyword Encrypt = new DbConnectionStringKeyword("Encrypt");
+        internal static readonly DbConnectionStringKeyword FailoverPartner = new DbConnectionStringKeyword("Failover Partner");
+        internal static readonly DbConnectionStringKeyword InitialCatalog = new DbConnectionStringKeyword("Initial Catalog");
+        internal static readonly DbConnectionStringKeyword MultipleActiveResultSets = new DbConnectionStringKeyword("Multiple Active Result Sets");
+        internal static readonly DbConnectionStringKeyword MultiSubnetFailover = new DbConnectionStringKeyword("Multi Subnet Failover");
+        internal static readonly DbConnectionStringKeyword NetworkLibrary = new DbConnectionStringKeyword("Network Library");
+        internal static readonly DbConnectionStringKeyword PacketSize = new DbConnectionStringKeyword("Packet Size");
+        internal static readonly DbConnectionStringKeyword Replication = new DbConnectionStringKeyword("Replication");
+        internal static readonly DbConnectionStringKeyword TransactionBinding = new DbConnectionStringKeyword("Transaction Binding");
+        internal static readonly DbConnectionStringKeyword TrustServerCertificate = new DbConnectionStringKeyword("Trust Server Certificate");
+        internal static readonly DbConnectionStringKeyword TypeSystemVersion = new DbConnectionStringKeyword("Type System Version");
+        internal static readonly DbConnectionStringKeyword UserInstance = new DbConnectionStringKeyword("User Instance");
+        internal static readonly DbConnectionStringKeyword WorkstationID = new DbConnectionStringKeyword("Workstation ID");
+        internal static readonly DbConnectionStringKeyword ConnectRetryCount = new DbConnectionStringKeyword("Connect Retry Count");
+        internal static readonly DbConnectionStringKeyword ConnectRetryInterval = new DbConnectionStringKeyword("Connect Retry Interval");
+        internal static readonly DbConnectionStringKeyword Authentication = new DbConnectionStringKeyword("Authentication");
+        internal static readonly DbConnectionStringKeyword ColumnEncryptionSetting = new DbConnectionStringKeyword("Column Encryption Setting");
+        internal static readonly DbConnectionStringKeyword EnclaveAttestationUrl = new DbConnectionStringKeyword("Enclave Attestation Url");
+        internal static readonly DbConnectionStringKeyword AttestationProtocol = new DbConnectionStringKeyword("Attestation Protocol");
+        internal static readonly DbConnectionStringKeyword IPAddressPreference = new DbConnectionStringKeyword("IP Address Preference");
+
+        // common keywords (OleDb, OracleClient, SqlClient)
+        internal static readonly DbConnectionStringKeyword DataSource = new DbConnectionStringKeyword("Data Source");
+        internal static readonly DbConnectionStringKeyword IntegratedSecurity = new DbConnectionStringKeyword("Integrated Security");
+        internal static readonly DbConnectionStringKeyword Password = new DbConnectionStringKeyword("Password");
+        internal static readonly DbConnectionStringKeyword Driver = new DbConnectionStringKeyword("Driver");
+        internal static readonly DbConnectionStringKeyword PersistSecurityInfo = new DbConnectionStringKeyword("Persist Security Info");
+        internal static readonly DbConnectionStringKeyword UserID = new DbConnectionStringKeyword("User ID");
+
+        // managed pooling (OracleClient, SqlClient)
+        internal static readonly DbConnectionStringKeyword Enlist = new DbConnectionStringKeyword("Enlist");
+        internal static readonly DbConnectionStringKeyword LoadBalanceTimeout = new DbConnectionStringKeyword("Load Balance Timeout");
+        internal static readonly DbConnectionStringKeyword MaxPoolSize = new DbConnectionStringKeyword("Max Pool Size");
+        internal static readonly DbConnectionStringKeyword Pooling = new DbConnectionStringKeyword("Pooling");
+        internal static readonly DbConnectionStringKeyword MinPoolSize = new DbConnectionStringKeyword("Min Pool Size");
+#if NETCOREAPP
+        internal static readonly DbConnectionStringKeyword PoolBlockingPeriod = new DbConnectionStringKeyword("Pool Blocking Period");
+#endif
+    }
+}

--- a/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
+++ b/source/Nevermore/Advanced/SqlConnectionStringHelpers.cs
@@ -2,7 +2,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Nevermore.Advanced
 {
-    public static class SqlConnectionStringHelpers
+    public static class SqlConnectionStringBuilderExtensions
     {
         // Extension method for SqlConnectionStringBuilder to override values
         public static void OverrideConnectionStringPropertyValueIfNotSet(this SqlConnectionStringBuilder connectionStringBuilder, DbConnectionStringKeyword propertyName, object overrideValue)

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -38,12 +38,11 @@
   <ItemGroup>
     <EmbeddedResource Include="UpgradeScripts\*.*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.539" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Octopus.TinyTypes" Version="0.1.539" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.1" />

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using Microsoft.Data.SqlClient;
 using Nevermore.Advanced;
 using Nevermore.Advanced.Hooks;
@@ -14,8 +13,6 @@ using Nevermore.Advanced.TypeHandlers;
 using Nevermore.Diagnostics;
 using Nevermore.Mapping;
 using Nevermore.RelatedDocuments;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Nevermore
 {
@@ -34,15 +31,15 @@ namespace Nevermore
             KeyBlockSize = NevermoreDefaults.DefaultKeyBlockSize;
             InstanceTypeResolvers = new InstanceTypeRegistry();
             RelatedDocumentStore = new EmptyRelatedDocumentStore();
-            
+
             this.UseJsonNetSerialization(s => {});
-            
+
             ReaderStrategies = new ReaderStrategyRegistry();
             ReaderStrategies.Register(new DocumentReaderStrategy(this));
             ReaderStrategies.Register(new ValueTupleReaderStrategy(this));
             ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
             ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
-            
+
             Hooks = new HookRegistry();
 
             DefaultSchema = NevermoreDefaults.FallbackDefaultSchemaName;
@@ -59,28 +56,28 @@ namespace Nevermore
                 return InitializeConnectionString(result);
             });
         }
-        
+
         public string ApplicationName { get; set; }
 
         public string ConnectionString => connectionString.Value;
-        
+
         public bool AllowSynchronousOperations { get; set; }
-        
+
         public string DefaultSchema { get; set; }
 
         public IDocumentMapRegistry DocumentMaps { get; set; }
-        
+
         public IDocumentSerializer DocumentSerializer { get; set; }
-        
+
         public IRelatedDocumentStore RelatedDocumentStore { get; set; }
-        
+
         public IQueryLogger QueryLogger { get; set; }
 
         public IHookRegistry Hooks { get; }
         public int KeyBlockSize { get; set; }
-        
+
         public IReaderStrategyRegistry ReaderStrategies { get; }
-        
+
         public ITypeHandlerRegistry TypeHandlers { get; }
         public IInstanceTypeRegistry InstanceTypeResolvers { get; }
 
@@ -102,27 +99,13 @@ namespace Nevermore
             if (ApplicationName != null) builder.ApplicationName = ApplicationName;
             if (ForceMultipleActiveResultSets) builder.MultipleActiveResultSets = true;
 
-            OverrideValueIfNotSet(builder, nameof(builder.ConnectTimeout), NevermoreDefaults.DefaultConnectTimeoutSeconds);
-            OverrideValueIfNotSet(builder, nameof(builder.ConnectRetryCount), NevermoreDefaults.DefaultConnectRetryCount);
-            OverrideValueIfNotSet(builder, nameof(builder.ConnectRetryInterval), NevermoreDefaults.DefaultConnectRetryInterval);
-            OverrideValueIfNotSet(builder, nameof(builder.TrustServerCertificate), NevermoreDefaults.DefaultTrustServerCertificate);
+            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectTimeout, NevermoreDefaults.DefaultConnectTimeoutSeconds);
+            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectRetryCount, NevermoreDefaults.DefaultConnectRetryCount);
+            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectRetryInterval, NevermoreDefaults.DefaultConnectRetryInterval);
+            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.TrustServerCertificate, NevermoreDefaults.DefaultTrustServerCertificate);
 
             return builder.ToString();
         }
 
-        static void OverrideValueIfNotSet(SqlConnectionStringBuilder connectionStringBuilder, string propertyName, object overrideValue)
-        {
-            var defaultConnectionStringBuilder = new SqlConnectionStringBuilder();
-
-            var property = connectionStringBuilder.GetType().GetRuntimeProperty(propertyName);
-
-            var defaultValue = property.GetValue(defaultConnectionStringBuilder);
-            var currentValue = property.GetValue(connectionStringBuilder);
-
-            if (Equals(defaultValue, currentValue))
-            {
-                property.SetValue(connectionStringBuilder, overrideValue);
-            }
-        }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -99,10 +99,11 @@ namespace Nevermore
             if (ApplicationName != null) builder.ApplicationName = ApplicationName;
             if (ForceMultipleActiveResultSets) builder.MultipleActiveResultSets = true;
 
-            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectTimeout, NevermoreDefaults.DefaultConnectTimeoutSeconds);
-            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectRetryCount, NevermoreDefaults.DefaultConnectRetryCount);
-            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.ConnectRetryInterval, NevermoreDefaults.DefaultConnectRetryInterval);
-            SqlConnectionStringHelpers.OverrideValueIfNotSet(builder, DbConnectionStringKeywords.TrustServerCertificate, NevermoreDefaults.DefaultTrustServerCertificate);
+
+            builder.OverrideConnectionStringPropertyValueIfNotSet(DbConnectionStringKeyword.ConnectTimeout, NevermoreDefaults.DefaultConnectTimeoutSeconds);
+            builder.OverrideConnectionStringPropertyValueIfNotSet(DbConnectionStringKeyword.ConnectRetryCount, NevermoreDefaults.DefaultConnectRetryCount);
+            builder.OverrideConnectionStringPropertyValueIfNotSet(DbConnectionStringKeyword.ConnectRetryInterval, NevermoreDefaults.DefaultConnectRetryInterval);
+            builder.OverrideConnectionStringPropertyValueIfNotSet(DbConnectionStringKeyword.TrustServerCertificate, NevermoreDefaults.DefaultTrustServerCertificate);
 
             return builder.ToString();
         }


### PR DESCRIPTION
## Background 
`OverrideValueIfNotSet` doesn’t actually check the connection string to see if a value is set. Rather it compares a new builder's property values with that of the builder that we're wanting to override.

For example, if the connection string has boolean a property set explicitly, if the new builder has the same value set by default. `OverrideValueIfNotSet` compares properties and determines that both have the same default value and so it needs to override.

So if a consumer wants to explicitly set `Trust Server Certificate=False` in the string, OverrideValueIfNotSet treats that as being equal to the builder’s default and overrides it anyway with our override value, instead of ignoring it.

## Results

This fix updates how we validate and uses the builder's ShouldSerialize which checks if the value is in the connection string.

However we also needed to copy in the DbConnectionStringKeywords from [Ms SqlClient](https://github.com/dotnet/SqlClient/blob/5c5a15d5ac842b48c4e99bff951b026f07f1a5d3/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs#L885) as we're unable to use the indexer to set values for certain properties, and we're also unable to get the display names through reflection. So this is our fall back.

## How To Review
There should be adequate test coverage here
Quality 👀 