### PR TITLE
Adding GroupBy Support 

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -258,6 +258,48 @@ WHERE ([Price] > 5)";
         }
 
         [Test]
+        public void ShouldGenerateCountBySpaceForQueryBuilder()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+
+            CreateQueryBuilder<object>("Orders")
+                .NoLock()
+                .GroupBy("SpaceId")
+                .Column("SpaceId")
+                .CountColumn("OrderCount")
+                .ToList();
+
+            const string expected = @"SELECT [SpaceId],
+COUNT (*) AS [OrderCount]
+FROM [dbo].[Orders] NOLOCK
+GROUP BY [SpaceId]";
+
+            actual.Should().Be(expected);
+        }        
+        
+        [Test]
+        public void ShouldGenerateCountDistinctBySpaceForQueryBuilder()
+        {
+            string actual = null;
+            transaction.Stream<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+
+            CreateQueryBuilder<object>("Orders")
+                .NoLock()
+                .GroupBy("SpaceId")
+                .Column("SpaceId")
+                .CountColumn("[Name]", true,"OrderCount")
+                .ToList();
+
+            const string expected = @"SELECT [SpaceId],
+COUNT (DISTINCT [Name]) AS [OrderCount]
+FROM [dbo].[Orders] NOLOCK
+GROUP BY [SpaceId]";
+
+            actual.Should().Be(expected);
+        }   
+
+        [Test]
         public void ShouldGenerateCountForJoin()
         {
             string actual = null;

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -112,20 +112,6 @@ namespace Nevermore.Advanced
             selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression(expression)), columnAlias));
             return this;
         }
-
-
-        public IQueryBuilder<TRecord> CountColumn(string columnAlias)
-        {
-            selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression("COUNT (*)")), columnAlias));
-            return this;
-        }
-
-        public IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias)
-        {
-            var distinctClause = distinct ? "DISTINCT " : string.Empty;
-            selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression($"COUNT ({distinctClause}{expression})")), columnAlias));
-            return this;
-        }
         
         public IQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class
         {

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -113,6 +113,20 @@ namespace Nevermore.Advanced
             return this;
         }
 
+
+        public IQueryBuilder<TRecord> CountColumn(string columnAlias)
+        {
+            selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression("COUNT (*)")), columnAlias));
+            return this;
+        }
+
+        public IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias)
+        {
+            var distinctClause = distinct ? "DISTINCT " : string.Empty;
+            selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression($"COUNT ({distinctClause}{expression})")), columnAlias));
+            return this;
+        }
+        
         public IQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class
         {
             return new QueryBuilder<TNewRecord, TSelectBuilder>(selectBuilder, readQueryExecutor, tableAliasGenerator, uniqueParameterNameGenerator, ParameterValues, Parameters, ParameterDefaults);
@@ -197,6 +211,18 @@ namespace Nevermore.Advanced
         public ISelectBuilder GetSelectBuilder()
         {
             return selectBuilder.Clone();
+        }
+
+        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName)
+        {
+            selectBuilder.AddGroupBy(fieldName);
+            return this;
+        }
+
+        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
+        {
+            selectBuilder.AddGroupBy(fieldName, tableAlias);
+            return this;
         }
 
         public IOrderedQueryBuilder<TRecord> OrderBy(string fieldName)

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -199,13 +199,13 @@ namespace Nevermore.Advanced
             return selectBuilder.Clone();
         }
 
-        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName)
+        public IQueryBuilder<TRecord> GroupBy(string fieldName)
         {
             selectBuilder.AddGroupBy(fieldName);
             return this;
         }
 
-        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
+        public IQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
         {
             selectBuilder.AddGroupBy(fieldName, tableAlias);
             return this;

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -350,12 +350,12 @@ namespace Nevermore.Advanced
             return Final(Builder.WhereParameterized(fieldName, operand, parameterNames));
         }
 
-        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName)
+        public IQueryBuilder<TRecord> GroupBy(string fieldName)
         {
             return Final(Builder.GroupBy(fieldName));
         }
 
-        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
+        public IQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
         {
             return Final(Builder.GroupBy(fieldName, tableAlias));
         }

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -404,17 +404,6 @@ namespace Nevermore.Advanced
         {
             return Builder.CalculatedColumn(expression, columnAlias);
         }
-
-        public IQueryBuilder<TRecord> CountColumn(string columnAlias)
-        {
-            return Builder.CalculatedColumn("COUNT (*)", columnAlias);
-        }
-
-        public IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias)
-        {
-            var distinctClause = distinct ? "DISTINCT " : string.Empty;
-            return Builder.CalculatedColumn($"COUNT ({distinctClause}{expression})", columnAlias);
-        }
         
         public IQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class
         {

--- a/source/Nevermore/Advanced/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/SourceQueryBuilder.cs
@@ -350,6 +350,16 @@ namespace Nevermore.Advanced
             return Final(Builder.WhereParameterized(fieldName, operand, parameterNames));
         }
 
+        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName)
+        {
+            return Final(Builder.GroupBy(fieldName));
+        }
+
+        public IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias)
+        {
+            return Final(Builder.GroupBy(fieldName, tableAlias));
+        }
+
         public IOrderedQueryBuilder<TRecord> OrderBy(string fieldName)
         {
             return Final(Builder.OrderBy(fieldName));
@@ -395,6 +405,17 @@ namespace Nevermore.Advanced
             return Builder.CalculatedColumn(expression, columnAlias);
         }
 
+        public IQueryBuilder<TRecord> CountColumn(string columnAlias)
+        {
+            return Builder.CalculatedColumn("COUNT (*)", columnAlias);
+        }
+
+        public IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias)
+        {
+            var distinctClause = distinct ? "DISTINCT " : string.Empty;
+            return Builder.CalculatedColumn($"COUNT ({distinctClause}{expression})", columnAlias);
+        }
+        
         public IQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class
         {
             return Builder.AsType<TNewRecord>();

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -135,6 +135,21 @@ namespace Nevermore
         IQueryBuilder<TRecord> WhereNotNull(string fieldName);
 
         /// <summary>
+        /// Adds a group by clause to the query.  If this is used, then all selected should be included in the group by, or be a calculated column
+        /// </summary>
+        /// <param name="fieldName">The column that the query should be grouped by</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IOrderedQueryBuilder<TRecord> GroupBy(string fieldName);
+        
+        /// <summary>
+        /// Adds a group by clause to the query.  If this is used, then all selected should be included in the group by, or be a calculated column
+        /// </summary>
+        /// <param name="fieldName">The column that the query should be grouped by</param>
+        /// <param name="tableAlias">The alias for where the column exists</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias);
+
+        /// <summary>
         /// Adds an order by clause to the query, where the order by clause will be in the default order (ascending).
         /// If no order by clauses are added to the query, the query will be ordered by the Id column in ascending order.
         /// </summary>
@@ -212,6 +227,24 @@ namespace Nevermore
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         IQueryBuilder<TRecord> CalculatedColumn(string expression, string columnAlias);
 
+        /// <summary>
+        /// Adds a count() column to the column selection for the query.
+        /// In this version, the rows are counted. 
+        /// </summary>
+        /// <param name="columnAlias">The alias for the calculated column</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IQueryBuilder<TRecord> CountColumn(string columnAlias);
+        
+        /// <summary>
+        /// Adds a calculated column to the column selection for the query.
+        /// In this version, the optionally distinct non null expression values are counted. 
+        /// </summary>
+        /// <param name="expression">The expression that will be used in the SQL string for the count calculation</param>
+        /// <param name="distinct">Get the distinct count</param>
+        /// <param name="columnAlias">The alias for the calculated column</param>
+        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
+        IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias);
+        
         /// <summary>
         /// Change the type of the record returned by the QueryBuilder.
         /// This is useful if the initial type no longer matches the columns returned by the query.

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -226,24 +226,6 @@ namespace Nevermore
         /// <param name="columnAlias">The alias for the calculated column</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
         IQueryBuilder<TRecord> CalculatedColumn(string expression, string columnAlias);
-
-        /// <summary>
-        /// Adds a count() column to the column selection for the query.
-        /// In this version, the rows are counted. 
-        /// </summary>
-        /// <param name="columnAlias">The alias for the calculated column</param>
-        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        IQueryBuilder<TRecord> CountColumn(string columnAlias);
-        
-        /// <summary>
-        /// Adds a calculated column to the column selection for the query.
-        /// In this version, the optionally distinct non null expression values are counted. 
-        /// </summary>
-        /// <param name="expression">The expression that will be used in the SQL string for the count calculation</param>
-        /// <param name="distinct">Get the distinct count</param>
-        /// <param name="columnAlias">The alias for the calculated column</param>
-        /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        IQueryBuilder<TRecord> CountColumn(string expression, bool distinct, string columnAlias);
         
         /// <summary>
         /// Change the type of the record returned by the QueryBuilder.

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -139,7 +139,7 @@ namespace Nevermore
         /// </summary>
         /// <param name="fieldName">The column that the query should be grouped by</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        IOrderedQueryBuilder<TRecord> GroupBy(string fieldName);
+        IQueryBuilder<TRecord> GroupBy(string fieldName);
         
         /// <summary>
         /// Adds a group by clause to the query.  If this is used, then all selected should be included in the group by, or be a calculated column
@@ -147,7 +147,7 @@ namespace Nevermore
         /// <param name="fieldName">The column that the query should be grouped by</param>
         /// <param name="tableAlias">The alias for where the column exists</param>
         /// <returns>The query builder that can be used to further modify the query, or execute the query</returns>
-        IOrderedQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias);
+        IQueryBuilder<TRecord> GroupBy(string fieldName, string tableAlias);
 
         /// <summary>
         /// Adds an order by clause to the query, where the order by clause will be in the default order (ascending).

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -7,7 +7,12 @@ namespace Nevermore
     public interface ISelectBuilder
     {
         void AddTop(int top);
+
         void AddDistinct();
+        
+        void AddGroupBy(string fieldName);
+        void AddGroupBy(string fieldName, string tableAlias);
+        
         void AddOrder(string fieldName, bool descending);
         void AddOrder(string fieldName, string tableAlias, bool descending);
         void AddWhere(UnaryWhereParameter whereParams);

--- a/source/Nevermore/Querying/AST/GroupBy.cs
+++ b/source/Nevermore/Querying/AST/GroupBy.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nevermore.Querying.AST
+{
+    public class GroupBy
+    {
+        readonly IReadOnlyList<GroupByField> fields;
+
+        public GroupBy(IReadOnlyList<GroupByField> fields)
+        {
+            if (fields.Count < 1) throw new ArgumentException("Fields must have at least one value");
+            this.fields = fields;            
+        }
+        
+        public string GenerateSql()
+        {
+            return $"GROUP BY {string.Join(@", ", fields.Select(f => f.GenerateSql()))}";
+        }
+
+        public override string ToString() => GenerateSql();
+    }
+
+    public class GroupByField
+    {
+        readonly IColumn column;
+
+        public GroupByField(IColumn column)
+        {
+            this.column = column;
+        }
+
+        public string GenerateSql() => column.GenerateSql();
+
+        public override string ToString() => GenerateSql();
+    }
+}

--- a/source/Nevermore/Querying/AST/GroupBy.cs
+++ b/source/Nevermore/Querying/AST/GroupBy.cs
@@ -16,7 +16,8 @@ namespace Nevermore.Querying.AST
         
         public string GenerateSql()
         {
-            return $"GROUP BY {string.Join(@", ", fields.Select(f => f.GenerateSql()))}";
+            return @$"
+GROUP BY {string.Join(@", ", fields.Select(f => f.GenerateSql()))}";
         }
 
         public override string ToString() => GenerateSql();

--- a/source/Nevermore/Querying/AST/Select.cs
+++ b/source/Nevermore/Querying/AST/Select.cs
@@ -26,8 +26,7 @@
             var orderByString = orderBy != null ? $@"
 {orderBy.GenerateSql()}" : string.Empty;
             
-            var groupByString = groupBy != null ? $@"
-{groupBy.GenerateSql()}" : string.Empty;
+            var groupByString = groupBy?.GenerateSql();
             
             return $@"SELECT {rowSelection.GenerateSql()}{columns.GenerateSql()}
 FROM {from.GenerateSql()}{where.GenerateSql()}{groupByString}{orderByString}";

--- a/source/Nevermore/Querying/AST/Select.cs
+++ b/source/Nevermore/Querying/AST/Select.cs
@@ -7,14 +7,16 @@
         readonly ISelectSource from;
         readonly Where where;
         readonly OrderBy orderBy; // Can be null
+        readonly GroupBy groupBy; // Can be null
 
-        public Select(IRowSelection rowSelection, ISelectColumns columns, ISelectSource from, Where where, OrderBy orderBy)
+        public Select(IRowSelection rowSelection, ISelectColumns columns, ISelectSource from, Where where, GroupBy groupBy, OrderBy orderBy)
         {
             this.rowSelection = rowSelection;
             this.columns = columns;
             this.from = from;
             this.where = where;
             this.orderBy = orderBy;
+            this.groupBy = groupBy;
         }
 
         public string Schema => @from.Schema;
@@ -23,8 +25,12 @@
         {
             var orderByString = orderBy != null ? $@"
 {orderBy.GenerateSql()}" : string.Empty;
+            
+            var groupByString = groupBy != null ? $@"
+{groupBy.GenerateSql()}" : string.Empty;
+            
             return $@"SELECT {rowSelection.GenerateSql()}{columns.GenerateSql()}
-FROM {from.GenerateSql()}{where.GenerateSql()}{orderByString}";
+FROM {from.GenerateSql()}{where.GenerateSql()}{groupByString}{orderByString}";
         }
 
         public override string ToString()


### PR DESCRIPTION
Nevermore is based on a SQL database, but is missing some operations that can make queries simpler to write, and faster to run.
One missing feature is the GroupBy clause for obtaining aggregate information from the datastore.
While I was at it, I added a CountColumn helper method, which allows the (GroupBy) query to add a count column - mainly because the current Count() method expects that it finalises the query and is the only column returned (runs as scalar), whereas we want to include the count as one of the columns returned.

NOTE: Using GroupBy can easily result in queries that fall over, and at the moment there is no safeguard as to what columns are selected (eg, included in the group, or an aggregate), so be careful using it.