### PR TITLE
Transaction name tests

### DIFF
--- a/source/Nevermore.IntegrationTests/Model/Transaction.cs
+++ b/source/Nevermore.IntegrationTests/Model/Transaction.cs
@@ -1,0 +1,8 @@
+﻿namespace Nevermore.IntegrationTests.Model
+{
+    public class Transaction
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
Do not merge.

---

I couldn't make the read transaction name work.

* `BeginTransaction` works
* `BeginWriteTransaction` works
* `BeginReadTransaction` does not work

I noticed that `BeginReadTransaction` does not hold an open transaction on SQL Server. I am not sure if this is by design. In SQL Profiler, I could not see any `BEGIN TRANSACTION` for `BeginReadTransaction` either but it works for those other 2 methods.

**BeginReadTransaction:**

![image](https://user-images.githubusercontent.com/3007213/130895629-28112d75-872d-4f4d-b5a9-fe56a4c791de.png)

---

**BeginWriteTransaction:**

![image](https://user-images.githubusercontent.com/3007213/130895923-5a55a693-3c33-4d89-9d80-b0a191ea1b16.png)

See the queries below.

```
select * from sys.dm_tran_active_transactions

SELECT * FROM sys.sysprocesses
WHERE [program_name] LIKE '%Nevermore%'
	-- open_tran = 1
```