### PR TITLE
Add support for identity primary keys

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -19,16 +19,16 @@ namespace Nevermore.IntegrationTests.Advanced
 
             using var transaction = Store.BeginTransaction();
 
-            var customer = new Customer {Id = "C131", FirstName = "Fred", LastName = "Freddy"};
+            var customer = new Customer {Id = "C131".ToCustomerId(), FirstName = "Fred", LastName = "Freddy"};
             transaction.Insert(customer);
             AssertLogged(log, "BeforeInsert", "AfterInsert");
 
-            customer = transaction.Load<Customer>("C131");
+            customer = transaction.Load<Customer, CustomerId>("C131".ToCustomerId());
 
             transaction.Update(customer);
             AssertLogged(log, "BeforeUpdate", "AfterUpdate");
 
-            transaction.Delete(customer);
+            transaction.Delete<Customer, CustomerId>(customer);
             AssertLogged(log, "BeforeDelete", "AfterDelete");
 
             transaction.Commit();

--- a/source/Nevermore.IntegrationTests/Advanced/IdentityIdFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/IdentityIdFixture.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class IdentityIdFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void InsertUpdatesDocumentId()
+        {
+            // ChaosSqlCommand is set to retry some of the reads which breaks row versioning code because INSERTS/UPDATES,
+            // even executed via SqlReader, must not be retired.
+            NoMonkeyBusiness();
+
+            var document1 = new DocumentWithIdentityId {Name = "Name"};
+
+            document1.Id.Should().Be(0);
+
+            RunInTransaction(transaction => transaction.Insert(document1));
+
+            document1.Id.Should().NotBe(0);
+        }
+
+        [Test]
+        public void InsertManyUpdatesDocumentIds()
+        {
+            // ChaosSqlCommand is set to retry some of the reads which breaks row versioning code because INSERTS/UPDATES,
+            // even executed via SqlReader, must not be retired.
+            NoMonkeyBusiness();
+
+            var document1 = new DocumentWithIdentityId {Name = "Name"};
+            var document2 = new DocumentWithIdentityId {Name = "Name"};
+
+            document1.Id.Should().Be(0);
+            document2.Id.Should().Be(0);
+
+            RunInTransaction(transaction => transaction.InsertMany(new[]
+            {
+                document1, 
+                document2
+            }));
+
+            document1.Id.Should().NotBe(0);
+            document2.Id.Should().NotBe(0);
+            document1.Id.Should().NotBe(document2.Id);
+        }
+        
+        [Test]
+        public async Task InsertAsyncUpdatesDocumentIdAndRowVersion()
+        {
+            // ChaosSqlCommand is set to retry some of the reads which breaks row versioning code because INSERTS/UPDATES,
+            // even executed via SqlReader, must not be retired.
+            NoMonkeyBusiness();
+
+            var document1 = new DocumentWithIdentityId {Name = "Name"};
+
+            document1.Id.Should().Be(0);
+
+            await RunInTransactionAsync(async transaction => await transaction.InsertAsync(document1));
+
+            document1.Id.Should().NotBe(0);
+        }
+
+        
+        [Test]
+        public async Task InsertAsyncUpdatesDocumentId()
+        {
+            // ChaosSqlCommand is set to retry some of the reads which breaks row versioning code because INSERTS/UPDATES,
+            // even executed via SqlReader, must not be retired.
+            NoMonkeyBusiness();
+
+            var document1 = new DocumentWithIdentityIdAndRowVersion {Name = "Name"};
+
+            document1.Id.Should().Be(0);
+
+            await RunInTransactionAsync(async transaction => await transaction.InsertAsync(document1));
+
+            document1.Id.Should().NotBe(0);
+            
+            var document2  = RunInTransaction(transaction => transaction.Load<DocumentWithIdentityIdAndRowVersion>(document1.Id));
+
+            document2.RowVersion.Should().Equal(document1.RowVersion);
+
+            document2.Name = "Name2";
+            RunInTransaction(transaction => transaction.Update(document2));
+
+            document2.RowVersion.Should().NotEqual(document1.RowVersion);
+        }
+
+        TResult RunInTransaction<TResult>(Func<IRelationalTransaction, TResult> func)
+        {
+            using var transaction = Store.BeginTransaction();
+            var result = func(transaction);
+            transaction.Commit();
+
+            return result;
+        }
+
+        void RunInTransaction(Action<IRelationalTransaction> action)
+        {
+            RunInTransaction(transaction =>
+            {
+                action(transaction);
+                return string.Empty;
+            });
+        }
+        
+        async Task<TResult> RunInTransactionAsync<TResult>(Func<IRelationalTransaction, Task<TResult>> func)
+        {
+            using var transaction = Store.BeginTransaction();
+            var result = await func(transaction);
+            await transaction.CommitAsync();
+
+            return result;
+        }
+        
+        async Task RunInTransactionAsync(Func<IRelationalTransaction,Task> action)
+        {
+           await RunInTransactionAsync(async transaction =>
+            {
+                await action(transaction);
+                return true;
+            });
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/MappingFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MappingFixture.cs
@@ -19,7 +19,7 @@ namespace Nevermore.IntegrationTests.Advanced
 
             // Test accessibility
             public string Prop1 { get; set; }
-            public string Prop2 { get; } = "Hello"; 
+            public string Prop2 { get; } = "Hello";
             public string Prop3 { get; private set; }
             public string Prop4 { get; protected set; }
             public string Prop5 { get; private set; }
@@ -31,13 +31,13 @@ namespace Nevermore.IntegrationTests.Advanced
                 Prop5 = prop5;
             }
         }
-        
+
         enum Education { School, HighSchool, College }
 
         public override void OneTimeSetUp()
         {
             base.OneTimeSetUp();
-            
+
             NoMonkeyBusiness();
             KeepDataBetweenTests();
 
@@ -86,7 +86,7 @@ namespace Nevermore.IntegrationTests.Advanced
         [Test, Order(2)]
         public void ShouldWorkIfProp2IsSaveOnly()
         {
-            var map = ((IDocumentMap)new UserMap()).Build();
+            var map = ((IDocumentMap)new UserMap()).Build(Configuration.PrimaryKeyHandlers);
             // Pretend the user edited their document map to set it to SaveOnly
             ((IColumnMappingBuilder) map.Columns.Single(c => c.ColumnName == "Prop2")).SaveOnly();
             Configuration.DocumentMaps.Register(map);
@@ -105,9 +105,9 @@ namespace Nevermore.IntegrationTests.Advanced
                 Prop1 = "Prop1",
                 FirstName = "Fred"
             };
-            
+
             user.SetOtherProps("Prop3", "Prop4", "Prop5");
-            
+
             transaction.Insert(user);
             transaction.Update(user);
             transaction.Commit();
@@ -117,7 +117,7 @@ namespace Nevermore.IntegrationTests.Advanced
         public void ShouldLoad()
         {
             using var transaction = Store.BeginTransaction();
-            
+
             var user = transaction.Load<User>("users-123");
             user.Should().NotBeNull();
             user.Age.Should().Be(18);
@@ -132,7 +132,7 @@ namespace Nevermore.IntegrationTests.Advanced
         public void ShouldDelete()
         {
             using var transaction = Store.BeginTransaction();
-            
+
             transaction.Delete<User>("users-123");
             var user = transaction.Load<User>("users-123");
             user.Should().BeNull();

--- a/source/Nevermore.IntegrationTests/Advanced/NoJsonFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/NoJsonFixture.cs
@@ -1,7 +1,4 @@
-using System.Collections.Generic;
-using System.Data;
 using FluentAssertions;
-using Microsoft.Data.SqlClient.Server;
 using Nevermore.IntegrationTests.SetUp;
 using Nevermore.Mapping;
 using NUnit.Framework;
@@ -14,9 +11,9 @@ namespace Nevermore.IntegrationTests.Advanced
         {
             base.OneTimeSetUp();
             NoMonkeyBusiness();
-            
+
             ExecuteSql("create table TestSchema.Car([Id] nvarchar(50), [Name] nvarchar(100))");
-            
+
             Store.Configuration.DocumentMaps.Register(new CarMap());
         }
 
@@ -25,23 +22,23 @@ namespace Nevermore.IntegrationTests.Advanced
             public string Id { get; set; }
             public string Name { get; set; }
         }
-        
-        class CarMap : DocumentMap<Car> 
+
+        class CarMap : DocumentMap<Car>
         {
             public CarMap()
             {
                 Column(m => m.Name);
-                
+
                 JsonStorageFormat = JsonStorageFormat.NoJson;
             }
         }
-        
+
         [Test]
         public void ShouldMapWithoutJson()
         {
             using var transaction = Store.BeginTransaction();
             transaction.Insert(new Car { Name = "Volvo" });
-            
+
             var car = transaction.Load<Car>("Cars-1");
             car.Should().NotBeNull();
             car.Name.Should().Be("Volvo");
@@ -54,9 +51,9 @@ namespace Nevermore.IntegrationTests.Advanced
             car.Name.Should().Be("Bertie");
 
             transaction.Query<Car>().Count().Should().Be(1);
-            
-            transaction.Delete(car);
-            
+
+            transaction.Delete<Car, string>(car);
+
             transaction.Query<Car>().Count().Should().Be(0);
 
             car = transaction.Load<Car>("Cars-1");

--- a/source/Nevermore.IntegrationTests/KeyAllocatorFixture.cs
+++ b/source/Nevermore.IntegrationTests/KeyAllocatorFixture.cs
@@ -18,7 +18,7 @@ namespace Nevermore.IntegrationTests
             var allocatorA = new KeyAllocator(Store, 10);
             var allocatorB = new KeyAllocator(Store, 10);
 
-            // A gets 1-10 
+            // A gets 1-10
             AssertNext(allocatorA, "Todos", 1);
             AssertNext(allocatorA, "Todos", 2);
             AssertNext(allocatorA, "Todos", 3);
@@ -76,7 +76,7 @@ namespace Nevermore.IntegrationTests
             const int allocationCount = 20;
             const int threadCount = 10;
 
-            var projectIds = new ConcurrentBag<string>();
+            var customerIds = new ConcurrentBag<CustomerId>();
             var deploymentIds = new ConcurrentBag<string>();
             var random = new Random(1);
 
@@ -90,21 +90,21 @@ namespace Nevermore.IntegrationTests
                         var sequence = random.Next(3);
                         if (sequence == 0)
                         {
-                            var id = transaction.AllocateId(typeof (Customer));
-                            projectIds.Add(id);
+                            var id = transaction.AllocateId<Customer, CustomerId>();
+                            customerIds.Add(id);
                             transaction.Commit();
                         }
                         else if (sequence == 1)
                         {
                             // Abandon some transactions (just projects to make it easier)
-                            var id = transaction.AllocateId(typeof(Customer));
+                            var id = transaction.AllocateId<Customer, CustomerId>();
                             // Abandoned Ids are not returned to the pool
-                            projectIds.Add(id);
+                            customerIds.Add(id);
                             transaction.Dispose();
                         }
                         else if (sequence == 2)
                         {
-                            var id = transaction.AllocateId(typeof(Order));
+                            var id = transaction.AllocateId<Order, string>();
                             deploymentIds.Add(id);
                             transaction.Commit();
                         }
@@ -115,21 +115,21 @@ namespace Nevermore.IntegrationTests
             Task.WaitAll(tasks);
             Func<string, int> removePrefix = x => int.Parse(x.Split('-')[1]);
 
-            var projectIdsAfter = projectIds.Select(removePrefix).OrderBy(x => x).ToArray();
+            var customerIdsAfter = customerIds.Select(x => removePrefix(x.Value)).OrderBy(x => x).ToArray();
             var deploymentIdsAfter = deploymentIds.Select(removePrefix).OrderBy(x => x).ToArray();
 
-            projectIdsAfter.Distinct().Count().Should().Be(projectIdsAfter.Length);
+            customerIdsAfter.Distinct().Count().Should().Be(customerIdsAfter.Length);
             deploymentIdsAfter.Distinct().Count().Should().Be(deploymentIdsAfter.Length);
-            
+
             // Check that there are no gaps in sequence
 
-            var firstProjectId = projectIdsAfter.First();
-            var lastProjectId = projectIdsAfter.Last();
+            var firstProjectId = customerIdsAfter.First();
+            var lastProjectId = customerIdsAfter.Last();
 
             var expectedProjectIds = Enumerable.Range(firstProjectId, lastProjectId - firstProjectId + 1)
                 .ToList();
 
-            projectIdsAfter.Should().BeEquivalentTo(expectedProjectIds);
+            customerIdsAfter.Should().BeEquivalentTo(expectedProjectIds);
         }
 
         static void AssertNext(KeyAllocator allocator, string collection, int expected)

--- a/source/Nevermore.IntegrationTests/Model/CustomIdType.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomIdType.cs
@@ -1,0 +1,54 @@
+﻿#nullable enable
+using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class CustomIdType<T>
+    {
+        internal CustomIdType(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
+
+        public override string? ToString()
+        {
+            return Value?.ToString();
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return !(Value is null) && Value.Equals(((CustomIdType<T>) obj).Value);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+
+        public static CustomIdType<T>? Create(Type customType, T value)
+        {
+            const BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            var instance = Activator.CreateInstance(customType, bindingFlags, null, new object[] { value! }, CultureInfo.CurrentCulture);
+            return instance as CustomIdType<T>;
+        }
+
+        public static TCustomIdType? Create<TCustomIdType>(T value) where TCustomIdType : CustomIdType<T>
+        {
+            return (TCustomIdType?) Create(typeof(TCustomIdType), value);
+        }
+    }
+
+    public class StringCustomIdType : CustomIdType<string>
+    {
+        internal StringCustomIdType(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/CustomPrefixIdKeyHandler.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomPrefixIdKeyHandler.cs
@@ -1,0 +1,11 @@
+namespace Nevermore.IntegrationTests.Model
+{
+    class CustomPrefixIdKeyHandler : StringCustomIdTypeIdKeyHandler<CustomPrefixId>
+    {
+        public const string CustomPrefix = "CustomPrefix";
+
+        public CustomPrefixIdKeyHandler():base(CustomPrefix)
+        {
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -9,7 +9,7 @@ namespace Nevermore.IntegrationTests.Model
             Roles = new ReferenceCollection();
         }
 
-        public string Id { get; set; }
+        public CustomerId Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public ReferenceCollection Roles { get; }
@@ -17,5 +17,22 @@ namespace Nevermore.IntegrationTests.Model
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }
         public string[] Passphrases { get; set; }
+    }
+
+    public class CustomerId : StringCustomIdType
+    {
+        internal CustomerId(string value) : base(value)
+        {
+        }
+    }
+
+#nullable enable
+
+    public static class CustomerIdExtensionMethods
+    {
+        public static CustomerId? ToCustomerId(this string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : new CustomerId(value);
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefix.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefix.cs
@@ -1,0 +1,15 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithCustomPrefix
+    {
+        public CustomPrefixId Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class CustomPrefixId : StringCustomIdType
+    {
+        internal CustomPrefixId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixAndStringId.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixAndStringId.cs
@@ -1,0 +1,8 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithCustomPrefixAndStringId
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixAndStringIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixAndStringIdMap.cs
@@ -1,0 +1,15 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithCustomPrefixAndStringIdMap : DocumentMap<DocumentWithCustomPrefixAndStringId>
+    {
+        public const string CustomPrefix = "CustomPrefix";
+
+        public DocumentWithCustomPrefixAndStringIdMap()
+        {
+            Id().KeyHandler(new StringPrimaryKeyHandler(CustomPrefix));
+            Column(m => m.Name);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithCustomPrefixMap.cs
@@ -1,0 +1,13 @@
+﻿using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithCustomPrefixMap : DocumentMap<DocumentWithCustomPrefix>
+    {
+        public DocumentWithCustomPrefixMap()
+        {
+            Id();
+            Column(m => m.Name);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityId.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityId.cs
@@ -1,0 +1,8 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithIdentityId
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersion.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersion.cs
@@ -1,0 +1,9 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithIdentityIdAndRowVersion
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public byte[] RowVersion { get; set; }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersionMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersionMap.cs
@@ -1,0 +1,14 @@
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithIdentityIdAndRowVersionMap : DocumentMap<DocumentWithIdentityIdAndRowVersion>
+    {
+        public DocumentWithIdentityIdAndRowVersionMap()
+        {
+            Id(t => t.Id).Identity();
+            Column(t => t.Name);
+            RowVersion(m => m.RowVersion);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdMap.cs
@@ -1,0 +1,13 @@
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    public class DocumentWithIdentityIdMap : DocumentMap<DocumentWithIdentityId>
+    {
+        public DocumentWithIdentityIdMap()
+        {
+            Id(t => t.Id).Identity();
+            Column(t => t.Name);
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/StringCustomIdTypeHandler.cs
+++ b/source/Nevermore.IntegrationTests/Model/StringCustomIdTypeHandler.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+using System;
+using System.Data;
+using System.Data.Common;
+using Nevermore.Advanced.TypeHandlers;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    class StringCustomIdTypeHandler<T> : ITypeHandler where T : CustomIdType<string>
+    {
+        public bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(T);
+        }
+
+        public object? ReadDatabase(DbDataReader reader, int columnIndex)
+        {
+            if (reader.IsDBNull(columnIndex)) return null;
+            var value = reader.GetString(columnIndex);
+            if (string.IsNullOrWhiteSpace(value)) return null;
+            return CustomIdType<string>.Create<T>(value);
+        }
+
+        public void WriteDatabase(DbParameter parameter, object value)
+        {
+            parameter.DbType = DbType.String;
+            if (value is T wrapped)
+            {
+                parameter.Value = wrapped.Value;
+            }
+            else
+            {
+                parameter.Value = null;
+            }
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Model/StringCustomIdTypeIdKeyHandler.cs
+++ b/source/Nevermore.IntegrationTests/Model/StringCustomIdTypeIdKeyHandler.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+using System;
+using System.Data;
+using Microsoft.Data.SqlClient.Server;
+using Nevermore.Mapping;
+
+namespace Nevermore.IntegrationTests.Model
+{
+    class StringCustomIdTypeIdKeyHandler<T> : IPrimaryKeyHandler
+        where T : StringCustomIdType
+    {
+        readonly string? customPrefix;
+
+        public StringCustomIdTypeIdKeyHandler(string? customPrefix = null)
+        {
+            this.customPrefix = customPrefix;
+        }
+
+        public Type Type => typeof(T);
+
+        public SqlMetaData GetSqlMetaData(string name)
+            =>  new SqlMetaData(name, SqlDbType.NVarChar, 300);
+
+        public object? ConvertToPrimitiveValue(object? id)
+        {
+            if (!(id is StringCustomIdType stringCustomType))
+                throw new ArgumentException($"Expected the id to be a {typeof(T).Name}");
+            return stringCustomType.Value;
+        }
+
+        public object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+        {
+            var key = keyAllocator.NextId(tableName);
+            return CustomIdType<string>.Create<T>($"{customPrefix ?? tableName}s-{key}")!;
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
@@ -108,7 +108,7 @@ namespace Nevermore.IntegrationTests
             var order = new Order() {Id = orderId};
             using (var trn = Store.BeginTransaction())
             {
-                trn.Delete(order);
+                trn.Delete<Order, string>(order);
                 trn.Commit();
             }
         }
@@ -245,7 +245,7 @@ namespace Nevermore.IntegrationTests
 
         RelatedDocumentRow[] GetReferencesFromDb()
         {
-            var map = ((IDocumentMap)new OrderMap()).Build().RelatedDocumentsMappings.First();
+            var map = ((IDocumentMap)new OrderMap()).Build(Configuration.PrimaryKeyHandlers).RelatedDocumentsMappings.First();
 
             Func<IDataReader, RelatedDocumentRow> Callback()
                 => reader
@@ -302,7 +302,7 @@ namespace Nevermore.IntegrationTests
                     return hashCode;
                 }
             }
-            
+
             public static bool operator ==(RelatedDocumentRow left, RelatedDocumentRow right) => Equals(left, right);
             public static bool operator !=(RelatedDocumentRow left, RelatedDocumentRow right) => !Equals(left, right);
         }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
@@ -16,7 +16,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
             using (var trn = Store.BeginTransaction())
             {
                 var product = trn.Load<Product>(id);
-                trn.Delete(product);
+                trn.Delete<Product, string>(product);
                 trn.Commit();
             }
 

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -29,7 +29,9 @@ namespace Nevermore.IntegrationTests.SetUp
                 new MessageWithGuidIdMap(),
                 new DocumentWithRowVersionMap(),
                 new DocumentWithIdentityIdMap(),
-                new DocumentWithIdentityIdAndRowVersionMap()
+                new DocumentWithIdentityIdAndRowVersionMap(),
+                new DocumentWithCustomPrefixMap(),
+                new DocumentWithCustomPrefixAndStringIdMap()
             };
 
             var config = new RelationalStoreConfiguration(ConnectionString)
@@ -38,18 +40,25 @@ namespace Nevermore.IntegrationTests.SetUp
                 ApplicationName = "Nevermore-IntegrationTests",
                 DefaultSchema = "TestSchema"
             };
-            config.DocumentMaps.Register(documentMaps);
 
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
+            config.TypeHandlers.Register(new StringCustomIdTypeHandler<CustomerId>());
+            config.TypeHandlers.Register(new StringCustomIdTypeHandler<CustomPrefixId>());
+
+            config.PrimaryKeyHandlers.Register(new StringCustomIdTypeIdKeyHandler<CustomerId>());
+            config.PrimaryKeyHandlers.Register(new CustomPrefixIdKeyHandler());
+
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
             config.InstanceTypeResolvers.Register(new BrandTypeResolver());
+
+            config.DocumentMaps.Register(documentMaps);
 
             config.UseJsonNetSerialization(settings =>
             {
                 settings.ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor;
             });
 
-            GenerateSchemaAutomatically(documentMaps);
+            GenerateSchemaAutomatically(config, documentMaps);
 
             Store = new RelationalStore(config);
         }
@@ -83,14 +92,14 @@ namespace Nevermore.IntegrationTests.SetUp
             resetBetweenTests = false;
         }
 
-        void GenerateSchemaAutomatically(params IDocumentMap[] mappings)
+        void GenerateSchemaAutomatically(RelationalStoreConfiguration configuration, params IDocumentMap[] mappings)
         {
             try
             {
                 var schema = new StringBuilder();
                 foreach (var map in mappings)
                 {
-                    SchemaGenerator.WriteTableSchema(map.Build(), null, schema);
+                    SchemaGenerator.WriteTableSchema(map.Build(configuration.PrimaryKeyHandlers), null, schema);
                 }
                 integrationTestDatabase.ExecuteScript(schema.ToString());
             }

--- a/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
@@ -12,7 +12,9 @@ namespace Nevermore.IntegrationTests.SetUp
         {
             var tableName = tableNameOverride ?? mapping.TableName;
             result.AppendLine("CREATE TABLE [TestSchema].[" + tableName + "] (");
-            result.Append($"  [Id] {GetDatabaseType(mapping.IdColumn)} NOT NULL CONSTRAINT [PK_{tableName}_Id] PRIMARY KEY CLUSTERED, ").AppendLine();
+
+            var identity = mapping.IsIdentityId ? " IDENTITY(1,1)" : null;
+            result.Append($"  [Id] {GetDatabaseType(mapping.IdColumn)}{identity} NOT NULL CONSTRAINT [PK_{tableName}_Id] PRIMARY KEY CLUSTERED, ").AppendLine();
 
             foreach (var column in mapping.WritableIndexedColumns())
             {
@@ -20,6 +22,10 @@ namespace Nevermore.IntegrationTests.SetUp
             }
 
             result.AppendFormat("  [JSON] NVARCHAR(MAX) NOT NULL").AppendLine();
+
+            if (mapping.IsRowVersioningEnabled)
+                result.Append("  ,[RowVersion] TIMESTAMP").AppendLine();
+
             result.AppendLine(")");
 
             foreach (var unique in mapping.UniqueConstraints)

--- a/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data;
 using System.Linq;
 using System.Text;
+using Nevermore.IntegrationTests.Model;
 using Nevermore.Mapping;
 using Nevermore.Util;
 
@@ -58,7 +59,7 @@ namespace Nevermore.IntegrationTests.SetUp
 
         static string GetDatabaseType(ColumnMapping column)
         {
-            var dbType = DatabaseTypeConverter.AsDbType(column.Type);
+            var dbType = typeof(StringCustomIdType).IsAssignableFrom(column.Type) ? DbType.String : DatabaseTypeConverter.AsDbType(column.Type);
 
             switch (dbType)
             {

--- a/source/Nevermore.Tests/CommandParameterValuesFixture.cs
+++ b/source/Nevermore.Tests/CommandParameterValuesFixture.cs
@@ -25,7 +25,7 @@ namespace Nevermore.Tests
             command.Parameters["someId_2"].Value.Should().Be("id2");
             command.Parameters["someIdentifier"].Value.Should().Be("value");
         }
-        
+
         [Test]
         public void ShouldReplaceParametersWithExactMatchEndOfQuery()
         {
@@ -91,19 +91,19 @@ namespace Nevermore.Tests
                 Column(c => c.LastName).MaxLength(256);
             }
         }
-        
+
         [Test]
         public void ShouldUseMaxLengthsWhenAvailable()
         {
             var mapping = new Map();
-            
+
             var parameters = new CommandParameterValues();
             parameters["FirstName"] = "Fred";
             parameters["LastName"] = "Fred";
-            
+
             var command = new SqlCommand($"SELECT BLAH BLAH");
-            
-            parameters.ContributeTo(command, new TypeHandlerRegistry(), ((IDocumentMap)mapping).Build());
+
+            parameters.ContributeTo(command, new TypeHandlerRegistry(), ((IDocumentMap)mapping).Build(new PrimaryKeyHandlerRegistry()));
 
             command.Parameters["FirstName"].Size.Should().Be(128);
             command.Parameters["LastName"].Size.Should().Be(256);

--- a/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Delete/DeleteQueryBuilderFixture.cs
@@ -6,7 +6,6 @@ using Nevermore.Advanced.Serialization;
 using Nevermore.Mapping;
 using Nevermore.Querying;
 using Nevermore.Util;
-using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -27,7 +26,7 @@ namespace Nevermore.Tests.Delete
             mappings = Substitute.For<IDocumentMapRegistry>();
             mappings.Resolve<object>().Returns(c => new EmptyMap());
             mappings.Resolve(Arg.Any<Type>()).Returns(c => new EmptyMap());
-            
+
             queryExecutor = Substitute.For<IWriteQueryExecutor>();
             queryExecutor.ExecuteNonQuery(Arg.Any<PreparedCommand>()).Returns(info =>
             {
@@ -164,7 +163,7 @@ AND ([Price] < @price_1)");
                 .Parameter("OTHERVAR", "Bar")
                 .Delete();
 #pragma warning restore NV0006
-            
+
             parameters.Count.Should().Be(2);
             foreach (var parameter in parameters)
                 query.Should().Contain("@" + parameter.Key, "Should contain @" + parameter.Key);
@@ -227,7 +226,13 @@ AND ([Price] < @price_1)");
         }
     }
 
+    internal class Empty
+    {}
+
     internal class EmptyMap : DocumentMap
     {
+        public EmptyMap() : base(typeof(Empty), "Empty")
+        {
+        }
     }
 }

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithIdentityId.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithIdentityId.approved.txt
@@ -1,0 +1,8 @@
+DECLARE @InsertedRows TABLE ([Id] int)
+INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn], [JSON]) OUTPUT inserted.[Id] INTO @InsertedRows VALUES 
+(@AColumn, @JSON)
+SELECT [Id] FROM @InsertedRows
+
+@Id=0
+@JSON={}
+@AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithIdentityIdAndRowVersion.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithIdentityIdAndRowVersion.approved.txt
@@ -1,0 +1,8 @@
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8), [Id] int)
+INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn], [JSON]) OUTPUT inserted.[RowVersion],inserted.[Id] INTO @InsertedRows VALUES 
+(@AColumn, @JSON)
+SELECT [RowVersion],[Id] FROM @InsertedRows
+
+@Id=0
+@JSON={}
+@AColumn=AValue

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertDocumentWithReadOnlyColumn.approved.txt
@@ -1,5 +1,7 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@Id, @AColumn, @JSON)
+SELECT [RowVersion] FROM @InsertedRows
 
 @Id=Doc-1
 @JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON])  VALUES 
 (@0__Id, @0__AColumn, @0__JSON)
 ,(@1__Id, @1__AColumn, @1__JSON)
 ,(@2__Id, @2__AColumn, @2__JSON)

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocumentWithMultipleRelatedDocumentsMaps.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON])  VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [dbo].[RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertMultipleDocuments.approved.txt
@@ -1,6 +1,8 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@0__Id, @0__AColumn, @0__JSON)
 ,(@1__Id, @1__AColumn, @1__JSON)
+SELECT [RowVersion] FROM @InsertedRows
 
 @0__Id=New-Id-1
 @0__JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocument.approved.txt
@@ -1,5 +1,7 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@Id, @AColumn, @JSON)
+SELECT [RowVersion] FROM @InsertedRows
 
 @Id=New-Id
 @JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithDocumentIdAlreadySet.approved.txt
@@ -1,5 +1,7 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@Id, @AColumn, @JSON)
+SELECT [RowVersion] FROM @InsertedRows
 
 @Id=SuppliedId
 @JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithManyRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON])  VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [dbo].[RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithNoRelatedDocuments.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON])  VALUES 
 (@Id, @AColumn, @JSON)
 
 @Id=New-Id

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithOneRelatedDocument.approved.txt
@@ -1,4 +1,4 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON]) VALUES 
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [AColumn], [JSON])  VALUES 
 (@Id, @AColumn, @JSON)
 INSERT INTO [dbo].[RelatedDocument] ([Id], [Table], [RelatedDocumentId], [RelatedDocumentTable]) VALUES
 (@Id, 'TestDocumentTbl', @relateddocument_0, 'OtherTbl')

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertSingleDocumentWithTableNameAndHints.approved.txt
@@ -1,5 +1,7 @@
-INSERT INTO [dbo].[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[AltTableName] WITH (NOLOCK) ([Id], [AColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@Id, @AColumn, @JSON)
+SELECT [RowVersion] FROM @InsertedRows
 
 @Id=New-Id
 @JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithoutDefaultColumns.approved.txt
@@ -1,5 +1,7 @@
-INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn]) OUTPUT inserted.RowVersion VALUES 
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([AColumn]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
 (@AColumn)
+SELECT [RowVersion] FROM @InsertedRows
 
 @Id=New-Id
 @JSON={"NotMapped":"NonMappedValue"}

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -27,7 +27,9 @@ namespace Nevermore.Tests.Util
                 new TestDocumentMap(),
                 new TestDocumentWithRelatedDocumentsMap(),
                 new TestDocumentWithMultipleRelatedDocumentsMap(),
-                new OtherMap());
+                new OtherMap(),
+                new TestDocumentWithIdentityIdMap(),
+                new TestDocumentWithIdentityIdAndRowVersionMap());
             builder = new DataModificationQueryBuilder(
                 configuration,
                 m => idAllocator()
@@ -71,8 +73,8 @@ namespace Nevermore.Tests.Util
                 new[] {document},
                 new InsertOptions
                 {
-                    TableName ="AltTableName",
-                    Hint ="WITH (NOLOCK)"
+                    TableName = "AltTableName",
+                    Hint = "WITH (NOLOCK)"
                 }
             );
 
@@ -86,7 +88,7 @@ namespace Nevermore.Tests.Util
 
             var result = builder.PrepareInsert(
                 new[] {document},
-                new InsertOptions { IncludeDefaultModelColumns = false}
+                new InsertOptions {IncludeDefaultModelColumns = false}
             );
 
             this.Assent(Format(result));
@@ -195,8 +197,24 @@ namespace Nevermore.Tests.Util
             var document = new TestDocument {AColumn = "AValue", NotMapped = "NonMappedValue", Id = "Doc-1", ReadOnly = "Value"};
 
             idAllocator = () => "New-Id-" + (++n);
-            var result = builder.PrepareInsert(new [] { document });
+            var result = builder.PrepareInsert(new[] {document});
 
+            this.Assent(Format(result));
+        }
+
+        [Test]
+        public void InsertDocumentWithIdentityId()
+        {
+            var document = new TestDocumentWithIdentityId {AColumn = "AValue"};
+            var result = builder.PrepareInsert(new[] {document});
+            this.Assent(Format(result));
+        }
+
+        [Test]
+        public void InsertDocumentWithIdentityIdAndRowVersion()
+        {
+            var document = new TestDocumentWithIdentityIdAndRowVersion {AColumn = "AValue"};
+            var result = builder.PrepareInsert(new[] {document});
             this.Assent(Format(result));
         }
 
@@ -219,7 +237,7 @@ namespace Nevermore.Tests.Util
 
             var result = builder.PrepareUpdate(
                 document,
-                new UpdateOptions { Hint = "WITH (NO LOCK)"}
+                new UpdateOptions {Hint = "WITH (NO LOCK)"}
             );
 
             this.Assent(Format(result));
@@ -384,6 +402,19 @@ namespace Nevermore.Tests.Util
             public string Id { get; set; }
         }
 
+        class TestDocumentWithIdentityId
+        {
+            public int Id { get; set; }
+            public string AColumn { get; set; }
+        }
+
+        class TestDocumentWithIdentityIdAndRowVersion
+        {
+            public int Id { get; set; }
+            public string AColumn { get; set; }
+            public int RowVersion { get; set; }
+        }
+
         class TestDocumentMap : DocumentMap<TestDocument>
         {
             public TestDocumentMap()
@@ -422,6 +453,27 @@ namespace Nevermore.Tests.Util
             public OtherMap()
             {
                 TableName = "OtherTbl";
+            }
+        }
+
+        class TestDocumentWithIdentityIdMap : DocumentMap<TestDocumentWithIdentityId>
+        {
+            public TestDocumentWithIdentityIdMap()
+            {
+                TableName = "TestDocumentTbl";
+                Id(t => t.Id).Identity();
+                Column(t => t.AColumn);
+            }
+        }
+
+        class TestDocumentWithIdentityIdAndRowVersionMap : DocumentMap<TestDocumentWithIdentityIdAndRowVersion>
+        {
+            public TestDocumentWithIdentityIdAndRowVersionMap()
+            {
+                TableName = "TestDocumentTbl";
+                Id(t => t.Id).Identity();
+                Column(t => t.AColumn);
+                RowVersion(t => t.RowVersion);
             }
         }
     }

--- a/source/Nevermore.sln.DotSettings
+++ b/source/Nevermore.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">400</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>

--- a/source/Nevermore.sln.DotSettings
+++ b/source/Nevermore.sln.DotSettings
@@ -4,6 +4,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=retriable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -90,7 +90,7 @@ namespace Nevermore.Advanced
             {
                 return new ArrayParametersQueryBuilder<TRecord>(AddAlwaysFalseWhere(), parameterNamesList);
             }
-            
+
             selectBuilder.AddWhere(new ArrayWhereParameter(fieldName, operand, parameterNamesList));
             IQueryBuilder<TRecord> builder = this;
             return new ArrayParametersQueryBuilder<TRecord>(parameterNamesList.Aggregate(builder, (b, p) => b.Parameter(p)), parameterNamesList);
@@ -398,10 +398,10 @@ namespace Nevermore.Advanced
             {
                 results.Add(item);
             }
-            
+
             return results;
         }
-        
+
         SubquerySelectBuilder BuildToList(int skip, int take, out CommandParameterValues parmeterValues)
         {
             const string rowNumberColumnName = "RowNum";
@@ -454,7 +454,7 @@ namespace Nevermore.Advanced
         {
             var results = new List<TRecord>();
 
-            await foreach (var item in StreamAsync(cancellationToken)) 
+            await foreach (var item in StreamAsync(cancellationToken))
                 results.Add(item);
 
             return results;

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -26,9 +27,9 @@ namespace Nevermore.Advanced
         readonly RetriableOperation operationsToRetry;
         readonly IRelationalStoreConfiguration configuration;
         readonly ITableAliasGenerator tableAliasGenerator = new TableAliasGenerator();
-        readonly string name;
+        readonly string? name;
 
-        DbConnection connection;
+        DbConnection? connection;
 
         protected IUniqueParameterNameGenerator ParameterNameGenerator { get; } = new UniqueParameterNameGenerator();
 
@@ -39,7 +40,7 @@ namespace Nevermore.Advanced
 
         public IDictionary<string, object> State { get; }
 
-        public ReadTransaction(RelationalTransactionRegistry registry, RetriableOperation operationsToRetry, IRelationalStoreConfiguration configuration, string name = null)
+        public ReadTransaction(RelationalTransactionRegistry registry, RetriableOperation operationsToRetry, IRelationalStoreConfiguration configuration, string? name = null)
         {
             State = new Dictionary<string, object>();
             this.registry = registry;
@@ -51,7 +52,7 @@ namespace Nevermore.Advanced
             registry.Add(this);
         }
 
-        protected DbTransaction Transaction { get; private set; }
+        protected DbTransaction? Transaction { get; private set; }
 
         public void Open()
         {
@@ -71,34 +72,35 @@ namespace Nevermore.Advanced
         public void Open(IsolationLevel isolationLevel)
         {
             Open();
-            Transaction = connection.BeginTransaction(isolationLevel);
+            Transaction = connection!.BeginTransaction(isolationLevel);
         }
 
         public async Task OpenAsync(IsolationLevel isolationLevel)
         {
             await OpenAsync();
-            Transaction = await connection.BeginTransactionAsync(isolationLevel);
+            Transaction = await connection!.BeginTransactionAsync(isolationLevel);
         }
 
         [Pure]
-        private TDocument Load<TDocument, TKey>(TKey id) where TDocument : class
+        public TDocument? Load<TDocument, TKey>(TKey id) where TDocument : class
         {
             return Stream<TDocument>(PrepareLoad<TDocument, TKey>(id)).FirstOrDefault();
         }
 
         [Pure]
-        public TDocument Load<TDocument>(string id) where TDocument : class => Load<TDocument, string>(id);
+        public TDocument? Load<TDocument>(string id) where TDocument : class => Load<TDocument, string>(id);
 
         [Pure]
-        public TDocument Load<TDocument>(int id) where TDocument : class => Load<TDocument, int>(id);
+        public TDocument? Load<TDocument>(int id) where TDocument : class => Load<TDocument, int>(id);
 
         [Pure]
-        public TDocument Load<TDocument>(long id) where TDocument : class => Load<TDocument, long>(id);
+        public TDocument? Load<TDocument>(long id) where TDocument : class => Load<TDocument, long>(id);
 
         [Pure]
-        public TDocument Load<TDocument>(Guid id) where TDocument : class => Load<TDocument, Guid>(id);
+        public TDocument? Load<TDocument>(Guid id) where TDocument : class => Load<TDocument, Guid>(id);
 
-        private async Task<TDocument> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
+        [Pure]
+        public async Task<TDocument?> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = StreamAsync<TDocument>(PrepareLoad<TDocument, TKey>(id), cancellationToken);
             await foreach (var row in results.WithCancellation(cancellationToken))
@@ -107,50 +109,63 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument?> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, string>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument?> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, int>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument?> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, long>(id, cancellationToken);
 
         [Pure]
-        public Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
+        public Task<TDocument?> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadAsync<TDocument, Guid>(id, cancellationToken);
 
-        private List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+        [Pure]
+        public List<TDocument> LoadMany<TDocument, TKey>(params TKey[] ids) where TDocument : class
             => LoadStream<TDocument, TKey>(ids).ToList();
 
+        [Pure]
+        public List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+            => LoadStream<TDocument, TKey>(ids).ToList();
+
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(params string[] ids) where TDocument : class
             => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(params int[] ids) where TDocument : class
           => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(params long[] ids) where TDocument : class
           => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(params Guid[] ids) where TDocument : class
           => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(IEnumerable<string> ids) where TDocument : class
             => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(IEnumerable<int> ids) where TDocument : class
            => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(IEnumerable<long> ids) where TDocument : class
            => LoadStream<TDocument>(ids).ToList();
 
+        [Pure]
         public List<TDocument> LoadMany<TDocument>(IEnumerable<Guid> ids) where TDocument : class
            => LoadStream<TDocument>(ids).ToList();
 
         [Pure]
-        private async Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
+        public async Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = new List<TDocument>();
             await foreach (var item in LoadStreamAsync<TDocument, TKey>(ids, cancellationToken))
@@ -178,7 +193,7 @@ namespace Nevermore.Advanced
             => LoadManyAsync<TDocument, Guid>(ids, cancellationToken);
 
         [Pure]
-        private TDocument LoadRequired<TDocument, TKey>(TKey id) where TDocument : class
+        public TDocument LoadRequired<TDocument, TKey>(TKey id) where TDocument : class
         {
             var result = Load<TDocument, TKey>(id);
             if (result == null)
@@ -203,7 +218,7 @@ namespace Nevermore.Advanced
             => LoadRequired<TDocument, Guid>(id);
 
         [Pure]
-        private async Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
+        public async Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
             var result = await LoadAsync<TDocument, TKey>(id, cancellationToken);
             if (result == null)
@@ -227,7 +242,12 @@ namespace Nevermore.Advanced
         public Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
             => LoadRequiredAsync<TDocument, Guid>(id, cancellationToken);
 
-        private List<TDocument> LoadManyRequired<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+        [Pure]
+        public List<TDocument> LoadManyRequired<TDocument, TKey>(params TKey[] ids) where TDocument : class
+            => LoadManyRequired<TDocument, TKey>(ids.AsEnumerable());
+
+        [Pure]
+        public List<TDocument> LoadManyRequired<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Distinct().ToList();
             var results = LoadMany<TDocument, TKey>(idList);
@@ -240,31 +260,40 @@ namespace Nevermore.Advanced
             return results;
         }
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(params string[] ids) where TDocument : class
             => LoadManyRequired<TDocument, string>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(params int[] ids) where TDocument : class
             => LoadManyRequired<TDocument, int>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(params long[] ids) where TDocument : class
             => LoadManyRequired<TDocument, long>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(params Guid[] ids) where TDocument : class
             => LoadManyRequired<TDocument, Guid>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<string> ids) where TDocument : class
            => LoadManyRequired<TDocument, string>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<int> ids) where TDocument : class
           => LoadManyRequired<TDocument, int>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<long> ids) where TDocument : class
           => LoadManyRequired<TDocument, long>(ids);
 
+        [Pure]
         public List<TDocument> LoadManyRequired<TDocument>(IEnumerable<Guid> ids) where TDocument : class
           => LoadManyRequired<TDocument, Guid>(ids);
 
-        private async Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
+        [Pure]
+        public async Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var idList = ids.Distinct().ToArray();
             var results = await LoadManyAsync<TDocument, TKey>(idList, cancellationToken);
@@ -277,20 +306,28 @@ namespace Nevermore.Advanced
             return results;
         }
 
+        [Pure]
         public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<string> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadManyRequiredAsync<TDocument, string>(ids, cancellationToken);
 
+        [Pure]
         public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<int> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadManyRequiredAsync<TDocument, int>(ids, cancellationToken);
 
+        [Pure]
         public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<long> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadManyRequiredAsync<TDocument, long>(ids, cancellationToken);
 
+        [Pure]
         public Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class
             => LoadManyRequiredAsync<TDocument, Guid>(ids, cancellationToken);
 
         [Pure]
-        private IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
+        public IEnumerable<TDocument> LoadStream<TDocument, TKey>(params TKey[] ids) where TDocument : class
+            => LoadStream<TDocument, TKey>(ids.AsEnumerable());
+
+        [Pure]
+        public IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class
         {
             var idList = ids.Where(id => id != null).Distinct().ToList();
 
@@ -330,7 +367,7 @@ namespace Nevermore.Advanced
             => LoadStream<TDocument, Guid>(ids);
 
         [Pure]
-        private async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument, TKey>(IEnumerable<TKey> ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
+        public async IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument, TKey>(IEnumerable<TKey> ids, [EnumeratorCancellation] CancellationToken cancellationToken = default) where TDocument : class
         {
             var idList = ids.Where(id => id != null).Distinct().ToList();
             if (idList.Count == 0)
@@ -361,7 +398,7 @@ namespace Nevermore.Advanced
         public ITableSourceQueryBuilder<TRecord> Query<TRecord>() where TRecord : class
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
-            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), map.IdColumn.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, configuration.GetSchemaNameOrDefault(map), map.IdColumn?.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public ISubquerySourceBuilder<TRecord> RawSqlQuery<TRecord>(string query) where TRecord : class
@@ -369,12 +406,12 @@ namespace Nevermore.Advanced
             return new SubquerySourceBuilder<TRecord>(new RawSql(query), this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
-        public IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args, TimeSpan? commandTimeout = null)
+        public IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null)
         {
             return Stream<TRecord>(new PreparedCommand(query, args, RetriableOperation.Select, commandBehavior: CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, commandTimeout: commandTimeout));
         }
 
-        public IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        public IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
         {
             return StreamAsync<TRecord>(new PreparedCommand(query, args, RetriableOperation.Select, commandBehavior: CommandBehavior.SequentialAccess | CommandBehavior.SingleResult, commandTimeout: commandTimeout), cancellationToken);
         }
@@ -452,12 +489,12 @@ namespace Nevermore.Advanced
             }
         }
 
-        public int ExecuteNonQuery(string query, CommandParameterValues args, TimeSpan? commandTimeout = null)
+        public int ExecuteNonQuery(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null)
         {
             return ExecuteNonQuery(new PreparedCommand(query, args, RetriableOperation.None, commandBehavior: CommandBehavior.Default, commandTimeout: commandTimeout));
         }
 
-        public Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        public Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
         {
             return ExecuteNonQueryAsync(new PreparedCommand(query, args, RetriableOperation.None, commandBehavior: CommandBehavior.Default, commandTimeout: commandTimeout), cancellationToken);
         }
@@ -474,12 +511,12 @@ namespace Nevermore.Advanced
             return await command.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public TResult ExecuteScalar<TResult>(string query, CommandParameterValues args, RetriableOperation operation, TimeSpan? commandTimeout = null)
+        public TResult ExecuteScalar<TResult>(string query, CommandParameterValues? args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null)
         {
-            return ExecuteScalar<TResult>(new PreparedCommand(query, args, operation, commandTimeout: commandTimeout));
+            return ExecuteScalar<TResult>(new PreparedCommand(query, args, retriableOperation, commandTimeout: commandTimeout));
         }
 
-        public Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        public Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues? args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
         {
             return ExecuteScalarAsync<TResult>(new PreparedCommand(query, args, retriableOperation, null, commandTimeout), cancellationToken);
         }
@@ -489,7 +526,7 @@ namespace Nevermore.Advanced
             using var command = CreateCommand(preparedCommand);
             var result = command.ExecuteScalar();
             if (result == DBNull.Value)
-                return default;
+                return default!;
             return (TResult) result;
         }
 
@@ -498,16 +535,16 @@ namespace Nevermore.Advanced
             using var command = CreateCommand(preparedCommand);
             var result = await command.ExecuteScalarAsync(cancellationToken);
             if (result == DBNull.Value)
-                return default;
+                return default!;
             return (TResult) result;
         }
 
-        public DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null)
+        public DbDataReader ExecuteReader(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null)
         {
             return ExecuteReader(new PreparedCommand(query, args, RetriableOperation.Select, commandTimeout: commandTimeout));
         }
 
-        public Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
+        public Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default)
         {
             return ExecuteReaderAsync(new PreparedCommand(query, args, RetriableOperation.Select, commandTimeout: commandTimeout), cancellationToken);
         }
@@ -540,11 +577,14 @@ namespace Nevermore.Advanced
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
 
+            if (mapping.IdColumn is null)
+                throw new InvalidOperationException($"Cannot load {mapping.Type.Name} by Id, as no Id column has been mapped.");
+
             if (mapping.IdColumn.Type != typeof(TKey))
-                throw new ArgumentException($"Provided Id of type '{id.GetType().FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
+                throw new ArgumentException($"Provided Id of type '{id?.GetType().FullName}' does not match configured type of '{mapping.IdColumn?.Type.FullName}'.");
 
             var tableName = mapping.TableName;
-            var args = new CommandParameterValues {{"Id", id}};
+            var args = new CommandParameterValues {{ "Id", mapping.IdColumn.PrimaryKeyHandler.ConvertToPrimitiveValue(id) }};
             return new PreparedCommand($"SELECT TOP 1 * FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 
@@ -552,11 +592,11 @@ namespace Nevermore.Advanced
         {
             var mapping = configuration.DocumentMaps.Resolve(typeof(TDocument));
 
-            if (mapping.IdColumn.Type != typeof(TKey))
-                throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
+            if (mapping.IdColumn?.Type != typeof(TKey))
+                throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn?.Type.FullName}'.");
 
             var param = new CommandParameterValues();
-            param.AddTable("criteriaTable", idList.ToList());
+            param.AddTable("criteriaTable", idList.ToList(), configuration);
             var statement = $"SELECT s.* FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }
@@ -628,7 +668,7 @@ namespace Nevermore.Advanced
             return $"{CreatedTime} - {connection?.State} - {name}";
         }
 
-        string ITransactionDiagnostic.Name => name;
+        string? ITransactionDiagnostic.Name => name;
 
         void ITransactionDiagnostic.WriteCurrentTransactions(StringBuilder output)
         {

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -530,7 +530,7 @@ namespace Nevermore.Advanced
             return command.ReadResults(mapper);
         }
 
-        protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper, CancellationToken cancellationToken = default)
+        protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, Task<TResult>> mapper, CancellationToken cancellationToken)
         {
             using var command = CreateCommand(preparedCommand);
             return await command.ReadResultsAsync(mapper, cancellationToken);

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -282,7 +282,7 @@ namespace Nevermore.Advanced
 
             return await ReadResultsAsync(command,
                 async reader => await DataModificationOutput.ReadAsync(reader, command.Mapping,
-                    command.Operation == RetriableOperation.Insert, cancellationToken));
+                    command.Operation == RetriableOperation.Insert, cancellationToken), cancellationToken);
         }
 
         async Task<DataModificationOutput> ExecuteSingleDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -230,7 +230,7 @@ namespace Nevermore.Advanced
             return AllocateId(tableName, key => $"{idPrefix}-{key}");
         }
 
-        public string AllocateId(string tableName, Func<int, string> idFormatter)
+        string AllocateId(string tableName, Func<int, string> idFormatter)
         {
             var key = keyAllocator.NextId(tableName);
             return idFormatter(key);

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -36,8 +38,9 @@ namespace Nevermore.Advanced
             var command = builder.PrepareInsert(new[] {document}, options);
             configuration.Hooks.BeforeInsert(document, command.Mapping, this);
 
-            var newRowVersion = ExecuteSingleDataModification(command);
-            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
+            var output = ExecuteSingleDataModification(command);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, output);
+            ApplyIdentityIdsIfRequired(document, command.Mapping, output);
 
             configuration.Hooks.AfterInsert(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -53,8 +56,9 @@ namespace Nevermore.Advanced
             var command = builder.PrepareInsert(new[] {document}, options);
             await configuration.Hooks.BeforeInsertAsync(document, command.Mapping, this);
 
-            var newRowVersion = await ExecuteSingleDataModificationAsync(command, cancellationToken);
-            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
+            var output = await ExecuteSingleDataModificationAsync(command, cancellationToken);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, output);
+            ApplyIdentityIdsIfRequired(document, command.Mapping, output);
 
             await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -68,8 +72,9 @@ namespace Nevermore.Advanced
             var command = builder.PrepareInsert(documentList, options);
             foreach (var document in documents) configuration.Hooks.BeforeInsert(document, command.Mapping, this);
 
-            var newRowVersions = ExecuteDataModification(command);
-            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, newRowVersions);
+            var outputs = ExecuteDataModification(command);
+            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, outputs);
+            ApplyIdentityIdsIfRequired(documentList, command.Mapping, outputs);
 
             foreach (var document in documentList) configuration.Hooks.AfterInsert(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, documentList);
@@ -87,12 +92,15 @@ namespace Nevermore.Advanced
 
             var command = builder.PrepareInsert(documentList, options);
 
-            foreach (var document in documentList) await configuration.Hooks.BeforeInsertAsync(document, command.Mapping, this);
+            foreach (var document in documentList)
+                await configuration.Hooks.BeforeInsertAsync(document, command.Mapping, this);
 
-            var newRowVersions = await ExecuteDataModificationAsync(command, cancellationToken);
-            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, newRowVersions);
+            var outputs = await ExecuteDataModificationAsync(command, cancellationToken);
+            ApplyNewRowVersionsIfRequired(documentList, command.Mapping, outputs);
+            ApplyIdentityIdsIfRequired(documentList, command.Mapping, outputs);
 
-            foreach (var document in documentList) await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
+            foreach (var document in documentList)
+                await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
 
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, documentList);
         }
@@ -102,8 +110,8 @@ namespace Nevermore.Advanced
             var command = builder.PrepareUpdate(document, options);
             configuration.Hooks.BeforeUpdate(document, command.Mapping, this);
 
-            var newRowVersion = ExecuteSingleDataModification(command);
-            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
+            var output = ExecuteSingleDataModification(command);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, output);
 
             configuration.Hooks.AfterUpdate(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -119,8 +127,8 @@ namespace Nevermore.Advanced
             var command = builder.PrepareUpdate(document, options);
             await configuration.Hooks.BeforeUpdateAsync(document, command.Mapping, this);
 
-            var newRowVersion = await ExecuteSingleDataModificationAsync(command, cancellationToken);
-            ApplyNewRowVersionIfRequired(document, command.Mapping, newRowVersion);
+            var output = await ExecuteSingleDataModificationAsync(command, cancellationToken);
+            ApplyNewRowVersionIfRequired(document, command.Mapping, output);
 
             await configuration.Hooks.AfterUpdateAsync(document, command.Mapping, this);
             configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
@@ -206,6 +214,12 @@ namespace Nevermore.Advanced
             return AllocateId(mapping);
         }
 
+        public string AllocateId<TDocument>()
+        {
+            var mapping = configuration.DocumentMaps.Resolve<TDocument>();
+            return AllocateId(mapping);
+        }
+
         string AllocateId(DocumentMap mapping)
         {
             return AllocateId(mapping.TableName, mapping.IdFormat);
@@ -238,59 +252,118 @@ namespace Nevermore.Advanced
             await configuration.Hooks.AfterCommitAsync(this);
         }
 
-        object[] ExecuteDataModification(PreparedCommand command)
+        DataModificationOutput[] ExecuteDataModification(PreparedCommand command)
         {
-            if (!command.Mapping.IsRowVersioningEnabled)
+            if (!command.Mapping.HasModificationOutputs)
             {
                 ExecuteNonQuery(command);
-                return Array.Empty<object>();
+                return Array.Empty<DataModificationOutput>();
             }
 
             //The results need to be read eagerly so errors are raised while code is still executing within CommandExecutor error handling logic
-            return ReadResults(command, reader => reader.GetValue(0));
+            return ReadResults(command,
+                reader => DataModificationOutput.Read(reader, command.Mapping,
+                    command.Operation == RetriableOperation.Insert));
         }
 
-        object ExecuteSingleDataModification(PreparedCommand command)
+        DataModificationOutput ExecuteSingleDataModification(PreparedCommand command)
         {
             var results = ExecuteDataModification(command);
             return results.SingleOrDefault();
         }
 
-        async Task<object[]> ExecuteDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
+        async Task<DataModificationOutput[]> ExecuteDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
         {
-            if (!command.Mapping.IsRowVersioningEnabled)
+            if (!command.Mapping.HasModificationOutputs)
             {
                 await ExecuteNonQueryAsync(command, cancellationToken);
-                return Array.Empty<object>();
+                return Array.Empty<DataModificationOutput>();
             }
 
-            return await ReadResultsAsync(command, reader => reader.GetValue(0), cancellationToken);
+            return await ReadResultsAsync(command,
+                async reader => await DataModificationOutput.ReadAsync(reader, command.Mapping,
+                    command.Operation == RetriableOperation.Insert, cancellationToken));
         }
 
-        async Task<object> ExecuteSingleDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
+        async Task<DataModificationOutput> ExecuteSingleDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)
         {
             var results = await ExecuteDataModificationAsync(command, cancellationToken);
             return results.SingleOrDefault();
         }
 
-        void ApplyNewRowVersionsIfRequired(IReadOnlyList<object> documentList, DocumentMap mapping, object[] newRowVersions)
+        void ApplyNewRowVersionsIfRequired(IReadOnlyList<object> documentList, DocumentMap mapping, DataModificationOutput[] outputs)
         {
             if (!mapping.IsRowVersioningEnabled) return;
 
             for (var i = 0; i < documentList.Count; i++)
             {
-                ApplyNewRowVersionIfRequired(documentList[i], mapping, newRowVersions[i]);
+                ApplyNewRowVersionIfRequired(documentList[i], mapping, outputs[i]);
             }
         }
 
-        void ApplyNewRowVersionIfRequired<TDocument>(TDocument document, DocumentMap mapping, object newRowVersion) where TDocument : class
+        void ApplyNewRowVersionIfRequired<TDocument>(TDocument document, DocumentMap mapping, DataModificationOutput output) where TDocument : class
         {
             if (!mapping.IsRowVersioningEnabled) return;
 
-            if (newRowVersion == null) throw new StaleDataException($"Modification failed for '{typeof(TDocument).Name}' document with '{mapping.GetId(document)}' Id because submitted data was out of date. Refresh the document and try again.");
+            if (output?.RowVersion == null)
+                throw new StaleDataException($"Modification failed for '{typeof(TDocument).Name}' document with '{mapping.GetId(document)}' Id because submitted data was out of date. Refresh the document and try again.");
 
-            mapping.RowVersionColumn.PropertyHandler.Write(document, newRowVersion);
+            mapping.RowVersionColumn.PropertyHandler.Write(document, output.RowVersion);
         }
 
+        void ApplyIdentityIdsIfRequired(IReadOnlyList<object> documentList, DocumentMap mapping, DataModificationOutput[] outputs)
+        {
+            if (!mapping.IsIdentityId) return;
+
+            for (var i = 0; i < documentList.Count; i++)
+            {
+                ApplyIdentityIdsIfRequired(documentList[i], mapping, outputs[i]);
+            }
+        }
+
+        void ApplyIdentityIdsIfRequired<TDocument>(TDocument document, DocumentMap mapping, DataModificationOutput output) where TDocument : class
+        {
+            if (!mapping.IsIdentityId) return;
+
+            if (output?.Id == null)
+                throw new InvalidOperationException(
+                    $"Modification failed for '{typeof(TDocument).Name}' document with '{mapping.GetId(document)}' Id because the server failed to return a new Identity id.");
+
+            mapping.IdColumn.PropertyHandler.Write(document, output.Id);
+        }
+
+        class DataModificationOutput
+        {
+            public byte[] RowVersion { get; private set; }
+            public object Id { get; private set; }
+
+            public static DataModificationOutput Read(DbDataReader reader, DocumentMap map, bool isInsert)
+            {
+                var output = new DataModificationOutput();
+
+                if (map.IsRowVersioningEnabled)
+                    output.RowVersion =
+                        reader.GetFieldValue<byte[]>(map.RowVersionColumn.ColumnName);
+
+                if (map.IsIdentityId && isInsert)
+                    output.Id = reader.GetFieldValue<object>(map.IdColumn.ColumnName);
+
+                return output;
+            }
+
+            public static async Task<DataModificationOutput> ReadAsync(DbDataReader reader, DocumentMap map, bool isInsert, CancellationToken cancellationToken)
+            {
+                var output = new DataModificationOutput();
+
+                if (map.IsRowVersioningEnabled)
+                    output.RowVersion =
+                        await reader.GetFieldValueAsync<byte[]>(map.RowVersionColumn.ColumnName, cancellationToken);
+
+                if (map.IsIdentityId && isInsert)
+                    output.Id = await reader.GetFieldValueAsync<object>(map.IdColumn.ColumnName, cancellationToken);
+
+                return output;
+            }
+        }
     }
 }

--- a/source/Nevermore/CommandExecutor.cs
+++ b/source/Nevermore/CommandExecutor.cs
@@ -185,7 +185,7 @@ namespace Nevermore
             try
             {
                 var data = new List<T>();
-                using (var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior))
+                using (var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken))
                 {
                     while (await reader.ReadAsync(cancellationToken))
                     {

--- a/source/Nevermore/CommandExecutor.cs
+++ b/source/Nevermore/CommandExecutor.cs
@@ -180,15 +180,17 @@ namespace Nevermore
             }
         }
 
-        public async Task<T[]> ReadResultsAsync<T>(Func<DbDataReader, T> mapper, CancellationToken cancellationToken = default)
+        public async Task<T[]> ReadResultsAsync<T>(Func<DbDataReader, Task<T>> mapper, CancellationToken cancellationToken)
         {
             try
             {
                 var data = new List<T>();
-                await using var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken: cancellationToken);
-                while (await reader.ReadAsync(cancellationToken))
+                using (var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior))
                 {
-                    data.Add(mapper(reader));
+                    while (await reader.ReadAsync(cancellationToken))
+                    {
+                        data.Add(await mapper(reader));
+                    }
                 }
 
                 return data.ToArray();

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,47 +56,27 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable<T>(string name, IReadOnlyCollection<T> ids)
+        public void AddTable<T>(string name, IReadOnlyCollection<T> ids, IRelationalStoreConfiguration configuration)
         {
-            var idColumnMetadata = GetSqlMetaData(ids, "ParameterValue");
+            var primaryKeyHandler = configuration.PrimaryKeyHandlers.Resolve(typeof(T));
+            if (primaryKeyHandler is null)
+                throw new InvalidOperationException($"Unable to locate primary key handler for type {typeof(T).Name}");
+
+            var idColumnMetadata = primaryKeyHandler.GetSqlMetaData("ParameterValue");
 
             var dataRecords = ids.Where(v => v != null).Select(v =>
             {
                 var record = new SqlDataRecord(idColumnMetadata);
-                record.SetValue(0, v);
+                record.SetValue(0, primaryKeyHandler.ConvertToPrimitiveValue(v));
                 return record;
             }).ToList();
-            
+
             AddTable(name, new TableValuedParameter("dbo.[ParameterList]", dataRecords));
         }
-        
+
         public void AddTable(string name, TableValuedParameter tvp)
         {
             Add(name, tvp);
-        }
-
-        static SqlMetaData GetSqlMetaData<T>(IReadOnlyCollection<T> ids, string name)
-        {
-            var valueType = typeof(T);
-            var notSupportedErrorMsg = $"'{valueType.Name}' is not a valid ID type, supported types are: {nameof(String)}, {nameof(Int32)}, {nameof(Int64)} and {nameof(Guid)}.";
-            switch (Type.GetTypeCode(valueType))
-            {
-                //TODO: May consider dynamically resolving the 'ParameterValue' column length for User-Defined Table Type 'ParameterList' based on each DocumentMap configuration later.
-                //TODO: The fixed length of 300 is a temporary solution which match our table schema in Script0002-ParameterList.sql
-                case TypeCode.String: return new SqlMetaData(name, SqlDbType.NVarChar, 300);
-                case TypeCode.Int32: return new SqlMetaData(name, SqlDbType.Int);
-                case TypeCode.Int64: return new SqlMetaData(name, SqlDbType.BigInt);
-                case TypeCode.Object:
-                {
-                    if (valueType == typeof(Guid)) 
-                    { 
-                        return new SqlMetaData(name, SqlDbType.UniqueIdentifier);
-                    }
-                    
-                    throw new NotSupportedException(notSupportedErrorMsg);
-                }
-                default: throw new NotSupportedException(notSupportedErrorMsg);
-            }
         }
 
         void AddFromParametersObject(object args)
@@ -139,7 +119,7 @@ namespace Nevermore
                 command.Parameters.Add(p);
                 return;
             }
-            
+
             if (value is TableValuedParameter tvp && command is SqlCommand sqlCommand)
             {
                 var p = sqlCommand.Parameters.Add(name, SqlDbType.Structured);
@@ -154,9 +134,9 @@ namespace Nevermore
                 var i = 0;
 
                 var inClauseValues = ((IEnumerable) value).Cast<object>().ToList();
-                
+
                 ListExtender.ExtendListRepeatingLastValue(inClauseValues);
-                
+
                 foreach (var inClauseValue in inClauseValues)
                 {
                     i++;
@@ -181,7 +161,7 @@ namespace Nevermore
             var columnType = DatabaseTypeConverter.AsDbType(value.GetType());
             if (columnType == null)
                 throw new InvalidOperationException($"Cannot map type '{value.GetType().FullName}' to a DbType. Consider providing a custom ITypeHandler.");
-            
+
             var param = new SqlParameter();
             param.ParameterName = name;
             param.DbType = columnType.Value;
@@ -192,11 +172,11 @@ namespace Nevermore
                 var size = GetBestSizeBucket(text);
                 if (size > 0)
                 {
-                    param.Size = size; 
+                    param.Size = size;
                 }
             }
 
-            // To assist SQL's query plan caching, assign a parameter size for our 
+            // To assist SQL's query plan caching, assign a parameter size for our
             // common id lookups where possible.
             if (mapping != null
                 && mapping.IdColumn != null
@@ -223,11 +203,11 @@ namespace Nevermore
             command.Parameters.Add(param);
         }
 
-        
+
 
         // By default all string parameters have their size automatically assigned based on the length of the string.
         // This results in a different query plan depending on the size of the text used. The query plan ends up like this:
-        // 
+        //
         //   (@firstname nvarchar(24))SELECT TOP 100 *  FROM dbo.[Customer]  WHERE ([FirstName] <> @firstname)  ORDER BY [Id]
         //   (@firstname nvarchar(44))SELECT TOP 100 *  FROM dbo.[Customer]  WHERE ([FirstName] <> @firstname)  ORDER BY [Id]
         //   (@firstname nvarchar(47))SELECT TOP 100 *  FROM dbo.[Customer]  WHERE ([FirstName] <> @firstname)  ORDER BY [Id]

--- a/source/Nevermore/ConfigurationExtensions.cs
+++ b/source/Nevermore/ConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Nevermore.Advanced;
 using Nevermore.Advanced.Serialization;
@@ -18,10 +19,10 @@ namespace Nevermore
             callback(jsonNet.SerializerSettings);
         }
 
-        internal static string GetSchemaNameOrDefault(this IRelationalStoreConfiguration configuration, string schemaName)
+        internal static string GetSchemaNameOrDefault(this IRelationalStoreConfiguration configuration, string? schemaName)
         {
-            return schemaName 
-                ?? configuration.DefaultSchema 
+            return schemaName
+                ?? configuration.DefaultSchema
                 ?? NevermoreDefaults.FallbackDefaultSchemaName;
         }
 

--- a/source/Nevermore/IReadQueryExecutor.cs
+++ b/source/Nevermore/IReadQueryExecutor.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -19,7 +20,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] TDocument Load<TDocument>(string id) where TDocument : class;
+        [Pure] TDocument? Load<TDocument>(string id) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -27,7 +28,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] TDocument Load<TDocument>(int id) where TDocument : class;
+        [Pure] TDocument? Load<TDocument>(int id) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -35,7 +36,7 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] TDocument Load<TDocument>(long id) where TDocument : class;
+        [Pure] TDocument? Load<TDocument>(long id) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -43,25 +44,16 @@ namespace Nevermore
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] TDocument Load<TDocument>(Guid id) where TDocument : class;
+        [Pure] TDocument? Load<TDocument>(Guid id) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The type of the Id</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
-        /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] Task<TDocument> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
-
-        /// <summary>
-        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
-        /// </summary>
-        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
-        /// <param name="id">The <c>Id</c> of the document to find.</param>
-        /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] Task<TDocument> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
+        [Pure] TDocument? Load<TDocument, TKey>(TKey id) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -70,7 +62,7 @@ namespace Nevermore
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] Task<TDocument> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
+        [Pure] Task<TDocument?> LoadAsync<TDocument>(string id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
@@ -79,7 +71,35 @@ namespace Nevermore
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
-        [Pure] Task<TDocument> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+        [Pure] Task<TDocument?> LoadAsync<TDocument>(int id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument?> LoadAsync<TDocument>(long id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument?> LoadAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The type of the Id</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument?> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -158,6 +178,26 @@ namespace Nevermore
         /// the results may contain less items than the number of ID's queried for).
         /// </summary>
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument, TKey>(params TKey[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadMany<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="ids">A collection of ID's to query by.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The documents.</returns>
@@ -192,6 +232,17 @@ namespace Nevermore
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The documents.</returns>
         [Pure] Task<List<TDocument>> LoadManyAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
@@ -270,6 +321,26 @@ namespace Nevermore
         /// the results may contain less items than the number of ID's queried for).
         /// </summary>
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument, TKey>(params TKey[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IEnumerable<TDocument> LoadStream<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="ids">A collection of ID's to query by.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The documents as a lazy loaded stream.</returns>
@@ -304,6 +375,17 @@ namespace Nevermore
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The documents as a lazy loaded stream.</returns>
         [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. Documents that are not found are excluded from the result list (that is,
+        /// the results may contain less items than the number of ID's queried for).
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents as a lazy loaded stream.</returns>
+        [Pure] IAsyncEnumerable<TDocument> LoadStreamAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
@@ -341,6 +423,15 @@ namespace Nevermore
         /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] TDocument LoadRequired<TDocument, TKey>(TKey id) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="id">The <c>Id</c> of the document to find.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
@@ -372,6 +463,16 @@ namespace Nevermore
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
         [Pure] Task<TDocument> LoadRequiredAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Loads a single document given its ID. If the item is not found, throws a <see cref="ResourceNotFoundException" />.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="id">The <c>Id</c> of the document to find.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The document, or <c>null</c> if the document is not found.</returns>
+        [Pure] Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Loads a set of documents by their ID's. If any of the documents are not found, a
@@ -450,6 +551,26 @@ namespace Nevermore
         /// <see cref="ResourceNotFoundException" /> will be thrown.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument, TKey>(params TKey[] ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <returns>The documents.</returns>
+        [Pure] List<TDocument> LoadManyRequired<TDocument, TKey>(IEnumerable<TKey> ids) where TDocument : class;
+
+        /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
         /// <param name="ids">A collection of ID's to query by.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>The documents.</returns>
@@ -486,6 +607,17 @@ namespace Nevermore
         [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument>(IEnumerable<Guid> ids, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
+        /// Loads a set of documents by their ID's. If any of the documents are not found, a
+        /// <see cref="ResourceNotFoundException" /> will be thrown.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
+        /// <typeparam name="TKey">The primary key type of the document</typeparam>
+        /// <param name="ids">A collection of ID's to query by.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        /// <returns>The documents.</returns>
+        [Pure] Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
         /// Begins building a query that returns strongly typed documents.
         /// </summary>
         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
@@ -509,7 +641,7 @@ namespace Nevermore
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A stream of resulting documents.</returns>
-        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        [Pure] IEnumerable<TRecord> Stream<TRecord>(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns strongly typed documents.
@@ -520,10 +652,10 @@ namespace Nevermore
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>A stream of resulting documents.</returns>
-        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Executes a query that returns strongly typed documents. 
+        /// Executes a query that returns strongly typed documents.
         /// </summary>
         /// <param name="preparedCommand">Everything needed to run the query.</param>
         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
@@ -531,7 +663,7 @@ namespace Nevermore
         [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
 
         /// <summary>
-        /// Executes a query that returns strongly typed documents. 
+        /// Executes a query that returns strongly typed documents.
         /// </summary>
         /// <param name="preparedCommand">Everything needed to run the query.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
@@ -569,7 +701,7 @@ namespace Nevermore
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>The number of rows affected.</returns>
-        int ExecuteNonQuery(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        int ExecuteNonQuery(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns no results, typically one that will write to the database. It can also be
@@ -580,7 +712,7 @@ namespace Nevermore
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>Depends on the query, but typically the number of rows affected.</returns>
-        Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        Task<int> ExecuteNonQueryAsync(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a query that returns no results, typically one that will write to the database. It can also be
@@ -608,7 +740,7 @@ namespace Nevermore
         /// <param name="retriableOperation">The type of operation being performed. The retry policy on the transaction will then decide whether it's safe to retry this command if it fails.</param>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A scalar value.</returns>
-        TResult ExecuteScalar<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
+        TResult ExecuteScalar<TResult>(string query, CommandParameterValues? args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
@@ -620,7 +752,7 @@ namespace Nevermore
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>A scalar value.</returns>
-        Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        Task<TResult> ExecuteScalarAsync<TResult>(string query, CommandParameterValues? args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a query that returns a scalar value (e.g., SELECT query that returns a count).
@@ -646,7 +778,7 @@ namespace Nevermore
         /// <param name="args">Any arguments to pass to the query as command parameters.</param>
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <returns>A data reader.</returns>
-        [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null);
+        [Pure] DbDataReader ExecuteReader(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null);
 
         /// <summary>
         /// Executes a query that returns a data reader that you can process manually.
@@ -656,7 +788,7 @@ namespace Nevermore
         /// <param name="commandTimeout">A custom timeout to use for the command instead of the default.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         /// <returns>A data reader.</returns>
-        [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
+        [Pure] Task<DbDataReader> ExecuteReaderAsync(string query, CommandParameterValues? args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a query that returns a data reader that you can process manually.

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -13,39 +13,40 @@ namespace Nevermore
     {
         string ApplicationName { get; set; }
         string ConnectionString { get; }
-        
+
         /// <summary>
         /// Gets or sets whether synchronous operations are allowed. The default is <value>true</value>. Set to
         /// <value>false</value> to have Nevermore throw a <see cref="SynchronousOperationsDisabledException"/> when
         /// calling a synchronous operation.
         /// </summary>
         public bool AllowSynchronousOperations { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the default schema name (e.g., 'dbo') that will be used as a prefix on all statements. Can be
         /// overridden on each document map.
         /// </summary>
         string DefaultSchema { get; set; }
-        
+
         IDocumentMapRegistry DocumentMaps { get; }
         IDocumentSerializer DocumentSerializer { get; set; }
         IReaderStrategyRegistry ReaderStrategies { get; }
         ITypeHandlerRegistry TypeHandlers { get; }
         IInstanceTypeRegistry InstanceTypeResolvers { get; }
+        IPrimaryKeyHandlerRegistry PrimaryKeyHandlers { get; }
         IRelatedDocumentStore RelatedDocumentStore { get; set; }
         IQueryLogger QueryLogger { get; set; }
-        
+
         /// <summary>
         /// Hooks can be used to apply general logic when documents are inserted, updated or deleted.
         /// </summary>
         IHookRegistry Hooks { get; }
-        
+
         /// <summary>
         /// Gets or sets the factory that creates SQL commands. Set this if you want to control how commands are set up,
-        /// or add a decorator to capture diagnostic information. 
+        /// or add a decorator to capture diagnostic information.
         /// </summary>
         ISqlCommandFactory CommandFactory { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the key block size that will be used for the key allocator. A higher number enables less
         /// SQL queries to get new blocks, but increases fragmentation.
@@ -54,11 +55,11 @@ namespace Nevermore
 
         /// <summary>
         /// Gets or sets whether Multiple Active Result Sets is enabled. On .NET Core 3.1 this has issues on Linux, so it
-        /// defaults to false. 
+        /// defaults to false.
         /// </summary>
         /// <remarks>https://docs.microsoft.com/en-us/sql/relational-databases/native-client/features/using-multiple-active-result-sets-mars?view=sql-server-ver15</remarks>
         bool ForceMultipleActiveResultSets { get; set; }
-        
+
         /// <summary>
         /// Gets or sets whether to actively detect similar queries being executed in a way that is slightly different,
         /// resulting in duplicate query plans being created.

--- a/source/Nevermore/ITransactionDiagnostic.cs
+++ b/source/Nevermore/ITransactionDiagnostic.cs
@@ -1,10 +1,11 @@
+#nullable enable
 using System.Text;
 
 namespace Nevermore
 {
     internal interface ITransactionDiagnostic
     {
-        public string Name { get; }
+        public string? Name { get; }
         public void WriteCurrentTransactions(StringBuilder output);
     }
 }

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -41,7 +41,7 @@ namespace Nevermore
 
         /// <summary>
         /// Immediately inserts multiple items into a specific table. Useful for up to a few hundred items, but not more
-        /// (depends on the number of properties in each item). 
+        /// (depends on the number of properties in each item).
         /// </summary>
         /// <typeparam name="TDocument">The type of document being inserted.</typeparam>
         /// <param name="documents">The document instances to insert (will be formed into a multiple VALUES for a single SQL INSERT.</param>
@@ -68,7 +68,7 @@ namespace Nevermore
         Task InsertManyAsync<TDocument>(IReadOnlyCollection<TDocument> documents, InsertOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
-        /// Updates an existing document in the database. 
+        /// Updates an existing document in the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being updated.</typeparam>
         /// <param name="document">The document to update.</param>
@@ -76,7 +76,7 @@ namespace Nevermore
         void Update<TDocument>(TDocument document, UpdateOptions options = null) where TDocument : class;
 
         /// <summary>
-        /// Updates an existing document in the database. 
+        /// Updates an existing document in the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being updated.</typeparam>
         /// <param name="document">The document to update.</param>
@@ -84,13 +84,22 @@ namespace Nevermore
         Task UpdateAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
-        /// Updates an existing document in the database. 
+        /// Updates an existing document in the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being updated.</typeparam>
         /// <param name="document">The document to update.</param>
         /// <param name="options">Advanced options for the update operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
         Task UpdateAsync<TDocument>(TDocument document, UpdateOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        void Delete<TDocument, TKey>(TKey id, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -128,9 +137,19 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class;
+        void Delete<TDocument, TKey>(TDocument document, DeleteOptions options = null) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -168,9 +187,20 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument, TKey>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
+
+        /// <summary>
+        /// Deletes an existing document from the database by its ID.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
+        /// <param name="id">The id of the document to delete.</param>
+        /// <param name="options">Advanced options for the delete operation.</param>
+        /// <param name="cancellationToken">Token to use to cancel the command.</param>
+        Task DeleteAsync<TDocument, TKey>(TKey id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -212,10 +242,11 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
+        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument, TKey>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Creates a deletion query for a strongly typed document.
@@ -226,26 +257,30 @@ namespace Nevermore
 
         /// <summary>
         /// Allocate an ID for the specified type. The type must be mapped.
-        /// If the mapping specifies a SingletonId, that is returned
+        /// If the mapping specifies a SingletonId, that is returned.
         /// </summary>
         /// <param name="documentType"></param>
         /// <returns></returns>
-        string AllocateId(Type documentType);
+        /// <exception cref="InvalidOperationException">Will be thrown if the requested key type does not match the mapped document's key type.</exception>
+        TKey AllocateId<TKey>(Type documentType);
 
         /// <summary>
-        /// Allocates an ID using the specified table name. Any mapping for that table is not used.
+        /// Allocates an ID using the specified table name. Any mapping for that table is not used. The configuration's PrimaryKeyHandlerRegistry must contain
+        /// an entry for the key type (primitives are handled out of the box).
         /// </summary>
         /// <param name="tableName"></param>
         /// <param name="idPrefix"></param>
         /// <returns></returns>
         string AllocateId(string tableName, string idPrefix);
-        
+
         /// <summary>
         /// Allocate an ID for the specified type. The type must be mapped.
         /// If the mapping specifies a SingletonId, that is returned
         /// </summary>
         /// <typeparam name="TDocument">The type of document.</typeparam>
+        /// <typeparam name="TKey">The key type to allocate, e.g. int, string, MyCustomStringType.</typeparam>
         /// <returns></returns>
-        string AllocateId<TDocument>();
+        /// <exception cref="InvalidOperationException">Will be thrown if the requested key type does not match the mapped document's key type.</exception>
+        TKey AllocateId<TDocument, TKey>();
     }
 }

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -239,5 +239,13 @@ namespace Nevermore
         /// <param name="idPrefix"></param>
         /// <returns></returns>
         string AllocateId(string tableName, string idPrefix);
+        
+        /// <summary>
+        /// Allocate an ID for the specified type. The type must be mapped.
+        /// If the mapping specifies a SingletonId, that is returned
+        /// </summary>
+        /// <typeparam name="TDocument">The type of document.</typeparam>
+        /// <returns></returns>
+        string AllocateId<TDocument>();
     }
 }

--- a/source/Nevermore/ListExtensions.cs
+++ b/source/Nevermore/ListExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,43 +9,19 @@ namespace Nevermore
     {
         /// <summary>
         /// Same as Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X IN (@param1, @param2)...".
-        /// In other cases calls collection.Contains(value). 
+        /// In other cases calls collection.Contains(value).
         /// </summary>
         /// <param name="value">The value to search for</param>
         /// <param name="collection">The collection to search within.</param>
         /// <returns>True if <paramref name="value"/> exists in <paramref name="collection"/></returns>
-        public static bool In<T>(this T value, IEnumerable<T> collection) where T : struct, IConvertible
+        public static bool In<T>(this T? value, IEnumerable<T?> collection)
         {
             return collection.Contains(value);
         }
-        
-        /// <summary>
-        /// Same as Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X IN (@param1, @param2)...".
-        /// In other cases calls collection.Contains(value). 
-        /// </summary>
-        /// <param name="value">The value to search for</param>
-        /// <param name="collection">The collection to search within.</param>
-        /// <returns>True if <paramref name="value"/> exists in <paramref name="collection"/></returns>
-        public static bool In<T>(this T? value, IEnumerable<T?> collection) where T : struct, IConvertible
-        {
-            return collection.Contains(value);
-        }
-        
-        /// <summary>
-        /// Same as Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X IN (@param1, @param2)...".
-        /// In other cases calls collection.Contains(value). 
-        /// </summary>
-        /// <param name="value">The value to search for</param>
-        /// <param name="collection">The collection to search within.</param>
-        /// <returns>True if <paramref name="value"/> exists in <paramref name="collection"/></returns>
-        public static bool In(this string value, IEnumerable<string> collection)
-        {
-            return collection.Contains(value);
-        }
-        
+
         /// <summary>
         /// Same as !Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X NOT IN (@param1, @param2)...".
-        /// In other cases calls !collection.Contains(value). 
+        /// In other cases calls !collection.Contains(value).
         /// </summary>
         /// <param name="value">The value to search for</param>
         /// <param name="collection">The collection to search within.</param>
@@ -53,11 +30,11 @@ namespace Nevermore
         {
             return !collection.Contains(value);
         }
-        
-        
+
+
         /// <summary>
         /// Same as !Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X NOT IN (@param1, @param2)...".
-        /// In other cases calls !collection.Contains(value). 
+        /// In other cases calls !collection.Contains(value).
         /// </summary>
         /// <param name="value">The value to search for</param>
         /// <param name="collection">The collection to search within.</param>
@@ -66,10 +43,10 @@ namespace Nevermore
         {
             return !collection.Contains(value);
         }
-        
+
         /// <summary>
         /// Same as !Contains but in the opposite calling structure. In Nevermore LINQ queries, translates to "WHERE X NOT IN (@param1, @param2)...".
-        /// In other cases calls !collection.Contains(value). 
+        /// In other cases calls !collection.Contains(value).
         /// </summary>
         /// <param name="value">The value to search for</param>
         /// <param name="collection">The collection to search within.</param>

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -8,7 +8,6 @@ namespace Nevermore.Mapping
     {
         const int DefaultPrimaryKeyIdLength = 50;
         const int DefaultMaxForeignKeyIdLength = 50;
-        int? maxLength;
 
         internal ColumnMapping(string columnName, Type type, IPropertyHandler handler, PropertyInfo property)
         {
@@ -21,11 +20,11 @@ namespace Nevermore.Mapping
                 return;
             if (Property.Name == "Id")
             {
-                maxLength = DefaultPrimaryKeyIdLength;
+                MaxLength = DefaultPrimaryKeyIdLength;
             }
             else if (Property.Name.EndsWith("Id")) // Foreign keys
             {
-                maxLength = DefaultMaxForeignKeyIdLength;
+                MaxLength = DefaultMaxForeignKeyIdLength;
             }
         }
 
@@ -34,13 +33,13 @@ namespace Nevermore.Mapping
         public IPropertyHandler PropertyHandler { get; private set; }
         public PropertyInfo Property { get; }
 
-        public int? MaxLength => maxLength;
+        public int? MaxLength { get; protected set; }
         public ColumnDirection Direction { get; protected set; }
 
 
         IColumnMappingBuilder IColumnMappingBuilder.MaxLength(int max)
         {
-            maxLength = max;
+            MaxLength = max;
             return this;
         }
 

--- a/source/Nevermore/Mapping/ColumnMapping.cs
+++ b/source/Nevermore/Mapping/ColumnMapping.cs
@@ -8,7 +8,6 @@ namespace Nevermore.Mapping
     {
         const int DefaultPrimaryKeyIdLength = 50;
         const int DefaultMaxForeignKeyIdLength = 50;
-        ColumnDirection direction;
         int? maxLength;
 
         internal ColumnMapping(string columnName, Type type, IPropertyHandler handler, PropertyInfo property)
@@ -36,7 +35,8 @@ namespace Nevermore.Mapping
         public PropertyInfo Property { get; }
 
         public int? MaxLength => maxLength;
-        public ColumnDirection Direction => direction;
+        public ColumnDirection Direction { get; protected set; }
+
 
         IColumnMappingBuilder IColumnMappingBuilder.MaxLength(int max)
         {
@@ -46,25 +46,27 @@ namespace Nevermore.Mapping
 
         IColumnMappingBuilder IColumnMappingBuilder.LoadOnly()
         {
-            direction = ColumnDirection.FromDatabase;
+            Direction = ColumnDirection.FromDatabase;
             return this;
         }
 
         IColumnMappingBuilder IColumnMappingBuilder.SaveOnly()
         {
-            direction = ColumnDirection.ToDatabase;
+            Direction = ColumnDirection.ToDatabase;
             return this;
         }
 
         IColumnMappingBuilder IColumnMappingBuilder.CustomPropertyHandler(IPropertyHandler propertyHandler)
         {
-            PropertyHandler = propertyHandler;
+            SetCustomPropertyHandler(propertyHandler);
             return this;
         }
 
+        protected virtual void SetCustomPropertyHandler(IPropertyHandler propertyHandler) => PropertyHandler = propertyHandler;
+
         public void Validate()
         {
-            if ((direction == ColumnDirection.FromDatabase || direction == ColumnDirection.Both) && !PropertyHandler.CanWrite)
+            if ((Direction == ColumnDirection.FromDatabase || Direction == ColumnDirection.Both) && !PropertyHandler.CanWrite)
             {
                 if (Property != null && PropertyHandler is PropertyHandler)
                 {

--- a/source/Nevermore/Mapping/DocumentMap.cs
+++ b/source/Nevermore/Mapping/DocumentMap.cs
@@ -76,7 +76,7 @@ namespace Nevermore.Mapping
         /// Configures the ID of the document.
         /// </summary>
         /// <returns>A builder to further configure the ID.</returns>
-        protected IColumnMappingBuilder Id()
+        protected IIdColumnMappingBuilder Id()
         {
             return map.IdColumn;
         }
@@ -87,7 +87,7 @@ namespace Nevermore.Mapping
         /// <param name="property">An expression that accesses the property. E.g., <code>c => c.FirstName</code></param>
         /// <typeparam name="TProperty">The property type of the Id column.</typeparam>
         /// <returns>A builder to further configure the ID.</returns>
-        protected IColumnMappingBuilder Id<TProperty>(Expression<Func<TDocument, TProperty>> property)
+        protected IIdColumnMappingBuilder Id<TProperty>(Expression<Func<TDocument, TProperty>> property)
         {
             return Id<TProperty>(null, property);
         }
@@ -99,11 +99,11 @@ namespace Nevermore.Mapping
         /// <param name="property">An expression that accesses the property. E.g., <code>c => c.FirstName</code></param>
         /// <typeparam name="TProperty">The property type of the Id column.</typeparam>
         /// <returns>A builder to further configure the ID.</returns>
-        protected IColumnMappingBuilder Id<TProperty>(string columnName, Expression<Func<TDocument, TProperty>> property)
+        protected IIdColumnMappingBuilder Id<TProperty>(string columnName, Expression<Func<TDocument, TProperty>> property)
         {
             var prop = GetPropertyInfo(property)
                 ?? throw new Exception("The expression for the Id column must be a property.");
-            map.IdColumn = new ColumnMapping(columnName ?? prop.Name, typeof(TProperty), new PropertyHandler(prop), prop);
+            map.IdColumn = new IdColumnMapping(columnName ?? prop.Name, typeof(TProperty), new PropertyHandler(prop), prop);
             return map.IdColumn;
         }
 
@@ -265,14 +265,14 @@ namespace Nevermore.Mapping
             };
         }
 
-        static ColumnMapping GetDefaultIdColumn()
+        static IdColumnMapping GetDefaultIdColumn()
         {
             var properties = typeof(TDocument).GetProperties();
             foreach (var property in properties)
             {
                 if (string.Equals(property.Name, "Id", StringComparison.OrdinalIgnoreCase))
                 {
-                    return new ColumnMapping("Id", property.PropertyType, new PropertyHandler(property), property);
+                    return new IdColumnMapping("Id", property.PropertyType, new PropertyHandler(property), property);
                 }
             }
 
@@ -298,7 +298,7 @@ namespace Nevermore.Mapping
         }
 
         public Type Type { get; set; }
-        public ColumnMapping IdColumn { get; set; }
+        public IdColumnMapping IdColumn { get; set; }
         public ColumnMapping RowVersionColumn { get; set; }
         public ColumnMapping TypeResolutionColumn { get; set; }
         public JsonStorageFormat JsonStorageFormat { get; set; }
@@ -317,6 +317,10 @@ namespace Nevermore.Mapping
         public string SchemaName { get; set; }
 
         public bool IsRowVersioningEnabled => RowVersionColumn != null;
+
+        public bool IsIdentityId => IdColumn.IsIdentity;
+
+        public bool HasModificationOutputs =>IsRowVersioningEnabled || IsIdentityId;
 
         public void Validate()
         {

--- a/source/Nevermore/Mapping/GuidPrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/GuidPrimaryKeyHandler.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public sealed class GuidPrimaryKeyHandler : PrimaryKeyHandler<Guid>
+    {
+        public override SqlMetaData GetSqlMetaData(string name)
+            =>  new SqlMetaData(name, SqlDbType.UniqueIdentifier);
+
+        public override object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+        {
+            return Guid.NewGuid();
+        }
+    }
+}

--- a/source/Nevermore/Mapping/IDocumentMap.cs
+++ b/source/Nevermore/Mapping/IDocumentMap.cs
@@ -2,6 +2,6 @@ namespace Nevermore.Mapping
 {
     public interface IDocumentMap
     {
-        DocumentMap Build();
+        DocumentMap Build(IPrimaryKeyHandlerRegistry primaryKeyHandlerRegistry);
     }
 }

--- a/source/Nevermore/Mapping/IIdColumnMappingBuilder.cs
+++ b/source/Nevermore/Mapping/IIdColumnMappingBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace Nevermore.Mapping
+﻿using System;
+
+namespace Nevermore.Mapping
 {
     public interface IIdColumnMappingBuilder : IColumnMappingBuilder
     {
@@ -7,5 +9,19 @@
         /// </summary>
         /// <remarks>This will also reset the PropertyHandler</remarks>
         IIdColumnMappingBuilder Identity();
+
+        /// <summary>
+        /// Explicitly set a primary key handler.
+        /// </summary>
+        /// <param name="primaryKeyHandler">The primary key handler.</param>
+        /// <returns></returns>
+        IIdColumnMappingBuilder KeyHandler(IPrimaryKeyHandler primaryKeyHandler);
+
+        /// <summary>
+        /// Builds the IdColumnMapping.
+        /// </summary>
+        /// <param name="primaryKeyHandlerRegistry">The primary key handler registry, which must be populated with the required handler prior to the DocumentMaps being registered.</param>
+        /// <returns>The built column mapping.</returns>
+        IdColumnMapping Build(IPrimaryKeyHandlerRegistry primaryKeyHandlerRegistry);
     }
 }

--- a/source/Nevermore/Mapping/IIdColumnMappingBuilder.cs
+++ b/source/Nevermore/Mapping/IIdColumnMappingBuilder.cs
@@ -1,0 +1,11 @@
+﻿namespace Nevermore.Mapping
+{
+    public interface IIdColumnMappingBuilder : IColumnMappingBuilder
+    {
+        /// <summary>
+        /// Nevermore will treat this Id as an IDENTITY column, and will update the document with the Id assigned by the database after insert.
+        /// </summary>
+        /// <remarks>This will also reset the PropertyHandler</remarks>
+        IIdColumnMappingBuilder Identity();
+    }
+}

--- a/source/Nevermore/Mapping/IPrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/IPrimaryKeyHandler.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public interface IPrimaryKeyHandler
+    {
+        /// <summary>
+        /// The property type this handler is responsible for.
+        /// </summary>
+        Type Type { get; }
+
+        /// <summary>
+        /// Gets the SqlMetaData to use for keys of this type. This is used for TableValueParameters.
+        /// </summary>
+        /// <param name="name">The name of the column.</param>
+        SqlMetaData GetSqlMetaData(string name);
+
+        /// <summary>
+        /// Convert the given id value to the underlying primitive type required for Sql command parameters.
+        /// </summary>
+        /// <param name="id">The id to convert.</param>
+        /// <returns>The converted id.</returns>
+        [return: NotNullIfNotNull("id")]
+        object? ConvertToPrimitiveValue(object? id);
+
+        /// <summary>
+        /// Get the next key for the given table.
+        /// </summary>
+        /// <remarks>The keyAllocator has to be passed here as it is tied to the RelationalStore instance, and thus can't be specified at configuration time in the constructor.</remarks>
+        /// <param name="keyAllocator">The key allocator to use getting the next id from.</param>
+        /// <param name="tableName">The table name the key is required for.</param>
+        /// <returns>The next key, as the type that matches the model object's Id property type. ConvertToPrimitiveValue should be called with this value if it is to be used as a Sql parameter.</returns>
+        object GetNextKey(IKeyAllocator keyAllocator, string tableName);
+    }
+}

--- a/source/Nevermore/Mapping/IdColumnMapping.cs
+++ b/source/Nevermore/Mapping/IdColumnMapping.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Nevermore.Mapping
+{
+    public class IdColumnMapping : ColumnMapping, IIdColumnMappingBuilder
+    {
+        static readonly HashSet<Type> ValidIdentityTypes = new HashSet<Type>
+        {
+            typeof(short),
+            typeof(int),
+            typeof(long)
+        };
+
+        bool hasCustomPropertyHandler;
+
+        internal IdColumnMapping(string columnName, Type type, IPropertyHandler handler, PropertyInfo property)
+            : base(columnName, type, handler, property)
+        { }
+
+        public bool IsIdentity { get; private set; }
+
+        /// <inheritdoc cref="IIdColumnMappingBuilder"/>
+        public IIdColumnMappingBuilder Identity()
+        {
+            if (!ValidIdentityTypes.Contains(Type))
+                throw new InvalidOperationException($"The type {Type.Name} is not supported for Identity columns. Identity columns must be one of 'short', 'int' or 'long'.");
+
+            if (hasCustomPropertyHandler)
+                throw new InvalidOperationException("Unable to configure an Identity Id column with a custom PropertyHandler");
+
+            IsIdentity = true;
+            Direction = ColumnDirection.FromDatabase;
+
+            return this;
+        }
+
+        protected override void SetCustomPropertyHandler(IPropertyHandler propertyHandler)
+        {
+            if (IsIdentity)
+                throw new InvalidOperationException("Unable to configure an Identity Id column with a custom PropertyHandler");
+
+            hasCustomPropertyHandler = true;
+            base.SetCustomPropertyHandler(propertyHandler);
+        }
+    }
+}

--- a/source/Nevermore/Mapping/IntPrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/IntPrimaryKeyHandler.cs
@@ -1,0 +1,16 @@
+using System.Data;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public sealed class IntPrimaryKeyHandler : PrimaryKeyHandler<int>
+    {
+        public override SqlMetaData GetSqlMetaData(string name)
+            =>  new SqlMetaData(name, SqlDbType.Int);
+
+        public override object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+        {
+            return keyAllocator.NextId(tableName);
+        }
+    }
+}

--- a/source/Nevermore/Mapping/LongPrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/LongPrimaryKeyHandler.cs
@@ -1,0 +1,16 @@
+using System.Data;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public sealed class LongPrimaryKeyHandler : PrimaryKeyHandler<long>
+    {
+        public override SqlMetaData GetSqlMetaData(string name)
+            =>  new SqlMetaData(name, SqlDbType.BigInt);
+
+        public override object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+        {
+            return keyAllocator.NextId(tableName);
+        }
+    }
+}

--- a/source/Nevermore/Mapping/PrimaryKeyHandlerRegistry.cs
+++ b/source/Nevermore/Mapping/PrimaryKeyHandlerRegistry.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Nevermore.Mapping
+{
+    public interface IPrimaryKeyHandlerRegistry
+    {
+        /// <summary>
+        /// Registers a mapping of key type to PrimaryKeyHandler type. StringPrimaryKeyHandler, IntPrimaryKeyHandler, LongPrimaryKeyHandler, and GuidPrimaryKeyHandler
+        /// are registered by default, with default settings. Calling register again for them will overwrite the default, you can use this if you want to override a
+        /// global default.
+        /// </summary>
+        void Register(IPrimaryKeyHandler handler);
+
+        IPrimaryKeyHandler? Resolve(Type columnType);
+    }
+
+    class PrimaryKeyHandlerRegistry : IPrimaryKeyHandlerRegistry
+    {
+        // maps key type to IPrimaryKeyHandler concrete type
+        readonly ConcurrentDictionary<Type, IPrimaryKeyHandler> mappings = new ConcurrentDictionary<Type, IPrimaryKeyHandler>();
+
+        public PrimaryKeyHandlerRegistry()
+        {
+            mappings.TryAdd(typeof(string), new StringPrimaryKeyHandler());
+            mappings.TryAdd(typeof(int), new IntPrimaryKeyHandler());
+            mappings.TryAdd(typeof(long), new LongPrimaryKeyHandler());
+            mappings.TryAdd(typeof(Guid), new GuidPrimaryKeyHandler());
+        }
+
+        public void Register(IPrimaryKeyHandler handler)
+        {
+            mappings[handler.Type] = handler;
+        }
+
+        public IPrimaryKeyHandler? Resolve(Type columnType)
+        {
+            var idType = columnType;
+
+            var maps = new List<IPrimaryKeyHandler>();
+
+            // Walk up the inheritance chain and make sure there's only one map for the document.
+            var currentType = idType;
+
+            while (true)
+            {
+                if (mappings.TryGetValue(currentType, out var m))
+                {
+                    maps.Add(m);
+                }
+
+                currentType = currentType.GetTypeInfo().BaseType;
+                if (currentType == typeof(object) || currentType == null)
+                    break;
+            }
+
+            if (maps.Count > 1)
+                throw new InvalidOperationException($"More than one key allocation strategy is registered against the type '{idType.FullName}'. The following maps could apply: " + string.Join(", ", maps.Select(m => m.GetType().FullName)));
+
+            var strategy = maps.SingleOrDefault();
+            return strategy;
+        }
+    }
+}

--- a/source/Nevermore/Mapping/PrimitivePrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/PrimitivePrimaryKeyHandler.cs
@@ -1,0 +1,22 @@
+﻿#nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public abstract class PrimaryKeyHandler<T> : IPrimaryKeyHandler
+    {
+        public Type Type => typeof(T);
+
+        public abstract SqlMetaData GetSqlMetaData(string name);
+
+        [return: NotNullIfNotNull("id")]
+        public virtual object? ConvertToPrimitiveValue(object? id)
+        {
+            return id;
+        }
+
+        public abstract object GetNextKey(IKeyAllocator keyAllocator, string tableName);
+    }
+}

--- a/source/Nevermore/Mapping/StringPrimaryKeyHandler.cs
+++ b/source/Nevermore/Mapping/StringPrimaryKeyHandler.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using System.Data;
+using Microsoft.Data.SqlClient.Server;
+
+namespace Nevermore.Mapping
+{
+    public sealed class StringPrimaryKeyHandler : PrimaryKeyHandler<string>
+    {
+        readonly Func<(string idPrefix, int key), string> format;
+
+        public StringPrimaryKeyHandler(string? idPrefix = null, Func<(string idPrefix, int key), string>? format = null)
+        {
+            IdPrefix = idPrefix;
+            this.format = format ?? (x => $"{x.idPrefix}-{x.key}");
+        }
+
+        public override SqlMetaData GetSqlMetaData(string name)
+            =>  new SqlMetaData(name, SqlDbType.NVarChar, 300);
+
+        public string? IdPrefix { get; private set; }
+
+        public override object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+        {
+            var nextKey = keyAllocator.NextId(tableName);
+            return format((IdPrefix ?? $"{tableName}s", nextKey));
+        }
+    }
+}

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -27,7 +27,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -27,7 +27,6 @@ namespace Nevermore
         public RelationalStoreConfiguration(Func<string> connectionStringFunc)
         {
             CommandFactory = new SqlCommandFactory();
-            DocumentMaps = new DocumentMapRegistry();
             KeyBlockSize = NevermoreDefaults.DefaultKeyBlockSize;
             InstanceTypeResolvers = new InstanceTypeRegistry();
             RelatedDocumentStore = new EmptyRelatedDocumentStore();
@@ -45,6 +44,10 @@ namespace Nevermore
             DefaultSchema = NevermoreDefaults.FallbackDefaultSchemaName;
 
             TypeHandlers = new TypeHandlerRegistry();
+
+            PrimaryKeyHandlers = new PrimaryKeyHandlerRegistry();
+
+            DocumentMaps = new DocumentMapRegistry(PrimaryKeyHandlers);
 
             AllowSynchronousOperations = true;
 
@@ -80,6 +83,8 @@ namespace Nevermore
 
         public ITypeHandlerRegistry TypeHandlers { get; }
         public IInstanceTypeRegistry InstanceTypeResolvers { get; }
+
+        public IPrimaryKeyHandlerRegistry PrimaryKeyHandlers { get; }
 
         /// <summary>
         /// MARS: https://docs.microsoft.com/en-us/sql/relational-databases/native-client/features/using-multiple-active-result-sets-mars?view=sql-server-ver15

--- a/source/Nevermore/Transient/DbCommandExtensions.cs
+++ b/source/Nevermore/Transient/DbCommandExtensions.cs
@@ -67,7 +67,7 @@ namespace Nevermore.Transient
             });
         }
 
-        public static async Task<DbDataReader> ExecuteReaderWithRetryAsync(this DbCommand command, RetryPolicy commandRetryPolicy, CommandBehavior commandBehavior, RetryPolicy connectionRetryPolicy = null, string operationName = "ExecuteReader", CancellationToken cancellationToken)
+        public static async Task<DbDataReader> ExecuteReaderWithRetryAsync(this DbCommand command, RetryPolicy commandRetryPolicy, CommandBehavior commandBehavior, CancellationToken cancellationToken, RetryPolicy connectionRetryPolicy = null, string operationName = "ExecuteReader")
         {
             GuardConnectionIsNotNull(command);
             var effectiveCommandRetryPolicy =
@@ -148,7 +148,7 @@ namespace Nevermore.Transient
             command.Connection.OpenWithRetry(retryPolicy);
             return true;
         }
-        
+
         static async Task<bool> EnsureValidConnectionAsync(DbCommand command, RetryPolicy retryPolicy, CancellationToken cancellationToken)
         {
             if (command == null) return false;


### PR DESCRIPTION
This PR adds support for identity number (`short`/`int`/`long`) primary keys.

There is a new `Identity()` method that chains off the `Id()` method in the `DocumentMap`. This marks the Id column as an identity column.

e.g. `Id(c => c.Id).Identity()`

This works by retrieving the identity value as part of the `INSERT` and updating the `Id` on the document, very similar to how the `RowVersion` is updated.

As there are now 2 output parameters, we need to change to use a table parameter to store them in. This also handles multiple inserts in a single statement