### PR TITLE
Extending cancellationToken's use in async calls

### DIFF
--- a/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/LoadFixture.cs
@@ -15,19 +15,15 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         [Test]
         public void LoadWithSingleId()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                trn.Load<Product>("A");
-            }
+            using var trn = Store.BeginTransaction();
+            var _ = trn.Load<Product>("A");
         }
 
         [Test]
         public void LoadWithMultipleIds()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                trn.LoadMany<Product>(new[] { "A", "B" });
-            }
+            using var trn = Store.BeginTransaction();
+            var _ = trn.LoadMany<Product>(new[] { "A", "B" });
         }
 
         [Test]
@@ -64,19 +60,15 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         [Test]
         public void LoadWithMoreThan2100Ids()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                trn.LoadMany<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
-            }
+            using var trn = Store.BeginTransaction();
+            var _ = trn.LoadMany<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
         }
 
         [Test]
         public void LoadStreamWithMoreThan2100Ids()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                trn.LoadStream<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
-            }
+            using var trn = Store.BeginTransaction();
+            var _ = trn.LoadStream<Product>(Enumerable.Range(1, 3000).Select(n => "ID-" + n));
         }
 
         [Test]
@@ -105,170 +97,157 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         [Test]
         public void StoreEnumInheritedTypesSerializesCorrectlyForNormalProduct()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var originalNormal = new Product()
             {
-                var originalNormal = new Product()
-                {
-                    Name = "Unicorn Dust",
-                    Id = "UD-01",
-                    Price = 11.1m,
-                };
+                Name = "Unicorn Dust",
+                Id = "UD-01",
+                Price = 11.1m,
+            };
 
-                trn.Insert(originalNormal);
+            trn.Insert(originalNormal);
 
-                var allProducts = trn.Stream<(string Id, string Type, string JSON)>("select Id, Type, [JSON] from TestSchema.Product").ToList();
+            var allProducts = trn.Stream<(string Id, string Type, string JSON)>("select Id, Type, [JSON] from TestSchema.Product").ToList();
 
-                var special = allProducts.Single(p => p.Id == "UD-01");
-                special.Type.Should().Be("Normal", "Type isn't serializing into column correctly");
-                special.JSON.Should().Be("{\"Price\":11.1}");
-            }
+            var special = allProducts.Single(p => p.Id == "UD-01");
+            special.Type.Should().Be("Normal", "Type isn't serializing into column correctly");
+            special.JSON.Should().Be("{\"Price\":11.1}");
         }
 
         [Test]
         public void StoreEnumInheritedTypesSerializesCorrectlyForSpecialProduct()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var originalSpecial = new SpecialProduct
             {
-                var originalSpecial = new SpecialProduct
-                {
-                    Name = "Unicorn Dust",
-                    BonusMaterial = "Directors Commentary",
-                    Id = "UD-01",
-                    Price = 11.1m,
-                };
+                Name = "Unicorn Dust",
+                BonusMaterial = "Directors Commentary",
+                Id = "UD-01",
+                Price = 11.1m,
+            };
 
-                var originalDud = new DodgyProduct
-                {
-                    Id = "DO-01",
-                    Name = "Something",
-                    Price = 12.3m,
-                    Tax = 15m
-                };
+            var originalDud = new DodgyProduct
+            {
+                Id = "DO-01",
+                Name = "Something",
+                Price = 12.3m,
+                Tax = 15m
+            };
 
-                trn.Insert(originalSpecial);
-                trn.Insert(originalDud);
+            trn.Insert(originalSpecial);
+            trn.Insert(originalDud);
 
-                var allProducts = trn.Stream<(string Id, string Type, string JSON)>("select Id, Type, [JSON] from TestSchema.Product").ToList();
+            var allProducts = trn.Stream<(string Id, string Type, string JSON)>("select Id, Type, [JSON] from TestSchema.Product").ToList();
 
-                var special = allProducts.Single(p => p.Id == "UD-01");
-                special.Type.Should().Be("Special", "Type isn't serializing into column correctly");
-                special.JSON.Should().Be("{\"BonusMaterial\":\"Directors Commentary\",\"Price\":11.1}");
-            }
+            var special = allProducts.Single(p => p.Id == "UD-01");
+            special.Type.Should().Be("Special", "Type isn't serializing into column correctly");
+            special.JSON.Should().Be("{\"BonusMaterial\":\"Directors Commentary\",\"Price\":11.1}");
         }
 
         [Test]
         public void StoreAndLoadEnumInheritedTypes()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var originalNormal = new Product
             {
-                var originalNormal = new Product
-                {
-                    Name = "Norm",
-                    Id = "NL-01",
-                    Price = 15.5m
-                };
+                Name = "Norm",
+                Id = "NL-01",
+                Price = 15.5m
+            };
 
-                var originalSpecial = new SpecialProduct
-                {
-                    Name = "Unicorn Dust",
-                    BonusMaterial = "Directors Commentary",
-                    Id = "UD-01",
-                    Price = 11.1m
-                };
+            var originalSpecial = new SpecialProduct
+            {
+                Name = "Unicorn Dust",
+                BonusMaterial = "Directors Commentary",
+                Id = "UD-01",
+                Price = 11.1m
+            };
 
-                var originalDud = new DodgyProduct
-                {
-                    Id = "DO-01",
-                    Name = "Something",
-                    Price = 12.3m,
-                    Tax = 15m
-                };
+            var originalDud = new DodgyProduct
+            {
+                Id = "DO-01",
+                Name = "Something",
+                Price = 12.3m,
+                Tax = 15m
+            };
 
-                trn.Insert(originalNormal);
-                trn.Insert<SpecialProduct>(originalSpecial);
-                trn.Insert<DodgyProduct>(originalDud);
+            trn.Insert(originalNormal);
+            trn.Insert(originalSpecial);
+            trn.Insert(originalDud);
 
-                var allProducts = trn.Query<Product>().ToList();
-                Assert.True(allProducts.Exists(p =>
-                    p is SpecialProduct sp && sp.BonusMaterial == originalSpecial.BonusMaterial), "Special product didn't load correctly");
-                Assert.True(allProducts.Exists(p => p is DodgyProduct dp && dp.Tax == originalDud.Tax), "Dodgy product didn't load correctly");
+            var allProducts = trn.Query<Product>().ToList();
+            Assert.True(allProducts.Exists(p =>
+                p is SpecialProduct sp && sp.BonusMaterial == originalSpecial.BonusMaterial), "Special product didn't load correctly");
+            Assert.True(allProducts.Exists(p => p is DodgyProduct dp && dp.Tax == originalDud.Tax), "Dodgy product didn't load correctly");
 
-                var onlySpecial = trn.Query<SpecialProduct>().ToList();
-                onlySpecial.Count.Should().Be(1);
-                onlySpecial[0].BonusMaterial.Should().Be(originalSpecial.BonusMaterial);
-            }
+            var onlySpecial = trn.Query<SpecialProduct>().ToList();
+            onlySpecial.Count.Should().Be(1);
+            onlySpecial[0].BonusMaterial.Should().Be(originalSpecial.BonusMaterial);
         }
 
         [Test]
         public void StoreStringInheritedTypesSerializeCorrectly()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
-                var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
+            using var trn = Store.BeginTransaction();
+            var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
+            var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
 
-                trn.Insert<Brand>(brandA);
-                trn.Insert<Brand>(brandB);
-                trn.Commit();
+            trn.Insert<Brand>(brandA);
+            trn.Insert<Brand>(brandB);
+            trn.Commit();
 
-                var allBrands = trn.Stream<(string Name, string JSON)>("select Name, [JSON] from TestSchema.Brand").ToList();
+            var allBrands = trn.Stream<(string Name, string JSON)>("select Name, [JSON] from TestSchema.Brand").ToList();
 
-                allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
-                var brandToTestSerialization = allBrands.Single(x => x.Name == "Brand A");
-                brandToTestSerialization.JSON.Should().Be("{\"Description\":\"Details for Brand A.\"}");
-            }
+            allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
+            var brandToTestSerialization = allBrands.Single(x => x.Name == "Brand A");
+            brandToTestSerialization.JSON.Should().Be("{\"Description\":\"Details for Brand A.\"}");
         }
         
         [Test]
         public void StoreAndLoadStringInheritedTypes()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
-                var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
+            using var trn = Store.BeginTransaction();
+            var brandA = new BrandA { Name = "Brand A", Description = "Details for Brand A." };
+            var brandB = new BrandB { Name = "Brand B", Description = "Details for Brand B." };
 
-                trn.Insert<Brand>(brandA);
-                trn.Insert<Brand>(brandB);
-                trn.Commit();
+            trn.Insert<Brand>(brandA);
+            trn.Insert<Brand>(brandB);
+            trn.Commit();
 
-                var allBrands = trn.Query<Brand>().ToList();
+            var allBrands = trn.Query<Brand>().ToList();
 
-                allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
-                allBrands.Single(x => x.Name == "Brand A").Should().BeOfType<BrandA>();
-            }
+            allBrands.SingleOrDefault(x => x.Name == "Brand A").Should().NotBeNull("Didn't retrieve BrandA");
+            allBrands.Single(x => x.Name == "Brand A").Should().BeOfType<BrandA>();
         }
 
         [Test]
         public void StoreAndLoadStringInheritedTypesThatAreProperties()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                var machineA = new Machine { Name = "Machine A", Description = "Details for Machine A.", Endpoint = new PassiveTentacleEndpoint { Name = "Quiet tentacle" }};
-                var machineB = new Machine { Name = "Machine B", Description = "Details for Machine B.", Endpoint = new ActiveTentacleEndpoint { Name = "Noisy tentacle" } };
+            using var trn = Store.BeginTransaction();
+            var machineA = new Machine { Name = "Machine A", Description = "Details for Machine A.", Endpoint = new PassiveTentacleEndpoint { Name = "Quiet tentacle" }};
+            var machineB = new Machine { Name = "Machine B", Description = "Details for Machine B.", Endpoint = new ActiveTentacleEndpoint { Name = "Noisy tentacle" } };
 
-                trn.Insert(machineA);
-                trn.Insert(machineB);
-                trn.Commit();
+            trn.Insert(machineA);
+            trn.Insert(machineB);
+            trn.Commit();
 
-                var allMachines = trn.Query<Machine>().ToList();
+            var allMachines = trn.Query<Machine>().ToList();
 
-                allMachines.SingleOrDefault(x => x.Name == "Machine A").Should().NotBeNull("Didn't retrieve Machine A");
-                allMachines.Single(x => x.Name == "Machine A").Endpoint.Should().BeOfType<PassiveTentacleEndpoint>();
-            }
+            allMachines.SingleOrDefault(x => x.Name == "Machine A").Should().NotBeNull("Didn't retrieve Machine A");
+            allMachines.Single(x => x.Name == "Machine A").Endpoint.Should().BeOfType<PassiveTentacleEndpoint>();
         }
 
         [Test]
         public void StoreAndLoadFromParameterizedRawSql()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                InsertProductAndLineItems("Unicorn Hair", 2m, trn, 1);         // subtotal: $2 of Unicorn Hair
-                InsertProductAndLineItems("Unicorn Poop", 3m, trn, 2, 3);      // subtotal: $15 of Unicorn Poop
-                InsertProductAndLineItems("Unicorn Dust", 1m, trn, 2, 1, 7);   // subtotal: $10 of Unicorn Dust
-                InsertProductAndLineItems("Fairy Bread", 10m, trn, 4);         // subtotal: $40 of Fairy Bread
-                trn.Commit();
+            using var trn = Store.BeginTransaction();
+            InsertProductAndLineItems("Unicorn Hair", 2m, trn, 1);         // subtotal: $2 of Unicorn Hair
+            InsertProductAndLineItems("Unicorn Poop", 3m, trn, 2, 3);      // subtotal: $15 of Unicorn Poop
+            InsertProductAndLineItems("Unicorn Dust", 1m, trn, 2, 1, 7);   // subtotal: $10 of Unicorn Dust
+            InsertProductAndLineItems("Fairy Bread", 10m, trn, 4);         // subtotal: $40 of Fairy Bread
+            trn.Commit();
 
-                var productSubtotalQuery =    @"SELECT
+            var productSubtotalQuery =    @"SELECT
                                                     Id,
                                                     ProductId,
                                                     ProductName,
@@ -294,17 +273,16 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
                                                     ) p ON p.ProductId = l.ProductId
                                                     GROUP BY p.ProductId, p.ProductName
                                                 ) p3
-                                                WHERE Subtotal >= @MinimumSubtotal";
+                                                WHERE Subtotal >= @minimum_subtotal";
 
-                var doubleDigitUnicornProductSubtotals = trn.RawSqlQuery<ProductSubtotal>(productSubtotalQuery)
-                    .Where(s => s.ProductName.Contains("Unicorn"))
-                    .Parameter("MinimumSubtotal", 10)
-                    .ToList();
+            var doubleDigitUnicornProductSubtotals = trn.RawSqlQuery<ProductSubtotal>(productSubtotalQuery)
+                .Where(s => s.ProductName.Contains("Unicorn"))
+                .Parameter("minimum_subtotal", 10)
+                .ToList();
 
-                doubleDigitUnicornProductSubtotals.Should().HaveCount(2);
-                doubleDigitUnicornProductSubtotals.Should().ContainSingle(s => s.ProductName == "Unicorn Poop").Which.Subtotal.Should().Be(15m);
-                doubleDigitUnicornProductSubtotals.Should().ContainSingle(s => s.ProductName == "Unicorn Dust").Which.Subtotal.Should().Be(10m);
-            }
+            doubleDigitUnicornProductSubtotals.Should().HaveCount(2);
+            doubleDigitUnicornProductSubtotals.Should().ContainSingle(s => s.ProductName == "Unicorn Poop").Which.Subtotal.Should().Be(15m);
+            doubleDigitUnicornProductSubtotals.Should().ContainSingle(s => s.ProductName == "Unicorn Dust").Which.Subtotal.Should().Be(10m);
         }
 
         void InsertProductAndLineItems(string productName, decimal productPrice, IWriteTransaction trn, params int[] quantities)
@@ -325,132 +303,124 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
         [Test]
         public void StoreAndLoadAnyIdTypes()
         {
-            using (var trn = Store.BeginTransaction())
-            {
-                var messageA = new MessageWithGuidId { Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A" };
+            using var trn = Store.BeginTransaction();
+            var messageA = new MessageWithGuidId { Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A" };
 
-                trn.Insert(messageA);
-                trn.Commit();
+            trn.Insert(messageA);
+            trn.Commit();
 
-                var loadedMessageA = trn.Load<MessageWithGuidId>(messageA.Id);
+            var loadedMessageA = trn.Load<MessageWithGuidId>(messageA.Id);
 
-                loadedMessageA.Sender.Should().Be(messageA.Sender);
-                loadedMessageA.Body.Should().Be(messageA.Body);
-            }
+            loadedMessageA.Sender.Should().Be(messageA.Sender);
+            loadedMessageA.Body.Should().Be(messageA.Body);
         }
 
         [Test]
         public void LoadByWrongIdType_ShouldThrowArgumentException()
         {
-            using (var trn = Store.BeginTransaction())
+            Action target = () =>
             {
-                Action target = () => trn.Load<MessageWithGuidId>(1);
+                using var trn = Store.BeginTransaction();
+                var _ = trn.Load<MessageWithGuidId>(1);
+            };
 
-                target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.Int32' does not match configured type of 'System.Guid'.");
-            }
+            target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.Int32' does not match configured type of 'System.Guid'.");
         }
 
         [Test]
         public void StoreAndLoadManyForStringIdType()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var messages = new List<MessageWithStringId>
             {
-                var messages = new List<MessageWithStringId>
-                {
-                    new MessageWithStringId {Id = "Messages-1", Sender = "Sender A", Body = "Body of Message A"},
-                    new MessageWithStringId {Id = "Messages-12", Sender = "Sender A", Body = "Body of Message A"}
-                };
+                new MessageWithStringId {Id = "Messages-1", Sender = "Sender A", Body = "Body of Message A"},
+                new MessageWithStringId {Id = "Messages-12", Sender = "Sender A", Body = "Body of Message A"}
+            };
 
-                foreach (var message in messages)
-                {
-                    trn.Insert(message);
-                }
-                trn.Commit();
-
-                var loadedMessages = trn.LoadMany<MessageWithStringId>(messages.Select(m => m.Id));
-
-                loadedMessages.ShouldAllBeEquivalentTo(messages);
+            foreach (var message in messages)
+            {
+                trn.Insert(message);
             }
+            trn.Commit();
+
+            var loadedMessages = trn.LoadMany<MessageWithStringId>(messages.Select(m => m.Id));
+
+            loadedMessages.ShouldAllBeEquivalentTo(messages);
         }
 
         [Test]
         public void StoreAndLoadManyForIntIdType()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var messages = new List<MessageWithIntId>
             {
-                var messages = new List<MessageWithIntId>
-                {
-                    new MessageWithIntId {Id = int.MinValue, Sender = "Sender A", Body = "Body of Message A"},
-                    new MessageWithIntId {Id = int.MaxValue, Sender = "Sender A", Body = "Body of Message A"}
-                };
+                new MessageWithIntId {Id = int.MinValue, Sender = "Sender A", Body = "Body of Message A"},
+                new MessageWithIntId {Id = int.MaxValue, Sender = "Sender A", Body = "Body of Message A"}
+            };
 
-                foreach (var message in messages)
-                {
-                    trn.Insert(message);
-                }
-                trn.Commit();
-
-                var loadedMessages = trn.LoadMany<MessageWithIntId>(messages.Select(m => m.Id));
-
-                loadedMessages.ShouldAllBeEquivalentTo(messages);
+            foreach (var message in messages)
+            {
+                trn.Insert(message);
             }
+            trn.Commit();
+
+            var loadedMessages = trn.LoadMany<MessageWithIntId>(messages.Select(m => m.Id));
+
+            loadedMessages.ShouldAllBeEquivalentTo(messages);
         }
 
         [Test]
         public void StoreAndLoadManyForLongIdType()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var messages = new List<MessageWithLongId>
             {
-                var messages = new List<MessageWithLongId>
-                {
-                    new MessageWithLongId {Id = long.MinValue, Sender = "Sender A", Body = "Body of Message A"},
-                    new MessageWithLongId {Id = long.MaxValue, Sender = "Sender A", Body = "Body of Message A"}
-                };
+                new MessageWithLongId {Id = long.MinValue, Sender = "Sender A", Body = "Body of Message A"},
+                new MessageWithLongId {Id = long.MaxValue, Sender = "Sender A", Body = "Body of Message A"}
+            };
 
-                foreach (var message in messages)
-                {
-                    trn.Insert(message);
-                }
-                trn.Commit();
-
-                var loadedMessages = trn.LoadMany<MessageWithLongId>(messages.Select(m => m.Id));
-
-                loadedMessages.ShouldAllBeEquivalentTo(messages);
+            foreach (var message in messages)
+            {
+                trn.Insert(message);
             }
+            trn.Commit();
+
+            var loadedMessages = trn.LoadMany<MessageWithLongId>(messages.Select(m => m.Id));
+
+            loadedMessages.ShouldAllBeEquivalentTo(messages);
         }
 
         [Test]
         public void StoreAndLoadManyForGuidIdType()
         {
-            using (var trn = Store.BeginTransaction())
+            using var trn = Store.BeginTransaction();
+            var messages = new List<MessageWithGuidId>
             {
-                var messages = new List<MessageWithGuidId>
-                {
-                    new MessageWithGuidId {Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A"},
-                    new MessageWithGuidId {Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A"}
-                };
+                new MessageWithGuidId {Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A"},
+                new MessageWithGuidId {Id = Guid.NewGuid(), Sender = "Sender A", Body = "Body of Message A"}
+            };
 
-                foreach (var message in messages)
-                {
-                    trn.Insert(message);
-                }
-                trn.Commit();
-
-                var loadedMessages = trn.LoadMany<MessageWithGuidId>(messages.Select(m => m.Id));
-
-                loadedMessages.ShouldAllBeEquivalentTo(messages);
+            foreach (var message in messages)
+            {
+                trn.Insert(message);
             }
+            trn.Commit();
+
+            var loadedMessages = trn.LoadMany<MessageWithGuidId>(messages.Select(m => m.Id));
+
+            loadedMessages.ShouldAllBeEquivalentTo(messages);
         }
 
         [Test]
         public void LoadManyByWrongIdType_ShouldThrowArgumentException()
         {
-            using (var trn = Store.BeginTransaction())
+            Action target = () =>
             {
-                Action target = () => trn.LoadMany<MessageWithGuidId>("Messages-1");
+                using var trn = Store.BeginTransaction();
+                var _ = trn.LoadMany<MessageWithGuidId>("Messages-1");
+            };
 
-                target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.String' does not match configured type of 'System.Guid'.");
-            }
+            target.ShouldThrow<ArgumentException>().Which.Message.Should().Be("Provided Id of type 'System.String' does not match configured type of 'System.Guid'.");
         }
     }
 }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -530,10 +530,10 @@ namespace Nevermore.Advanced
             return command.ReadResults(mapper);
         }
 
-        protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper)
+        protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper, CancellationToken cancellationToken = default)
         {
             using var command = CreateCommand(preparedCommand);
-            return await command.ReadResultsAsync(mapper);
+            return await command.ReadResultsAsync(mapper, cancellationToken);
         }
 
         PreparedCommand PrepareLoad<TDocument, TKey>(TKey id)

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -264,7 +264,7 @@ namespace Nevermore.Advanced
                 return Array.Empty<object>();
             }
 
-            return await ReadResultsAsync(command, reader => reader.GetValue(0));
+            return await ReadResultsAsync(command, reader => reader.GetValue(0), cancellationToken);
         }
 
         async Task<object> ExecuteSingleDataModificationAsync(PreparedCommand command, CancellationToken cancellationToken)

--- a/source/Nevermore/Transient/DbCommandExtensions.cs
+++ b/source/Nevermore/Transient/DbCommandExtensions.cs
@@ -14,16 +14,8 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
             return effectiveCommandRetryPolicy.ExecuteAction(() =>
             {
-                var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                try
-                {
-                    return command.ExecuteNonQuery();
-                }
-                finally
-                {
-                    if (weOwnTheConnectionLifetime && command.Connection != null && command.Connection.State == ConnectionState.Open)
-                        command.Connection.Close();
-                }
+                using var validCommand = ValidCommand.For(command, connectionRetryPolicy);
+                return validCommand.ExecuteNonQuery();
             });
         }
 
@@ -33,16 +25,8 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
             return effectiveCommandRetryPolicy.ExecuteAction(async () =>
             {
-                var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                try
-                {
-                    return await command.ExecuteNonQueryAsync();
-                }
-                finally
-                {
-                    if (weOwnTheConnectionLifetime && command.Connection != null && command.Connection.State == ConnectionState.Open)
-                        command.Connection.Close();
-                }
+                await using var validCommand = await ValidCommandAsync.For(command, connectionRetryPolicy, cancellationToken);
+                return await validCommand.ExecuteNonQueryAsync(cancellationToken);
             });
         }
 
@@ -54,18 +38,8 @@ namespace Nevermore.Transient
                 var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
                 return effectiveCommandRetryPolicy.ExecuteAction(() =>
                 {
-                    var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                    try
-                    {
-                        return command.ExecuteReader(behavior);
-                    }
-                    catch (Exception)
-                    {
-                        if (weOwnTheConnectionLifetime && command.Connection != null &&
-                            command.Connection.State == ConnectionState.Open)
-                            command.Connection.Close();
-                        throw;
-                    }
+                    using var validCommand = ValidCommand.For(command, connectionRetryPolicy);
+                    return validCommand.ExecuteReader(behavior);
                 });
             }
             catch (Exception ex)
@@ -83,18 +57,8 @@ namespace Nevermore.Transient
                     (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
                 return await effectiveCommandRetryPolicy.ExecuteActionAsync(async () =>
                 {
-                    var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                    try
-                    {
-                        return await command.ExecuteReaderAsync(commandBehavior, cancellationToken);
-                    }
-                    catch (Exception)
-                    {
-                        if (weOwnTheConnectionLifetime && command.Connection != null &&
-                            command.Connection.State == ConnectionState.Open)
-                            await command.Connection.CloseAsync();
-                        throw;
-                    }
+                    await using var validCommand = await ValidCommandAsync.For(command, connectionRetryPolicy, cancellationToken);
+                    return await validCommand.ExecuteReaderAsync(commandBehavior, cancellationToken);
                 });
             }
             catch (Exception ex)
@@ -109,16 +73,8 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
             return effectiveCommandRetryPolicy.ExecuteAction(() =>
             {
-                var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                try
-                {
-                    return command.ExecuteScalar();
-                }
-                finally
-                {
-                    if (weOwnTheConnectionLifetime && command.Connection != null && command.Connection.State == ConnectionState.Open)
-                        command.Connection.Close();
-                }
+                using var validCommand = ValidCommand.For(command, connectionRetryPolicy);
+                return validCommand.ExecuteScalar();
             });
         }
         
@@ -128,39 +84,96 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryManager.Instance.GetDefaultSqlCommandRetryPolicy()).LoggingRetries(operationName);
             return await effectiveCommandRetryPolicy.ExecuteActionAsync(async () =>
             {
-                var weOwnTheConnectionLifetime = EnsureValidConnection(command, connectionRetryPolicy);
-                try
-                {
-                    return await command.ExecuteScalarAsync(cancellationToken);
-                }
-                finally
-                {
-                    if (weOwnTheConnectionLifetime && command.Connection != null && command.Connection.State == ConnectionState.Open)
-                        await command.Connection.CloseAsync();
-                }
+                await using var validCommand = await ValidCommandAsync.For(command, connectionRetryPolicy, cancellationToken);
+                return await validCommand.ExecuteScalarAsync(cancellationToken);
             });
         }
 
         static void GuardConnectionIsNotNull(DbCommand command)
         {
-            if (command.Connection == null)
+            if (command?.Connection == null)
                 throw new InvalidOperationException("Connection property has not been initialized.");
+        }
+
+        class ValidCommand : IDisposable
+        {
+            DbConnection ourConnection = null;
+            
+            readonly DbCommand innerCommand = null;
+            
+            ValidCommand(DbCommand command, DbConnection connection = null)
+            {
+                innerCommand = command;
+                ourConnection = connection;
+            }
+
+            public static ValidCommand For(DbCommand command, RetryPolicy retryPolicy)
+            {
+                GuardConnectionIsNotNull(command);
+                
+                if (command.Connection.State == ConnectionState.Open) return new ValidCommand(command);
+                
+                command.Connection.OpenWithRetry(retryPolicy);
+                return new ValidCommand(command, command.Connection);
+            }
+
+            public object ExecuteScalar() => innerCommand.ExecuteScalar();
+
+            public DbDataReader ExecuteReader(CommandBehavior behavior) => innerCommand.ExecuteReader(behavior);
+
+            public int ExecuteNonQuery() => innerCommand.ExecuteNonQuery();
+            
+            public void Dispose()
+            {
+                if (ourConnection?.State != ConnectionState.Open) return;
+                ourConnection.Close();
+                ourConnection = null;
+            }
         }
 
         /// <summary>
         /// Ensures the command either has an existing open connection, or we will open one for it.
         /// </summary>
         /// <returns>True if we opened the connection (indicating we own its lifetime), False if the connection was already open (indicating someone else owns its lifetime)</returns>
-        static bool EnsureValidConnection(DbCommand command, RetryPolicy retryPolicy)
+        class ValidCommandAsync : IAsyncDisposable
         {
-            if (command == null) return false;
+            DbConnection ourConnection = null;
 
-            GuardConnectionIsNotNull(command);
+            readonly DbCommand innerCommand = null;
 
-            if (command.Connection.State == ConnectionState.Open) return false;
+            ValidCommandAsync(DbCommand command, DbConnection connection = null)
+            {
+                innerCommand = command;
+                ourConnection = connection;
+            }
+            
+            public static async Task<ValidCommandAsync> For(DbCommand command, RetryPolicy retryPolicy, CancellationToken cancellationToken)
+            {
+                GuardConnectionIsNotNull(command);
+                
+                if (command.Connection.State == ConnectionState.Open) return new ValidCommandAsync(command);
+                
+                await command.Connection.OpenWithRetryAsync(retryPolicy, cancellationToken);
+                return new ValidCommandAsync(command, command.Connection);
+            }
+            
+            public async ValueTask DisposeAsync()
+            {
+                if (ourConnection?.State == ConnectionState.Open)
+                {
+                    await ourConnection.CloseAsync();
+                    ourConnection = null;
+                }
+            }
 
-            command.Connection.OpenWithRetry(retryPolicy);
-            return true;
+            public Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+                => innerCommand.ExecuteScalarAsync(cancellationToken);
+            
+            public Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) 
+                => innerCommand.ExecuteReaderAsync(behavior, cancellationToken);
+
+            public Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+                => innerCommand.ExecuteNonQueryAsync(cancellationToken);
         }
     }
 }

--- a/source/Nevermore/Transient/DbConnectionExtensions.cs
+++ b/source/Nevermore/Transient/DbConnectionExtensions.cs
@@ -19,12 +19,22 @@ namespace Nevermore.Transient
             (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteAction(connection.Open);
         }
         
-        public static Task OpenWithRetryAsync(this DbConnection connection, CancellationToken cancellationToken = default)
+        public static Task OpenWithRetryAsync(this DbConnection connection)
+        {
+            return OpenWithRetryAsync(connection, RetryManager.Instance.GetDefaultSqlConnectionRetryPolicy());
+        }
+
+        public static Task OpenWithRetryAsync(this DbConnection connection, CancellationToken cancellationToken)
         {
             return OpenWithRetryAsync(connection, RetryManager.Instance.GetDefaultSqlConnectionRetryPolicy(), cancellationToken);
         }
 
-        public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy, CancellationToken cancellationToken = default)
+        public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy)
+        {
+            return OpenWithRetryAsync(connection, retryPolicy, CancellationToken.None);
+        }
+        
+        public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy, CancellationToken cancellationToken)
         {
             return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteActionAsync(() => connection.OpenAsync(cancellationToken));
         }

--- a/source/Nevermore/Transient/DbConnectionExtensions.cs
+++ b/source/Nevermore/Transient/DbConnectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nevermore.Transient
@@ -18,14 +19,14 @@ namespace Nevermore.Transient
             (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteAction(connection.Open);
         }
         
-        public static Task OpenWithRetryAsync(this DbConnection connection)
+        public static Task OpenWithRetryAsync(this DbConnection connection, CancellationToken cancellationToken = default)
         {
-            return OpenWithRetryAsync(connection, RetryManager.Instance.GetDefaultSqlConnectionRetryPolicy());
+            return OpenWithRetryAsync(connection, RetryManager.Instance.GetDefaultSqlConnectionRetryPolicy(), cancellationToken);
         }
 
-        public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy)
+        public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy, CancellationToken cancellationToken = default)
         {
-            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteActionAsync(connection.OpenAsync);
+            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteActionAsync(() => connection.OpenAsync(cancellationToken));
         }
     }
 }


### PR DESCRIPTION
Found that there were a few async operations that did not use/accept a cancellation token:

- ExecuteNonQueryWithRetryAsync method in Nevermore.Transient.DbCommandExtensions - meaning it waited for timeout or completion
- OpenWithRetryAsync - meaning it would timeout rather than cancelled
- ReadResultsAsync - didn't accept a cancellation token, so you couldn't interrupt the reading of the resultset

Also found that on a case-sensitive DB server, the MinimumSubtotal parameter in the StoreAndLoadFromParameterizedRawSql test would fail (as Parameter turns it to lowercase).  The rest of the changes are resharper warnings.