### PR TITLE
Ignore certain types of interpolation for purposes of SQL injection

### DIFF
--- a/source/Nevermore.Analyzers.Tests/CodeCompiler.cs
+++ b/source/Nevermore.Analyzers.Tests/CodeCompiler.cs
@@ -28,6 +28,12 @@ class Customer
     public string FirstName { get; set; }
     public string LastName { get; set; }
     public int? Age { get; set; }
+
+    public const string Constant = ""ConstantValue"";
+
+    public class Attributes {
+        public const string Constant = ""ConstantValue"";
+    }
 }
 
 class Program 

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.CodeAnalysis;
-using Microsoft.DotNet.PlatformAbstractions;
 using NUnit.Framework;
 
 namespace Nevermore.Analyzers.Tests
@@ -83,8 +77,9 @@ namespace Nevermore.Analyzers.Tests
         [TestCase("4.5")]
         [TestCase("4.5m")]
         [TestCase("true")]
-        [TestCase("Environment.SpecialFolder.Cookies")]
-        public void ShouldCompileIfInterpolatingAPrimitive(string value)
+        [TestCase("new DateTime(2021,1,1)")]
+        [TestCase("Environment.SpecialFolder.Cookies")] // A convenient built in enum we can use
+        public void ShouldCompileIfAInterpolatingAPrimitive(string value)
         {
 	        var code = $@"
 				var name = {value};

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
+using Microsoft.DotNet.PlatformAbstractions;
 using NUnit.Framework;
 
 namespace Nevermore.Analyzers.Tests
@@ -101,6 +102,16 @@ namespace Nevermore.Analyzers.Tests
 				transaction.Query<Customer>().Where($'Name = {name}').ToList();
 			";
 
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
+
+        [Test]
+        public void ShouldCompileIfInterpolatingAConstantFromAnotherType()
+        {
+	        var code = @"
+				transaction.Query<Customer>().Where($'Name = {Customer.Constant}').ToList();
+			";
 	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
 	        AssertPassed(results);
         }

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -83,6 +83,7 @@ namespace Nevermore.Analyzers.Tests
         [TestCase("4.5")]
         [TestCase("4.5m")]
         [TestCase("true")]
+        [TestCase("Environment.SpecialFolder.Cookies")]
         public void ShouldCompileIfAInterpolatingAPrimitive(string value)
         {
 	        var code = $@"
@@ -111,6 +112,16 @@ namespace Nevermore.Analyzers.Tests
         {
 	        var code = @"
 				transaction.Query<Customer>().Where($'Name = {Customer.Constant}').ToList();
+			";
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
+
+        [Test]
+        public void ShouldCompileIfInterpolatingAConstantFromANestedClass()
+        {
+	        var code = @"
+				transaction.Query<Customer>().Where($'Name = {Customer.Attributes.Constant}').ToList();
 			";
 	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
 	        AssertPassed(results);

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -84,7 +84,7 @@ namespace Nevermore.Analyzers.Tests
         [TestCase("4.5m")]
         [TestCase("true")]
         [TestCase("Environment.SpecialFolder.Cookies")]
-        public void ShouldCompileIfAInterpolatingAPrimitive(string value)
+        public void ShouldCompileIfInterpolatingAPrimitive(string value)
         {
 	        var code = $@"
 				var name = {value};

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -64,5 +64,33 @@ namespace Nevermore.Analyzers.Tests
 	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
 	        AssertPassed(results);
         }
+
+        [Test]
+        public void ShouldCompileIfInterpolatingANameOf()
+        {
+	        var code = @"
+				transaction.Query<Customer>().Where($'Name = {nameof(System)}').ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
+
+        [TestCase("1")]
+        [TestCase("(int?) 1")]
+        [TestCase("100000000L")]
+        [TestCase("4.5")]
+        [TestCase("4.5m")]
+        [TestCase("true")]
+        public void ShouldCompileIfAInterpolatingAPrimitive(string value)
+        {
+	        var code = $@"
+				var name = {value};
+				transaction.Query<Customer>().Where($'Name = ${{name}}').ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
     }
 }

--- a/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreSqlInjectionAnalyzerFixture.cs
@@ -92,5 +92,17 @@ namespace Nevermore.Analyzers.Tests
 	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
 	        AssertPassed(results);
         }
+
+        [Test]
+        public void ShouldCompileIfInterpolatingAConstant()
+        {
+	        var code = @"
+				const string name = 'Robert';
+				transaction.Query<Customer>().Where($'Name = {name}').ToList();
+			";
+
+	        var results = CodeCompiler.Compile<NevermoreSqlInjectionAnalyzer>(code);
+	        AssertPassed(results);
+        }
     }
 }

--- a/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
@@ -160,6 +160,9 @@ namespace Nevermore.Analyzers
             if (symbolType == null)
                 return false;
 
+            if (symbolType.EnumUnderlyingType != null)
+                return true;
+
             switch (symbolType.SpecialType)
             {
                 case SpecialType.System_Enum:

--- a/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
@@ -140,6 +140,16 @@ namespace Nevermore.Analyzers
 
                     return false;
                 }
+
+                // property
+                if (interpolationSyntax.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
+                {
+                    var symbol = context.SemanticModel.GetSymbolInfo(memberAccessExpressionSyntax).Symbol;
+                    if (symbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst)
+                        return true;
+
+                    return false;
+                }
             }
 
             return false;

--- a/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
@@ -28,29 +28,36 @@ namespace Nevermore.Analyzers
 
         void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
         {
-            compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(context =>
-            {
-                var ignoreThisBlock = false;
-
-                var errors = new List<Diagnostic>();
-
-                context.RegisterSyntaxNodeAction(invocationContext =>
+            compilationStartContext.RegisterCodeBlockStartAction<SyntaxKind>(
+                context =>
                 {
-                    var invocation = (InvocationExpressionSyntax)invocationContext.Node;
-                    ProcessInvocation(invocation, invocationContext, errors);
-                }, SyntaxKind.InvocationExpression);
+                    var ignoreThisBlock = false;
 
-                context.RegisterCodeBlockEndAction(c =>
-                {
-                    if (ignoreThisBlock)
-                        return;
+                    var errors = new List<Diagnostic>();
 
-                    foreach (var error in errors)
-                    {
-                        c.ReportDiagnostic(error);
-                    }
-                });
-            });
+                    context.RegisterSyntaxNodeAction(
+                        invocationContext =>
+                        {
+                            var invocation = (InvocationExpressionSyntax) invocationContext.Node;
+                            ProcessInvocation(invocation, invocationContext, errors);
+                        },
+                        SyntaxKind.InvocationExpression
+                    );
+
+                    context.RegisterCodeBlockEndAction(
+                        c =>
+                        {
+                            if (ignoreThisBlock)
+                                return;
+
+                            foreach (var error in errors)
+                            {
+                                c.ReportDiagnostic(error);
+                            }
+                        }
+                    );
+                }
+            );
         }
 
         void ProcessInvocation(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext context, List<Diagnostic> errors)
@@ -59,7 +66,7 @@ namespace Nevermore.Analyzers
             if (symbolInfo.Symbol?.Kind != SymbolKind.Method)
                 return;
 
-            var methodSymbol = (IMethodSymbol)symbolInfo.Symbol;
+            var methodSymbol = (IMethodSymbol) symbolInfo.Symbol;
 
             if (!methodsWeCareAbout.Contains(methodSymbol.Name))
                 return;
@@ -67,7 +74,7 @@ namespace Nevermore.Analyzers
             if (methodSymbol.ContainingType == null)
                 return;
 
-            if (!(methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore") || methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Querying")  || methodSymbol.ContainingType.Name.StartsWith("IQueryBuilder") || methodSymbol.ContainingType.Name == "QueryBuilderWhereExtensions" || methodSymbol.ContainingType.Name == "DeleteQueryBuilderExtensions"))
+            if (!(methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore") || methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Querying") || methodSymbol.ContainingType.Name.StartsWith("IQueryBuilder") || methodSymbol.ContainingType.Name == "QueryBuilderWhereExtensions" || methodSymbol.ContainingType.Name == "DeleteQueryBuilderExtensions"))
                 return;
 
             if (methodSymbol.Name == null)
@@ -76,14 +83,14 @@ namespace Nevermore.Analyzers
             if (invocation.ArgumentList.Arguments.Count < 1)
                 return;
 
-            var location = CheckForSqlInjection(invocation.ArgumentList.Arguments[0].Expression, context.SemanticModel);
+            var location = CheckForSqlInjection(context, invocation.ArgumentList.Arguments[0].Expression, context.SemanticModel);
             if (location != Location.None)
             {
                 errors.Add(Diagnostic.Create(Descriptors.NV0007NevermoreSqlInjectionError, location, "This expression uses string concatenation, which creates a risk of a SQL Injection vulnerability. Pass parameters or arguments instead. If you're absolutely sure it's safe, use '#pragma warning disable NV0007' plus a comment explaining why."));
             }
         }
 
-        static Location CheckForSqlInjection(ExpressionSyntax expression, SemanticModel model)
+        static Location CheckForSqlInjection(SyntaxNodeAnalysisContext context, ExpressionSyntax expression, SemanticModel model)
         {
             if (expression is BinaryExpressionSyntax binaryExpressionSyntax)
             {
@@ -95,13 +102,85 @@ namespace Nevermore.Analyzers
 
             if (expression is InterpolatedStringExpressionSyntax interpolatedStringExpressionSyntax)
             {
+                if (interpolatedStringExpressionSyntax.Contents.All(c => IsStringLiteralOrNameOf(context, c)))
+                    return Location.None;
                 return expression.GetLocation();
             }
 
             return Location.None;
         }
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptors.NV0007NevermoreSqlInjectionError);
+        static bool IsStringLiteralOrNameOf(SyntaxNodeAnalysisContext context, InterpolatedStringContentSyntax content)
+        {
+            // The string being interpolated into
+            if (content is InterpolatedStringTextSyntax)
+                return true;
 
+
+            if (content is InterpolationSyntax interpolationSyntax)
+            {
+                // nameof() invocation
+                if (interpolationSyntax.Expression is InvocationExpressionSyntax invocation)
+                    return invocation.Expression is IdentifierNameSyntax invocationIdentifier &&
+                           invocationIdentifier.Identifier.Text == "nameof";
+
+                // variable
+                if (interpolationSyntax.Expression is IdentifierNameSyntax identifierNameSyntax)
+                {
+                    var symbol = context.SemanticModel.GetSymbolInfo(identifierNameSyntax);
+                    var symbolType = GetSymbolType(symbol);
+                    if (IsTypeThatIsOkToConcatenate(symbolType))
+                        return true;
+
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsTypeThatIsOkToConcatenate(INamedTypeSymbol symbolType)
+        {
+            if (symbolType == null)
+                return false;
+
+            switch (symbolType.SpecialType)
+            {
+                case SpecialType.System_Enum:
+                case SpecialType.System_Boolean:
+                case SpecialType.System_Char:
+                case SpecialType.System_SByte:
+                case SpecialType.System_Byte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Decimal:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                case SpecialType.System_DateTime:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        static INamedTypeSymbol GetSymbolType(SymbolInfo symbol)
+        {
+            var type = (symbol.Symbol as ILocalSymbol)?.Type as INamedTypeSymbol;
+            if (type == null)
+                return null;
+
+            if (type.SpecialType == SpecialType.System_Nullable_T ||
+                type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+                return type.TypeArguments[0] as INamedTypeSymbol;
+
+            return type;
+        }
+
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptors.NV0007NevermoreSqlInjectionError);
     }
 }

--- a/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreSqlInjectionAnalyzer.cs
@@ -1,13 +1,6 @@
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.SymbolStore;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/source/Nevermore.Benchmarks/SetUp/IntegrationTestDatabase.cs
+++ b/source/Nevermore.Benchmarks/SetUp/IntegrationTestDatabase.cs
@@ -9,7 +9,7 @@ namespace Nevermore.Benchmarks.SetUp
 
         public IntegrationTestDatabase()
         {
-            var sqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "(local)\\SQLEXPRESS,1433";
+            var sqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "localhost";
             var username = Environment.GetEnvironmentVariable("NevermoreTestUsername");
             var password = Environment.GetEnvironmentVariable("NevermoreTestPassword");
             testDatabaseName = Environment.GetEnvironmentVariable("NevermoreBenchmarkDatabase") ?? "Nevermore-Benchmarks";
@@ -30,7 +30,7 @@ namespace Nevermore.Benchmarks.SetUp
 
             InstallSchema();
         }
-        
+
         public string ConnectionString { get; }
 
         void DropDatabase()
@@ -46,7 +46,7 @@ namespace Nevermore.Benchmarks.SetUp
                 Console.WriteLine("Could not drop the existing database: " + ex);
             }
         }
-        
+
         void CreateDatabase()
         {
             ExecuteScript(@"create database [" + testDatabaseName + "] COLLATE SQL_Latin1_General_CP1_CS_AS", GetMaster());

--- a/source/Nevermore.IntegrationTests/SetUp/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/IntegrationTestDatabase.cs
@@ -10,7 +10,7 @@ namespace Nevermore.IntegrationTests.SetUp
 
         public IntegrationTestDatabase()
         {
-            var sqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "(local)\\SQLEXPRESS,1433";
+            var sqlInstance = Environment.GetEnvironmentVariable("NevermoreTestServer") ?? "(local)";
             var username = Environment.GetEnvironmentVariable("NevermoreTestUsername");
             var password = Environment.GetEnvironmentVariable("NevermoreTestPassword");
             testDatabaseName = Environment.GetEnvironmentVariable("NevermoreTestDatabase") ?? "Nevermore-IntegrationTests";
@@ -31,7 +31,7 @@ namespace Nevermore.IntegrationTests.SetUp
 
             InstallSchema();
         }
-        
+
         public string ConnectionString { get; }
 
         void DropDatabase()
@@ -47,7 +47,7 @@ namespace Nevermore.IntegrationTests.SetUp
                 Console.WriteLine("Could not drop the existing database: " + ex.GetErrorSummary());
             }
         }
-        
+
         void CreateDatabase()
         {
             ExecuteScript(@"create database [" + testDatabaseName + "] COLLATE SQL_Latin1_General_CP1_CS_AS", GetMaster());


### PR DESCRIPTION
This will ignore `nameof`, numbers and constants. They are very unlikely to represent SQLi vectors.