### PR TITLE
Add support for `DISTINCT` select statement

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateDistinctForJoin.approved.txt
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.ShouldGenerateDistinctForJoin.approved.txt
@@ -1,0 +1,8 @@
+SELECT DISTINCT ALIAS_GENERATED_2.[Name]
+FROM (
+    SELECT *
+    FROM [dbo].[Orders]
+    WHERE ([Price] > 5)
+) ALIAS_GENERATED_2
+INNER JOIN [dbo].[Customers] ALIAS_Customers_1
+ON ALIAS_GENERATED_2.[CustomerId] = ALIAS_Customers_1.[Id]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -339,6 +339,42 @@ ORDER BY [Id]";
         }
 
         [Test]
+        public void ShouldGenerateDistinct()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+            CreateQueryBuilder<object>("Orders")
+                .NoLock()
+                .Where("[Price] > 5")
+                .Column("Name")
+                .Distinct();
+
+            var expected = @"SELECT DISTINCT [Name]
+FROM [dbo].[Orders] NOLOCK
+WHERE ([Price] > 5)";
+
+            actual.Should().Be(expected);
+        }
+
+
+        [Test]
+        public void ShouldGenerateDistinctForJoin()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+
+            var leftQueryBuilder = CreateQueryBuilder<object>("Orders")
+                .Where("[Price] > 5");
+            var rightQueryBuilder = CreateQueryBuilder<object>("Customers");
+
+            leftQueryBuilder.InnerJoin(rightQueryBuilder).On("CustomerId", JoinOperand.Equal, "Id")
+                .Column("Name")
+                .Distinct();
+
+            this.Assent(actual);
+        }
+
+        [Test]
         public void ShouldGenerateExpectedLikeParametersForQueryBuilder()
         {
             CommandParameterValues parameterValues = null;

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -63,6 +63,24 @@ ELSE
 FROM [dbo].[Accounts]
 ORDER BY [Id]");
         }
+        
+        
+        [Test]
+        public void ShouldNotModifyQueryBuilderStateFromDistinct()
+        {
+            var queryBuilder = QueryBuilder("Accounts");
+
+            queryBuilder.Distinct();
+
+            LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT DISTINCT *
+FROM [dbo].[Accounts]");
+
+            queryBuilder.ToList();
+
+            LastExecutedQuery().ShouldBeEquivalentTo(@"SELECT *
+FROM [dbo].[Accounts]
+ORDER BY [Id]");
+        }
 
         [Test]
         public void ShouldNotModifyQueryBuilderStateFromTake()

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -336,6 +336,22 @@ namespace Nevermore.Advanced
             return default;
         }
 
+        public IEnumerable<TRecord> Distinct()
+        {
+            var clonedSelectBuilder = selectBuilder.Clone();
+            clonedSelectBuilder.AddDistinct();
+            var stream = readQueryExecutor.Stream<TRecord>(clonedSelectBuilder.GenerateSelectWithoutDefaultOrderBy().GenerateSql(), paramValues, commandTimeout);
+            return stream;
+        }
+
+        public IAsyncEnumerable<TRecord> DistinctAsync(CancellationToken cancellationToken = default)
+        {
+            var clonedSelectBuilder = selectBuilder.Clone();
+            clonedSelectBuilder.AddDistinct();
+            var stream = readQueryExecutor.StreamAsync<TRecord>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, commandTimeout, cancellationToken);
+            return stream;
+        }
+
         public IEnumerable<TRecord> Take(int take)
         {
             var clonedSelectBuilder = selectBuilder.Clone();

--- a/source/Nevermore/Advanced/SelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilder.cs
@@ -261,6 +261,11 @@ namespace Nevermore.Advanced
             RowSelection = new Top(top);
         }
 
+        public void AddDistinct()
+        {
+            RowSelection = new Distinct();
+        }
+
         public virtual void AddOrder(string fieldName, bool @descending)
         {
             OrderByClauses.Add(new OrderByField(new Column(fieldName), @descending ? OrderByDirection.Descending : OrderByDirection.Ascending));

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -486,11 +486,21 @@ namespace Nevermore.Advanced
             return Final(Builder.Take(take));
         }
 
+        public IEnumerable<TRecord> Distinct()
+        {
+            return Final(Builder.Distinct());
+        }
+
         public IAsyncEnumerable<TRecord> TakeAsync(int take, CancellationToken cancellationToken = default)
         {
             return Final(Builder.TakeAsync(take, cancellationToken));
         }
 
+        public IAsyncEnumerable<TRecord> DistinctAsync(CancellationToken cancellationToken = default)
+        {
+            return Final(Builder.DistinctAsync(cancellationToken));
+        }
+        
         public List<TRecord> ToList(int skip, int take)
         {
             return Final(Builder.ToList(skip, take));

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -7,7 +7,7 @@ namespace Nevermore
     public interface ISelectBuilder
     {
         void AddTop(int top);
-
+        void AddDistinct();
         void AddOrder(string fieldName, bool descending);
         void AddOrder(string fieldName, string tableAlias, bool descending);
         void AddWhere(UnaryWhereParameter whereParams);

--- a/source/Nevermore/Querying/AST/IRowSelection.cs
+++ b/source/Nevermore/Querying/AST/IRowSelection.cs
@@ -23,4 +23,15 @@
         public string GenerateSql() => "";
         public override string ToString() => GenerateSql();
     }
+
+    public class Distinct : IRowSelection
+    {
+        public Distinct()
+        {
+            
+        }
+
+        public string GenerateSql() => $"DISTINCT ";
+        public override string ToString() => GenerateSql();
+    }
 }

--- a/source/Nevermore/Querying/ICompleteQuery.cs
+++ b/source/Nevermore/Querying/ICompleteQuery.cs
@@ -47,6 +47,19 @@ namespace Nevermore.Querying
         /// </summary>
         /// <param name="cancellationToken">Token used to cancel the command.</param>
         [Pure] Task<TRecord> FirstOrDefaultAsync(CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        ///  Executes the query and returns a distinct set of results based on the columns included included
+        /// </summary>
+        /// <returns>The distinct set of results from the column projection</returns>
+        [Pure] IEnumerable<TRecord> Distinct();
+
+        /// <summary>
+        ///  Executes the query and returns a distinct set of results based on the columns included
+        /// </summary>
+        /// <param name="cancellationToken">Token used to cancel the command.</param>
+        /// <returns>The distinct set of results from the column projection</returns>
+        [Pure] IAsyncEnumerable<TRecord> DistinctAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///  Executes the query and returns the specified number of rows


### PR DESCRIPTION
This change brings support to perform the `DISTINCT` sql operation to Nevermore. 
The approach here follows similar structure to the existing `TAKE` operation which has similar semantics albeit without the implicit ordering.