### PR TITLE
Updated the primitive reader strategy so it will use custom TypeHandlers

### DIFF
--- a/source/Nevermore/Advanced/ReaderStrategies/Primitives/PrimitiveReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/Primitives/PrimitiveReaderStrategy.cs
@@ -13,7 +13,7 @@ namespace Nevermore.Advanced.ReaderStrategies.Primitives
         {
             this.configuration = configuration;
         }
-        
+
         public bool CanRead(Type type)
         {
             return
@@ -23,7 +23,8 @@ namespace Nevermore.Advanced.ReaderStrategies.Primitives
                 || type.IsPrimitive
                 || type.IsValueType
                 || type.IsEnum
-                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                || configuration.TypeHandlers.Resolve(type) != null;
         }
 
         public Func<PreparedCommand, Func<DbDataReader, (TRecord, bool)>> CreateReader<TRecord>()
@@ -53,7 +54,7 @@ namespace Nevermore.Advanced.ReaderStrategies.Primitives
                     {
                         throw new ReaderException(rowNumber, 0, compiled.ExpressionSource, ex);
                     }
-                }; 
+                };
             };
         }
     }


### PR DESCRIPTION
This fixes a bug where `.Stream<CustomerId>` threw an exception about not being able to find a reader strategy.

This bug had surfaced in Octopus server, when doing a query along the lines of `.Stream<DeploymentId>("SELECT....")`

Apologies for the wall of whitespace changes that ended up in the files. The crux of the change is in `PrimitiveReaderStrategy`, and there is a new test to prove it now works, in `Examples.cs`