### PR TITLE
Fix a bug around unique parameter reuse

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/QueryReuseFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/QueryReuseFixture.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class QueryReuseFixture: FixtureWithRelationalStore
+    {
+        [Test]
+        public async Task UseSubqueryToShareQuery()
+        {
+            using var readTran = await Store.BeginReadTransactionAsync();
+
+            var customers1Query = readTran.Query<Customer>().Where(c => c.FirstName == "Tom");
+
+            if (await customers1Query.Subquery().Where(c => c.LastName == "Jones").AnyAsync())
+                throw new InvalidOperationException("Bad stuffs bad");
+
+            var customers  = await customers1Query.Where(c => c.FirstName != "Thomas").ToListAsync();
+
+            customers.Should().NotBeNull();
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -106,7 +106,6 @@ namespace Nevermore.IntegrationTests
         [Test]
         public void ShouldHandleLoadManyWithCustomKeyType()
         {
-            CustomerId customerId;
             var ids = new List<CustomerId>();
             using (var transaction = Store.BeginTransaction())
             {

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -216,7 +216,7 @@ namespace Nevermore.Advanced
 
         public IDeleteQueryBuilder<TDocument> DeleteQuery<TDocument>() where TDocument : class
         {
-            return new DeleteQueryBuilder<TDocument>(ParameterNameGenerator, builder, this);
+            return new DeleteQueryBuilder<TDocument>(ParameterNameGeneratorFactory(), builder, this);
         }
 
         public TKey AllocateId<TKey>(Type documentType)


### PR DESCRIPTION
There is a bug that occurs around parameter names when you re-use a query (via sub-query). This is a kinda esoteric bug and requires you to be re-adding the same where parameter on a query twice, however I did run into this issue when I was passing a base query to another method for re-use.

The error occurs as the `UniqueParameterNameGenerator` is unique per-transaction, not per-query. Also, if execute a query, a result of that is it removes the parameters from the unique name generator (after execution), which means if there are other queries using that parameter name, re-adding the parameter again causes a dictionary duplicate key exception.

The solution is to make the unique parameter name generator per-query, rather than per-transaction.

I did this by changing the transaction to have a builder func, rather than a single instance. Thus each QueryBuilder receives it's own instance of this `IUniqueParameterNameGenerator`, meaning each query (and subquery) maintains it's own list of unique parameter names.