### PR TITLE
Don't require key type for DELETE if you already have the document (similar to UPDATE)

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/HooksFixture.cs
@@ -28,7 +28,7 @@ namespace Nevermore.IntegrationTests.Advanced
             transaction.Update(customer);
             AssertLogged(log, "BeforeUpdate", "AfterUpdate");
 
-            transaction.Delete<Customer, CustomerId>(customer);
+            transaction.Delete(customer);
             AssertLogged(log, "BeforeDelete", "AfterDelete");
 
             transaction.Commit();

--- a/source/Nevermore.IntegrationTests/Advanced/NoJsonFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/NoJsonFixture.cs
@@ -52,7 +52,7 @@ namespace Nevermore.IntegrationTests.Advanced
 
             transaction.Query<Car>().Count().Should().Be(1);
 
-            transaction.Delete<Car, string>(car);
+            transaction.Delete(car);
 
             transaction.Query<Car>().Count().Should().Be(0);
 

--- a/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelatedDocumentTableFixture.cs
@@ -108,7 +108,7 @@ namespace Nevermore.IntegrationTests
             var order = new Order() {Id = orderId};
             using (var trn = Store.BeginTransaction())
             {
-                trn.Delete<Order, string>(order);
+                trn.Delete(order);
                 trn.Commit();
             }
         }

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/DeleteFixture.cs
@@ -16,7 +16,7 @@ namespace Nevermore.IntegrationTests.RelationalTransaction
             using (var trn = Store.BeginTransaction())
             {
                 var product = trn.Load<Product>(id);
-                trn.Delete<Product, string>(product);
+                trn.Delete(product);
                 trn.Commit();
             }
 

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -146,13 +146,18 @@ namespace Nevermore.Advanced
         public void Delete<TDocument>(Guid id, DeleteOptions options = null) where TDocument : class
             => Delete<TDocument, Guid>(id, options);
 
-        public void Delete<TDocument, TKey>(TDocument document, DeleteOptions options = null) where TDocument : class
+        public void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class
         {
-            var id = (TKey)configuration.DocumentMaps.GetId(document);
-            Delete<TDocument, TKey>(id, options);
+            var id = configuration.DocumentMaps.GetId(document);
+            DeleteInternal<TDocument>(id, options);
         }
 
         public void Delete<TDocument, TKey>(TKey id, DeleteOptions options = null) where TDocument : class
+        {
+            DeleteInternal<TDocument>(id, options);
+        }
+
+        void DeleteInternal<TDocument>(object id, DeleteOptions options) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             configuration.Hooks.BeforeDelete<TDocument>(id, command.Mapping, this);
@@ -172,8 +177,8 @@ namespace Nevermore.Advanced
         public Task DeleteAsync<TDocument>(Guid id, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument>(id, null, cancellationToken);
 
-        public Task DeleteAsync<TDocument, TKey>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class
-            => DeleteAsync<TDocument, TKey>(document, null, cancellationToken);
+        public Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class
+            => DeleteAsyncInternal<TDocument>(document, null, cancellationToken);
 
         public Task DeleteAsync<TDocument>(string id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument, string>(id, options, cancellationToken);
@@ -187,16 +192,21 @@ namespace Nevermore.Advanced
         public Task DeleteAsync<TDocument>(Guid id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument, Guid>(id, options, cancellationToken);
 
-        public Task DeleteAsync<TDocument, TKey>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        public Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var id = (TKey)configuration.DocumentMaps.GetId(document);
-            return DeleteAsync<TDocument, TKey>(id, options, cancellationToken);
+            var id = configuration.DocumentMaps.GetId(document);
+            return DeleteAsyncInternal<TDocument>(id, options, cancellationToken);
         }
 
         public Task DeleteAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
             => DeleteAsync<TDocument, TKey>(id, null, cancellationToken);
 
         public async Task DeleteAsync<TDocument, TKey>(TKey id, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class
+        {
+            await DeleteAsyncInternal<TDocument>(id, options, cancellationToken);
+        }
+
+        async Task DeleteAsyncInternal<TDocument>(object id, DeleteOptions options, CancellationToken cancellationToken) where TDocument : class
         {
             var command = builder.PrepareDelete<TDocument>(id, options);
             await configuration.Hooks.BeforeDeleteAsync<TDocument>(id, command.Mapping, this);

--- a/source/Nevermore/IWriteQueryExecutor.cs
+++ b/source/Nevermore/IWriteQueryExecutor.cs
@@ -137,10 +137,9 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
-        void Delete<TDocument, TKey>(TDocument document, DeleteOptions options = null) where TDocument : class;
+        void Delete<TDocument>(TDocument document, DeleteOptions options = null) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -187,10 +186,9 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument, TKey>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Deletes an existing document from the database by its ID.
@@ -242,11 +240,10 @@ namespace Nevermore
         /// Deletes an existing document from the database.
         /// </summary>
         /// <typeparam name="TDocument">The type of document being deleted.</typeparam>
-        /// <typeparam name="TKey">The document's key type</typeparam>
         /// <param name="document">The document to delete.</param>
         /// <param name="options">Advanced options for the delete operation.</param>
         /// <param name="cancellationToken">Token to use to cancel the command.</param>
-        Task DeleteAsync<TDocument, TKey>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
+        Task DeleteAsync<TDocument>(TDocument document, DeleteOptions options, CancellationToken cancellationToken = default) where TDocument : class;
 
         /// <summary>
         /// Creates a deletion query for a strongly typed document.


### PR DESCRIPTION
This is reverting the signature change for requiring the key type on DELETE from https://github.com/OctopusDeploy/Nevermore/pull/149/files#diff-95a0a8cc5b6199fbc1e65c196e85c81d920a9d2a6112c86fc00a7598715f12cf

This makes it easier to call DELETE ([Slack conversation](https://octopusdeploy.slack.com/archives/C020HNMNT3L/p1626060225075400))

**Bumps major version**
`+semver:major`