### PR TITLE
Add support for JSON_VALUE queries

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -60,5 +60,27 @@ namespace Nevermore.IntegrationTests
                 customersNotNull.Select(c => c.FirstName).Should().BeEquivalentTo("Bob", "Charlie");
             }
         }
+
+        [Test]
+        public void WhereJsonValueClause()
+        {
+            using (var t = Store.BeginTransaction())
+            {
+                foreach (var c in new []
+                         {
+                             new Product {Name = "Product 1", Price = 100},
+                             new Product {Name = "Product 2", Price = 200},
+                             new Product {Name = "Product 3", Price = 300},
+                         })
+                    t.Insert(c);
+                t.Commit();
+                
+                var products = t.Query<Product>()
+                    .Where(c => c.Price == 100)
+                    .ToList();
+
+                products.Select(c => c.Name).Should().BeEquivalentTo("Product 1");
+            }
+        }
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
@@ -7,14 +7,14 @@ namespace Nevermore.Advanced.SelectBuilders
 {
     public class TableSelectBuilder : SelectBuilderBase<ITableSource>
     {
-        public TableSelectBuilder(ITableSource from, IColumn idColumn) 
+        public TableSelectBuilder(ITableSource from, IColumn idColumn)
             : this(from, idColumn, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>())
         {
         }
 
         TableSelectBuilder(ITableSource from, IColumn idColumn,
             List<IWhereClause> whereClauses, List<GroupByField> groupByClauses,
-            List<OrderByField> orderByClauses, ISelectColumns columnSelection = null, 
+            List<OrderByField> orderByClauses, ISelectColumns columnSelection = null,
             IRowSelection rowSelection = null)
             : base(whereClauses, groupByClauses, orderByClauses, columnSelection, rowSelection)
         {
@@ -40,50 +40,53 @@ namespace Nevermore.Advanced.SelectBuilders
 
         public override void AddWhere(UnaryWhereParameter whereParams)
         {
-            if (From.ColumnNames.Contains(whereParams.FieldName))
+            if (ShouldReadFromJsonColumn(whereParams.FieldName))
             {
-                base.AddWhere(whereParams);
+                WhereClauses.Add(new UnaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterName));
             }
             else
             {
-                WhereClauses.Add(new UnaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterName));
+                base.AddWhere(whereParams);
             }
         }
 
         public override void AddWhere(BinaryWhereParameter whereParams)
-         {
-             if (From.ColumnNames.Contains(whereParams.FieldName))
-             {
-                 base.AddWhere(whereParams);
-             }
-             else
-             {
-                 WhereClauses.Add(new BinaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.FirstParameterName, whereParams.SecondParameterName));
-             }
-         }
- 
-         public override void AddWhere(ArrayWhereParameter whereParams)
-         {
-             if (From.ColumnNames.Contains(whereParams.FieldName))
-             {
-                 base.AddWhere(whereParams);
-             }
-             else
-             {
-                 WhereClauses.Add(new ArrayWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterNames));
-             }
-         }
- 
-         public override void AddWhere(IsNullWhereParameter whereParams)
-         {
-             if (From.ColumnNames.Contains(whereParams.FieldName))
-             {
-                 base.AddWhere(whereParams);
-             }
-             else
-             {
-                 WhereClauses.Add(new IsNullClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Not));
-             }
-         }
+        {
+            if (ShouldReadFromJsonColumn(whereParams.FieldName))
+            {
+                WhereClauses.Add(new BinaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.FirstParameterName, whereParams.SecondParameterName));
+            }
+            else
+            {
+                base.AddWhere(whereParams);
+            }
+        }
+
+        public override void AddWhere(ArrayWhereParameter whereParams)
+        {
+            if (ShouldReadFromJsonColumn(whereParams.FieldName))
+            {
+                WhereClauses.Add(new ArrayWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterNames));
+            }
+            else
+            {
+                base.AddWhere(whereParams);
+            }
+        }
+
+        public override void AddWhere(IsNullWhereParameter whereParams)
+        {
+            if (ShouldReadFromJsonColumn(whereParams.FieldName))
+            {
+                WhereClauses.Add(new IsNullClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Not));
+            }
+            else
+            {
+                base.AddWhere(whereParams);
+            }
+        }
+
+        bool ShouldReadFromJsonColumn(string fieldName)
+            => From.ColumnNames.Contains("JSON") && !From.ColumnNames.Contains(fieldName);
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
@@ -49,5 +49,41 @@ namespace Nevermore.Advanced.SelectBuilders
                 WhereClauses.Add(new UnaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterName));
             }
         }
+
+        public override void AddWhere(BinaryWhereParameter whereParams)
+         {
+             if (From.ColumnNames.Contains(whereParams.FieldName))
+             {
+                 base.AddWhere(whereParams);
+             }
+             else
+             {
+                 WhereClauses.Add(new BinaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.FirstParameterName, whereParams.SecondParameterName));
+             }
+         }
+ 
+         public override void AddWhere(ArrayWhereParameter whereParams)
+         {
+             if (From.ColumnNames.Contains(whereParams.FieldName))
+             {
+                 base.AddWhere(whereParams);
+             }
+             else
+             {
+                 WhereClauses.Add(new ArrayWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterNames));
+             }
+         }
+ 
+         public override void AddWhere(IsNullWhereParameter whereParams)
+         {
+             if (From.ColumnNames.Contains(whereParams.FieldName))
+             {
+                 base.AddWhere(whereParams);
+             }
+             else
+             {
+                 WhereClauses.Add(new IsNullClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Not));
+             }
+         }
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using Nevermore.Querying;
 using Nevermore.Querying.AST;
 
 namespace Nevermore.Advanced.SelectBuilders
@@ -34,6 +36,18 @@ namespace Nevermore.Advanced.SelectBuilders
         public override ISelectBuilder Clone()
         {
             return new TableSelectBuilder(From, IdColumn, new List<IWhereClause>(WhereClauses), new List<GroupByField>(GroupByClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+        }
+
+        public override void AddWhere(UnaryWhereParameter whereParams)
+        {
+            if (From.ColumnNames.Contains(whereParams.FieldName))
+            {
+                base.AddWhere(whereParams);
+            }
+            else
+            {
+                WhereClauses.Add(new UnaryWhereClause(new JsonValueFieldReference(whereParams.FieldName), whereParams.Operand, whereParams.ParameterName));
+            }
         }
     }
 }

--- a/source/Nevermore/Querying/AST/IWhereFieldReference.cs
+++ b/source/Nevermore/Querying/AST/IWhereFieldReference.cs
@@ -30,4 +30,16 @@
 
         public string GenerateSql() => $"{tableAlias}.{fieldReference.GenerateSql()}";
     }
+
+    public class JsonValueFieldReference : IWhereFieldReference
+    {
+        readonly string fieldName;
+
+        public JsonValueFieldReference(string fieldName)
+        {
+            this.fieldName = fieldName;
+        }
+
+        public string GenerateSql() => $"JSON_VALUE([JSON], '$.{fieldName}')";
+    }
 }


### PR DESCRIPTION
Not all properties on a document need be mapped as columns, e.g. for `Product`:

```csharp
public class Product
{
    public string Id { get; set; }
    public string Name { get; set; }
    public decimal Price { get; set; }

    public ProductType Type { get; set; } = ProductType.Normal;
}
```

The nevermore mapping could be:

```csharp
public class ProductMap : DocumentMap<Product>
{
    public ProductMap()
    {
        Column(m => m.Name);
        TypeResolutionColumn(m => m.Type);
    }
}
```

This means that currently, if we try and query by anything other than `Name` or `Type` e.g:

```csharp
var products = t.Query<Product>()
    .Where(c => c.Price == 100)
    .ToList();
```

We get the following error:

```SQL
Error while executing SQL command in transaction 'NonParallelWorker': Invalid column name 'Price'.
The command being executed was:
SELECT Id,Name,Type,JSON
FROM [TestSchema].[Product]
WHERE ([Price] = @price)
ORDER BY [Id]
```

The `Price` field was queried as a column, instead of being parsed as part of the json payload like so:

```diff
SELECT Id,Name,Type,JSON
FROM [TestSchema].[Product]
-WHERE ([Price] = @price)
+WHERE (JSON_VALUE([JSON], '$.Price') = @price)
ORDER BY [Id]
```
