### PR TITLE
Bug: pass transaction names through to SQL Server

### DIFF
--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -29,7 +29,7 @@ namespace Nevermore.Advanced
         readonly ITableAliasGenerator tableAliasGenerator = new TableAliasGenerator();
         readonly string? name;
 
-        DbConnection? connection;
+        SqlConnection? connection;
 
         protected IUniqueParameterNameGenerator ParameterNameGenerator { get; } = new UniqueParameterNameGenerator();
 
@@ -72,13 +72,16 @@ namespace Nevermore.Advanced
         public void Open(IsolationLevel isolationLevel)
         {
             Open();
-            Transaction = connection!.BeginTransaction(isolationLevel);
+            Transaction = connection.BeginTransaction(isolationLevel, name);
         }
 
         public async Task OpenAsync(IsolationLevel isolationLevel)
         {
             await OpenAsync();
-            Transaction = await connection!.BeginTransactionAsync(isolationLevel);
+
+            // We use the synchronous overload here even though there is an async one, because the BeginTransactionAsync calls
+            // the synchronous version anyway, and the async overload doesn't accept a name parameter.
+            Transaction = connection.BeginTransaction(isolationLevel, name);
         }
 
         [Pure]

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -72,7 +72,7 @@ namespace Nevermore.Advanced
         public void Open(IsolationLevel isolationLevel)
         {
             Open();
-            Transaction = connection.BeginTransaction(isolationLevel, name);
+            Transaction = connection.BeginTransaction(isolationLevel, name.Substring(0, Math.Min(name.Length, 32)));
         }
 
         public async Task OpenAsync(IsolationLevel isolationLevel)
@@ -81,7 +81,7 @@ namespace Nevermore.Advanced
 
             // We use the synchronous overload here even though there is an async one, because the BeginTransactionAsync calls
             // the synchronous version anyway, and the async overload doesn't accept a name parameter.
-            Transaction = connection.BeginTransaction(isolationLevel, name);
+            Transaction = connection.BeginTransaction(isolationLevel, name.Substring(0, Math.Min(name.Length, 32)));
         }
 
         [Pure]


### PR DESCRIPTION
Transaction name parameters are accepted by Nevermore but not propagated to SQL Server.

By the time an application becomes unresponsive it's very difficult to get a list of transactions from Nevermore, so we have to know to do it in advance.

With this change, we can just issue a `select * from sys.dm_tran_active_transactions` directly against SQL Server even if the application itself is unresponsive.