### PR TITLE
Change TableColumnsCache scoping

### DIFF
--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -50,7 +50,8 @@ namespace Nevermore
 
             DocumentMaps = new DocumentMapRegistry(PrimaryKeyHandlers);
 
-            TableColumnNameResolver = queryExecutor => new CachingTableColumnNameResolver(new JsonLastTableColumnNameResolver(queryExecutor), new TableColumnsCache());
+            var tableColumnsCache = new TableColumnsCache();
+            TableColumnNameResolver = queryExecutor => new CachingTableColumnNameResolver(new JsonLastTableColumnNameResolver(queryExecutor), tableColumnsCache);
 
             AllowSynchronousOperations = true;
 


### PR DESCRIPTION
currently our cache is per transaction (relates to #173). 

This change elevates the cache so that it is shared between all transactions created from the same config.