### PR TITLE
Async Support on IRelatedDocumentStore

### DIFF
--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -62,7 +62,7 @@ namespace Nevermore.Advanced
             ApplyIdentityIdsIfRequired(document, command.Mapping, output);
 
             await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
-            configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
+            await configuration.RelatedDocumentStore.PopulateRelatedDocumentsAsync(this, document, cancellationToken);
         }
 
         public void InsertMany<TDocument>(IReadOnlyCollection<TDocument> documents, InsertOptions options = null) where TDocument : class
@@ -103,7 +103,7 @@ namespace Nevermore.Advanced
             foreach (var document in documentList)
                 await configuration.Hooks.AfterInsertAsync(document, command.Mapping, this);
 
-            configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, documentList);
+            await configuration.RelatedDocumentStore.PopulateManyRelatedDocumentsAsync(this, documentList, cancellationToken);
         }
 
         public void Update<TDocument>(TDocument document, UpdateOptions options = null) where TDocument : class
@@ -132,7 +132,7 @@ namespace Nevermore.Advanced
             ApplyNewRowVersionIfRequired(document, command.Mapping, output);
 
             await configuration.Hooks.AfterUpdateAsync(document, command.Mapping, this);
-            configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, document);
+            await configuration.RelatedDocumentStore.PopulateRelatedDocumentsAsync(this, document, cancellationToken);
         }
 
         public void Delete<TDocument>(string id, DeleteOptions options = null) where TDocument : class

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -78,7 +78,7 @@ namespace Nevermore.Advanced
             ApplyIdentityIdsIfRequired(documentList, command.Mapping, outputs);
 
             foreach (var document in documentList) configuration.Hooks.AfterInsert(document, command.Mapping, this);
-            configuration.RelatedDocumentStore.PopulateRelatedDocuments(this, documentList);
+            configuration.RelatedDocumentStore.PopulateManyRelatedDocuments(this, documentList);
         }
 
         public Task InsertManyAsync<TDocument>(IReadOnlyCollection<TDocument> documents, CancellationToken cancellationToken = default) where TDocument : class

--- a/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nevermore.RelatedDocuments
 {
@@ -10,6 +12,16 @@ namespace Nevermore.RelatedDocuments
 
         public void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class
         {
+        }
+
+        public Task PopulateRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
@@ -19,7 +19,7 @@ namespace Nevermore.RelatedDocuments
             return Task.CompletedTask;
         }
 
-        public Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class
+        public Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance, CancellationToken cancellationToken = default) where TDocument : class
         {
             return Task.CompletedTask;
         }

--- a/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/EmptyRelatedDocumentStore.cs
@@ -8,7 +8,7 @@ namespace Nevermore.RelatedDocuments
         {
         }
 
-        public void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class
+        public void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class
         {
         }
     }

--- a/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
@@ -7,8 +7,8 @@ namespace Nevermore.RelatedDocuments
     public interface IRelatedDocumentStore
     {
         void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, TDocument instance) where TDocument : class;
-        void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class;
+        void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instances) where TDocument : class;
         Task PopulateRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
-        Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance, CancellationToken cancellationToken = default) where TDocument : class;
+        Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instances, CancellationToken cancellationToken = default) where TDocument : class;
     }
 }

--- a/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
@@ -5,6 +5,6 @@ namespace Nevermore.RelatedDocuments
     public interface IRelatedDocumentStore
     {
         void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, TDocument instance) where TDocument : class;
-        void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class;
+        void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class;
     }
 }

--- a/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nevermore.RelatedDocuments
 {
@@ -6,5 +8,7 @@ namespace Nevermore.RelatedDocuments
     {
         void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, TDocument instance) where TDocument : class;
         void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class;
+        Task PopulateRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
+        Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
     }
 }

--- a/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
+++ b/source/Nevermore/RelatedDocuments/IRelatedDocumentStore.cs
@@ -9,6 +9,6 @@ namespace Nevermore.RelatedDocuments
         void PopulateRelatedDocuments<TDocument>(IWriteTransaction transaction, TDocument instance) where TDocument : class;
         void PopulateManyRelatedDocuments<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance) where TDocument : class;
         Task PopulateRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
-        Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, TDocument instance, CancellationToken cancellationToken = default) where TDocument : class;
+        Task PopulateManyRelatedDocumentsAsync<TDocument>(IWriteTransaction transaction, IEnumerable<TDocument> instance, CancellationToken cancellationToken = default) where TDocument : class;
     }
 }


### PR DESCRIPTION
## Background

Currently the `IRelatedDocumentStore` only has synchronous methods. These methods are called from the async methods on `IWriteQueryExecutor`, meaning they're likely to block threads.

This PR introduces async versions of these methods to avoid the blocking.

It also corrects an ambiguity problem in the `IRelatedDocumentStore` interface.

This is a breaking change to the interface, so will require a major bump.