### PR TITLE
Support for strongly typed keys (Id property)

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -19,11 +19,11 @@ namespace Nevermore.IntegrationTests.Advanced
 
             using var transaction = Store.BeginTransaction();
 
-            var customer = new Customer {Id = "C131", FirstName = "Fred", LastName = "Freddy"};
+            var customer = new Customer {Id = "C131".ToCustomerId(), FirstName = "Fred", LastName = "Freddy"};
             transaction.Insert(customer);
             AssertLogged(log, "BeforeInsert", "AfterInsert");
 
-            customer = transaction.Load<Customer>("C131");
+            customer = transaction.Load<Customer, CustomerId>("C131".ToCustomerId());
 
             transaction.Update(customer);
             AssertLogged(log, "BeforeUpdate", "AfterUpdate");

--- a/source/Nevermore.IntegrationTests/Model/Customer.cs
+++ b/source/Nevermore.IntegrationTests/Model/Customer.cs
@@ -1,3 +1,4 @@
+using System;
 using Nevermore.IntegrationTests.Contracts;
 
 namespace Nevermore.IntegrationTests.Model
@@ -9,7 +10,7 @@ namespace Nevermore.IntegrationTests.Model
             Roles = new ReferenceCollection();
         }
 
-        public string Id { get; set; }
+        public CustomerId Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public ReferenceCollection Roles { get; }
@@ -17,5 +18,28 @@ namespace Nevermore.IntegrationTests.Model
         public int[] LuckyNumbers { get; set; }
         public string ApiKey { get; set; }
         public string[] Passphrases { get; set; }
+    }
+
+    public class CustomerId
+    {
+        public CustomerId(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+
+    public static class CustomerIdExtensionMethods
+    {
+        public static CustomerId? ToCustomerId(this string? value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? null : new CustomerId(value);
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
+++ b/source/Nevermore.IntegrationTests/Model/CustomerMap.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Data.Common;
+using System.Reflection;
+using Nevermore.Advanced.TypeHandlers;
 using Nevermore.Mapping;
 
 namespace Nevermore.IntegrationTests.Model
@@ -6,12 +10,51 @@ namespace Nevermore.IntegrationTests.Model
     {
         public CustomerMap()
         {
-            Id().MaxLength(100);
+            Id().MaxLength(100).CustomPropertyHandler(new CustomerIdPropertyHandler());
             Column(m => m.FirstName).MaxLength(20);
             Column(m => m.LastName).MaxLength(50);
             Column(m => m.Nickname);
             Column(m => m.Roles);
             Unique("UniqueCustomerNames", new[] { "FirstName", "LastName" }, "Customers must have a unique name");
+        }
+    }
+
+    class CustomerIdPropertyHandler : IPropertyHandler
+    {
+        PropertyInfo idProperty = typeof(Customer).GetProperty("Id");
+
+        public object Read(object target)
+        {
+            return (idProperty.GetValue(target) as CustomerId)?.Value;
+        }
+
+        public void Write(object target, object value)
+        {
+            if (value is CustomerId)
+                idProperty.SetValue(target, value);
+            else
+                idProperty.SetValue(target, ((string)value).ToCustomerId());
+        }
+    }
+
+    class CustomerIdTypeHandler : ITypeHandler
+    {
+        public bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CustomerId);
+        }
+
+        public object ReadDatabase(DbDataReader reader, int columnIndex)
+        {
+            if (reader.IsDBNull(columnIndex))
+                return default(CustomerId);
+            var text = reader.GetString(columnIndex);
+            return new CustomerId(text);
+        }
+
+        public void WriteDatabase(DbParameter parameter, object value)
+        {
+            parameter.Value = ((CustomerId)value)?.Value;
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -15,16 +15,16 @@ namespace Nevermore.IntegrationTests
             // The Id columns allow you to give records an ID, or use an auto-generated, unique ID
             using (var transaction = Store.BeginTransaction())
             {
-                var customer1 = new Customer {Id = "Customers-Alice", FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
+                var customer1 = new Customer {Id = "Customers-Alice".ToCustomerId(), FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
                 var customer2 = new Customer {FirstName = "Bob", LastName = "Banana", LuckyNumbers = new[] {12, 13}, Nickname = "B-man", Roles = {"web-server", "app-server"}};
                 var customer3 = new Customer {FirstName = "Charlie", LastName = "Cherry", LuckyNumbers = new[] {12, 13}, Nickname = "Chazza", Roles = {"web-server", "app-server"}};
                 transaction.Insert(customer1);
                 transaction.Insert(customer2);
                 transaction.Insert(customer3, new InsertOptions { CustomAssignedId = "Customers-Chazza"});
 
-                customer1.Id.Should().Be("Customers-Alice");
-                customer2.Id.Should().StartWith("Customers-");
-                customer3.Id.Should().Be("Customers-Chazza");
+                customer1.Id.Value.Should().Be("Customers-Alice");
+                customer2.Id.Value.Should().StartWith("Customers-");
+                customer3.Id.Value.Should().Be("Customers-Chazza");
 
                 transaction.Commit();
             }
@@ -82,7 +82,7 @@ namespace Nevermore.IntegrationTests
         [Test]
         public void ShouldHandleIdsWithInOperand()
         {
-            string customerId;
+            CustomerId customerId;
             using (var transaction = Store.BeginTransaction())
             {
                 var customer = new Customer {FirstName = "Alice", LastName = "Apple"};
@@ -94,7 +94,7 @@ namespace Nevermore.IntegrationTests
             using (var transaction = Store.BeginTransaction())
             {
                 var customer = transaction.Query<Customer>()
-                    .Where("Id", ArraySqlOperand.In, new[] {customerId})
+                    .Where("Id", ArraySqlOperand.In, new[] {customerId.Value})
                     .Stream()
                     .Single();
                 customer.FirstName.Should().Be("Alice");
@@ -233,7 +233,7 @@ namespace Nevermore.IntegrationTests
         [Test]
         public void ShouldPersistAndLoadReferenceCollectionsOnSingleDocuments()
         {
-            var customerId = string.Empty;
+            CustomerId? customerId = null;
             using (var transaction = Store.BeginTransaction())
             {
                 var customer = new Customer {FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
@@ -243,7 +243,7 @@ namespace Nevermore.IntegrationTests
             }
             using (var transaction = Store.BeginTransaction())
             {
-                var loadedCustomer = transaction.Load<Customer>(customerId);
+                var loadedCustomer = transaction.Load<Customer, CustomerId>(customerId);
                 loadedCustomer.Roles.Count.Should().Be(2);
             }
         }
@@ -256,7 +256,7 @@ namespace Nevermore.IntegrationTests
             {
                 var customer = new Customer {FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
                 transaction.Insert(customer, new InsertOptions { CustomAssignedId = "12345" });
-                Assert.That(customer.Id, Is.EqualTo("12345"), "Id passed in should be used");
+                Assert.That(customer.Id?.Value, Is.EqualTo("12345"), "Id passed in should be used");
             }
         }
 
@@ -265,9 +265,9 @@ namespace Nevermore.IntegrationTests
         {
             using (var transaction = Store.BeginTransaction())
             {
-                var customer = new Customer {Id = "12345", FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
+                var customer = new Customer {Id = "12345".ToCustomerId(), FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
                 transaction.Insert(customer, new InsertOptions { CustomAssignedId = "12345" });
-                Assert.That(customer.Id, Is.EqualTo("12345"), "Id passed in should be used if same");
+                Assert.That(customer.Id?.Value, Is.EqualTo("12345"), "Id passed in should be used if same");
             }
         }
 
@@ -278,7 +278,7 @@ namespace Nevermore.IntegrationTests
             {
                 Assert.Throws<ArgumentException>(() =>
                 {
-                    var customer = new Customer {Id = "123456", FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
+                    var customer = new Customer {Id = "123456".ToCustomerId(), FirstName = "Alice", LastName = "Apple", LuckyNumbers = new[] {12, 13}, Nickname = "Ally", Roles = {"web-server", "app-server"}};
                     transaction.Insert(customer, new InsertOptions { CustomAssignedId = "12345" });
                 });
             }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -43,7 +43,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 Type = ProductType.Normal
             };
             trn.Insert(product1);
-            
+
             var product2 = new Product
             {
                 Id = "Products-133",
@@ -53,9 +53,9 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
             };
             trn.Insert(product2);
             trn.Commit();
-            
+
             var ids = new[] {product1.Id, product2.Id};
-            
+
             var products = trn.LoadMany<Product>(ids);
 
             products.Should().HaveCount(ids.Length);
@@ -83,13 +83,13 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         public void StoreNonInheritedTypesSerializesCorrectly()
         {
             using var trn = Store.BeginTransaction();
-            
+
             var customer = new Customer
             {
                 FirstName = "Bob",
                 LastName = "Tester",
                 Nickname = "Bob the builder",
-                Id = "Customers-01"
+                Id = "Customers-01".ToCustomerId()
             };
 
             trn.Insert(customer);
@@ -218,7 +218,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                 brandToTestSerialization.JSON.Should().Be("{\"Description\":\"Details for Brand A.\"}");
             }
         }
-        
+
         [Test]
         public void StoreAndLoadStringInheritedTypes()
         {

--- a/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/FixtureWithRelationalStore.cs
@@ -33,6 +33,8 @@ namespace Nevermore.IntegrationTests.SetUp
                 new DocumentWithRowVersionMap());
 
             config.TypeHandlers.Register(new ReferenceCollectionTypeHandler());
+            config.TypeHandlers.Register(new CustomerIdTypeHandler());
+
             config.InstanceTypeResolvers.Register(new ProductTypeResolver());
             config.InstanceTypeResolvers.Register(new BrandTypeResolver());
 

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -14,6 +14,7 @@ using Nevermore.Diagnositcs;
 using Nevermore.Diagnostics;
 using Nevermore.Querying.AST;
 using Nevermore.Transient;
+using Nevermore.Util;
 
 namespace Nevermore.Advanced
 {
@@ -81,7 +82,7 @@ namespace Nevermore.Advanced
         }
 
         [Pure]
-        private TDocument Load<TDocument, TKey>(TKey id) where TDocument : class
+        public TDocument Load<TDocument, TKey>(TKey id) where TDocument : class
         {
             return Stream<TDocument>(PrepareLoad<TDocument, TKey>(id)).FirstOrDefault();
         }
@@ -545,6 +546,8 @@ namespace Nevermore.Advanced
 
             var tableName = mapping.TableName;
             var args = new CommandParameterValues {{"Id", id}};
+            if (mapping.IdColumn.Type.IsStronglyTypedString())
+                args = new CommandParameterValues {{"Id", id.ToString()}};
             return new PreparedCommand($"SELECT TOP 1 * FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{tableName}] WHERE [{mapping.IdColumn.ColumnName}] = @Id", args, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.SequentialAccess);
         }
 

--- a/source/Nevermore/IReadQueryExecutor.cs
+++ b/source/Nevermore/IReadQueryExecutor.cs
@@ -45,6 +45,8 @@ namespace Nevermore
         /// <returns>The document, or <c>null</c> if the document is not found.</returns>
         [Pure] TDocument Load<TDocument>(Guid id) where TDocument : class;
 
+        [Pure] TDocument Load<TDocument, TKey>(TKey id) where TDocument : class;
+
         /// <summary>
         /// Loads a single document given its ID. If the item is not found, returns <c>null</c>.
         /// </summary>
@@ -523,7 +525,7 @@ namespace Nevermore
         [Pure] IAsyncEnumerable<TRecord> StreamAsync<TRecord>(string query, CommandParameterValues args = null, TimeSpan? commandTimeout = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Executes a query that returns strongly typed documents. 
+        /// Executes a query that returns strongly typed documents.
         /// </summary>
         /// <param name="preparedCommand">Everything needed to run the query.</param>
         /// <typeparam name="TRecord">The type of document being queried. Results from the database will be mapped to this type.</typeparam>
@@ -531,7 +533,7 @@ namespace Nevermore
         [Pure] IEnumerable<TRecord> Stream<TRecord>(PreparedCommand preparedCommand);
 
         /// <summary>
-        /// Executes a query that returns strongly typed documents. 
+        /// Executes a query that returns strongly typed documents.
         /// </summary>
         /// <param name="preparedCommand">Everything needed to run the query.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -109,7 +109,7 @@ namespace Nevermore.Util
             var mapping = mappings.Resolve(typeof(TDocument));
 
             var idType = id.GetType();
-            if (mapping.IdColumn.Type != idType)
+            if (mapping.IdColumn.Type != idType && !mapping.IdColumn.Type.IsStronglyTypedString())
                 throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
 
             return PrepareDelete(mapping, id, options);
@@ -268,7 +268,8 @@ namespace Nevermore.Util
                 customAssignedId != null && id != null && customAssignedId != id)
                 throw new ArgumentException("Do not pass a different Id when one is already set on the document");
 
-            if (mapping.IdColumn.Type == typeof(string) && string.IsNullOrWhiteSpace((string)id))
+            if ((mapping.IdColumn.Type == typeof(string) && string.IsNullOrWhiteSpace((string)id)) ||
+                (mapping.IdColumn.Type.IsStronglyTypedString() && string.IsNullOrWhiteSpace(id?.ToString())))
             {
                 id = string.IsNullOrWhiteSpace(customAssignedId as string) ? allocateId(mapping) : customAssignedId;
                 mapping.IdColumn.PropertyHandler.Write(document, id);

--- a/source/Nevermore/Util/DatabaseTypeMap.cs
+++ b/source/Nevermore/Util/DatabaseTypeMap.cs
@@ -63,8 +63,8 @@ namespace Nevermore.Util
             {
                 return DbType.Binary;
             }
-            if (propertyType == typeof(StreamReader) || propertyType == typeof(TextReader) || propertyType == typeof(StringReader) || 
-                typeof(TextReader).IsAssignableFrom(propertyType) )
+            if (propertyType == typeof(StreamReader) || propertyType == typeof(TextReader) || propertyType == typeof(StringReader) ||
+                typeof(TextReader).IsAssignableFrom(propertyType) || propertyType.IsStronglyTypedString())
             {
                 return DbType.String;
             }

--- a/source/Nevermore/Util/StronglyTypeStringExtensionMethods.cs
+++ b/source/Nevermore/Util/StronglyTypeStringExtensionMethods.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nevermore.Util
+{
+    static class StronglyTypeStringExtensionMethods
+    {
+        public static bool IsStronglyTypedString(this Type type)
+        {
+            var property = type.GetProperty("Value");
+            return type.GetProperties().Length == 1 && property != null && property.PropertyType == typeof(string);
+        }
+    }
+}


### PR DESCRIPTION
This is a draft for discussion around the concept of supporting strongly typed keys (e.g. TinyTypes).

Nevermore already has support for these types in most columns, through the use of Type Handlers. This investigation was around working out what it might take to support their use as an `Id`.

The end result seems to be, not all that much.

Investigation Assumptions:
- whatever strongly typed string implementation you chose to use, it has to have the following traits
    - it must have a single property, of type string, which is called `Value`
    - it must implement `ToString` to return `Value`
    - the types can't be implicitly cast to string

More complex things could be done here, e.g. configuration could be allowed to override the property etc

The core implementation changes of interest were to the following classes:
- ReadTransaction
- DatabaseTypeMap
- DataModificationQueryBuilder