### PR TITLE
Fix type name in concurrency error message

### DIFF
--- a/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersion.cs
+++ b/source/Nevermore.IntegrationTests/Model/DocumentWithIdentityIdAndRowVersion.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nevermore.IntegrationTests.Model
 {
-    public class DocumentWithIdentityIdAndRowVersion
+    public class DocumentWithIdentityIdAndRowVersion : IId
     {
         public int Id { get; set; }
         public string Name { get; set; }

--- a/source/Nevermore.IntegrationTests/Model/IId.cs
+++ b/source/Nevermore.IntegrationTests/Model/IId.cs
@@ -1,0 +1,7 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public interface IId
+    {
+        int Id { get; }
+    }
+}

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -334,7 +334,7 @@ namespace Nevermore.Advanced
             if (!mapping.IsRowVersioningEnabled) return;
 
             if (output?.RowVersion == null)
-                throw new StaleDataException($"Modification failed for '{typeof(TDocument).Name}' document with '{mapping.GetId(document)}' Id because submitted data was out of date. Refresh the document and try again.");
+                throw new StaleDataException($"Modification failed for '{mapping.Type.Name}' document with '{mapping.GetId(document)}' Id because submitted data was out of date. Refresh the document and try again.");
 
             mapping.RowVersionColumn!.PropertyHandler.Write(document, output.RowVersion);
         }


### PR DESCRIPTION
# Background

The error message produced in the case of a concurrency issue includes the name of the document type involved. This name is determined by using the generic type argument passed through to the `Update()` method. This type is not necessarily going to match the actual type of the document - it might be an interface implemented by the document, for example.

# Result

Take the document type name from the type stored on the mapping instead. This will be the actual type of the document.

## Before

```
Modification failed for 'IId`1' document with '1' Id because submitted data was out of date. Refresh the document and try again.
```

## After

```
Modification failed for 'Channel' document with '1' Id because submitted data was out of date. Refresh the document and try again.
```