### PR TITLE
Add query hint support

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Assent;
 using FluentAssertions;
-using Nevermore.Advanced;
 using Nevermore.Advanced.QueryBuilders;
 using Nevermore.Querying.AST;
 using NSubstitute;
@@ -1799,6 +1798,37 @@ ORDER BY [Id]";
                 .GenerateSql();
 
             this.Assent(subquerySql);
+        }
+
+        [Test]
+        public void ShouldGenerateOptionUnknown()
+        {
+            var actual = CreateQueryBuilder<object>("Orders")
+                .Option("OPTIMIZE FOR UNKNOWN")
+                .DebugViewRawQuery();
+
+            const string expected = @"SELECT *
+FROM [dbo].[Orders]
+ORDER BY [Id]
+OPTION (OPTIMIZE FOR UNKNOWN)";
+
+            actual.Should().Be(expected);
+        }
+
+        [Test]
+        public void ShouldGenerateOptionUnknownAndForceExternalPushDown()
+        {
+            var actual = CreateQueryBuilder<object>("Orders")
+                .Option("OPTIMIZE FOR UNKNOWN")
+                .Option("FORCE EXTERNALPUSHDOWN")
+                .DebugViewRawQuery();
+
+            const string expected = @"SELECT *
+FROM [dbo].[Orders]
+ORDER BY [Id]
+OPTION (OPTIMIZE FOR UNKNOWN, FORCE EXTERNALPUSHDOWN)";
+
+            actual.Should().Be(expected);
         }
     }
 

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -237,6 +237,12 @@ namespace Nevermore.Advanced
             return this;
         }
 
+        public IQueryBuilder<TRecord> Option(string queryHint)
+        {
+            selectBuilder.AddOption(queryHint);
+            return this;
+        }
+
         public IQueryBuilder<TRecord> Column(string name)
         {
             selectBuilder.AddColumn(name);

--- a/source/Nevermore/Advanced/QueryBuilders/SourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilders/SourceQueryBuilder.cs
@@ -321,5 +321,10 @@ namespace Nevermore.Advanced.QueryBuilders
         {
             return Builder.DebugViewRawQuery();
         }
+
+        public IQueryBuilder<TRecord> Option(string queryHint)
+        {
+            return Final(Builder.Option(queryHint));
+        }
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/JoinSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/JoinSelectBuilder.cs
@@ -9,13 +9,14 @@ namespace Nevermore.Advanced.SelectBuilders
     {
         protected override JoinedSource From { get; }
 
-        public JoinSelectBuilder(JoinedSource from) : this(from, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>())
+        public JoinSelectBuilder(JoinedSource from) : this(from, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>(), new List<IOptionClause>())
         {
         }
 
-        JoinSelectBuilder(JoinedSource from, List<IWhereClause> whereClauses, List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, 
+        JoinSelectBuilder(JoinedSource from,
+            List<IWhereClause> whereClauses, List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, List<IOptionClause> optionClauses,
             ISelectColumns columnSelection = null, IRowSelection rowSelection = null) 
-            : base(whereClauses, groupByClauses, orderByClauses, columnSelection, rowSelection)
+            : base(whereClauses, groupByClauses, orderByClauses, optionClauses, columnSelection, rowSelection)
         {
             From = from;
         }
@@ -31,7 +32,13 @@ namespace Nevermore.Advanced.SelectBuilders
 
         public override ISelectBuilder Clone()
         {
-            return new JoinSelectBuilder(From, new List<IWhereClause>(WhereClauses), new List<GroupByField>(GroupByClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new JoinSelectBuilder(From,
+                new List<IWhereClause>(WhereClauses),
+                new List<GroupByField>(GroupByClauses),
+                new List<OrderByField>(OrderByClauses),
+                new List<IOptionClause>(OptionClauses),
+                ColumnSelection,
+                RowSelection);
         }
 
         public override void AddWhere(UnaryWhereParameter whereParams)

--- a/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
@@ -12,23 +12,26 @@ namespace Nevermore.Advanced.SelectBuilders
         protected readonly List<OrderByField> OrderByClauses;
         protected readonly List<GroupByField> GroupByClauses;
         protected readonly List<IWhereClause> WhereClauses;
+        protected readonly List<IOptionClause> OptionClauses;
         protected ISelectColumns ColumnSelection;
         protected IRowSelection RowSelection;
 
         protected SelectBuilderBase(
-            List<IWhereClause> whereClauses, 
+            List<IWhereClause> whereClauses,
             List<GroupByField> groupByClauses,
-            List<OrderByField> orderByClauses, 
+            List<OrderByField> orderByClauses,
+            List<IOptionClause> optionClauses,
             ISelectColumns columnSelection = null,
             IRowSelection rowSelection = null)
         {
             WhereClauses = whereClauses;
             OrderByClauses = orderByClauses;
             GroupByClauses = groupByClauses;
-            this.RowSelection = rowSelection;
-            this.ColumnSelection = columnSelection;
+            OptionClauses = optionClauses;
+            RowSelection = rowSelection;
+            ColumnSelection = columnSelection;
         }
-        
+
         public ISelectSource SelectSource { get; }
 
         protected abstract ISelectColumns DefaultSelect { get; }
@@ -52,7 +55,7 @@ namespace Nevermore.Advanced.SelectBuilders
 
         ISelect GenerateSelectInner(Func<OrderBy> getDefaultOrderBy)
         {
-            return new Select(GetRowSelection(), GetColumnSelection(), From, GetWhere() ?? new Where(), GetGroupBy(), GetOrderBy(getDefaultOrderBy));
+            return new Select(GetRowSelection(), GetColumnSelection(), From, GetWhere() ?? new Where(), GetGroupBy(), GetOrderBy(getDefaultOrderBy), GetOption());
         }
 
         public abstract ISelectBuilder Clone();
@@ -84,6 +87,11 @@ namespace Nevermore.Advanced.SelectBuilders
         {
             var orderByFields = GetDefaultOrderByFields().ToList();
             return !orderByFields.Any() ? null : new OrderBy(orderByFields);
+        }
+
+        IOption GetOption()
+        {
+            return new Option(OptionClauses);
         }
 
         public void AddTop(int top)
@@ -183,6 +191,11 @@ namespace Nevermore.Advanced.SelectBuilders
         public void AddDefaultColumnSelection()
         {
             AddColumnSelection(DefaultSelect);
+        }
+
+        public void AddOption(string queryHint)
+        {
+            OptionClauses.Add(new OptionClause(queryHint));
         }
 
         ISelectColumns GetColumnSelection() => ColumnSelection ?? DefaultSelect;

--- a/source/Nevermore/Advanced/SelectBuilders/SubquerySelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/SubquerySelectBuilder.cs
@@ -6,13 +6,14 @@ namespace Nevermore.Advanced.SelectBuilders
     public class SubquerySelectBuilder : SelectBuilderBase<ISubquerySource>
     {
         public SubquerySelectBuilder(ISubquerySource from) 
-            : this(from, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>())
+            : this(from, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>(), new List<IOptionClause>())
         {
         }
         
-        SubquerySelectBuilder(ISubquerySource from, List<IWhereClause> whereClauses,  List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, 
+        SubquerySelectBuilder(ISubquerySource from,
+            List<IWhereClause> whereClauses,  List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, List<IOptionClause> optionClauses,
             ISelectColumns columnSelection = null, IRowSelection rowSelection = null) 
-            : base(whereClauses, groupByClauses, orderByClauses, columnSelection, rowSelection)
+            : base(whereClauses, groupByClauses, orderByClauses, optionClauses, columnSelection, rowSelection)
         {
             From = @from;
         }
@@ -27,7 +28,13 @@ namespace Nevermore.Advanced.SelectBuilders
 
         public override ISelectBuilder Clone()
         {
-            return new SubquerySelectBuilder(From, new List<IWhereClause>(WhereClauses), new List<GroupByField>(GroupByClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new SubquerySelectBuilder(From,
+                new List<IWhereClause>(WhereClauses),
+                new List<GroupByField>(GroupByClauses),
+                new List<OrderByField>(OrderByClauses),
+                new List<IOptionClause>(OptionClauses),
+                ColumnSelection,
+                RowSelection);
         }
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/TableSelectBuilder.cs
@@ -6,15 +6,15 @@ namespace Nevermore.Advanced.SelectBuilders
     public class TableSelectBuilder : SelectBuilderBase<ITableSource>
     {
         public TableSelectBuilder(ITableSource from, IColumn idColumn) 
-            : this(from, idColumn, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>())
+            : this(from, idColumn, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>(), new List<IOptionClause>())
         {
         }
 
         TableSelectBuilder(ITableSource from, IColumn idColumn,
             List<IWhereClause> whereClauses, List<GroupByField> groupByClauses,
-            List<OrderByField> orderByClauses, ISelectColumns columnSelection = null, 
+            List<OrderByField> orderByClauses, List<IOptionClause> optionClauses, ISelectColumns columnSelection = null, 
             IRowSelection rowSelection = null)
-            : base(whereClauses, groupByClauses, orderByClauses, columnSelection, rowSelection)
+            : base(whereClauses, groupByClauses, orderByClauses, optionClauses, columnSelection, rowSelection)
         {
             From = from;
             IdColumn = idColumn;
@@ -33,7 +33,14 @@ namespace Nevermore.Advanced.SelectBuilders
 
         public override ISelectBuilder Clone()
         {
-            return new TableSelectBuilder(From, IdColumn, new List<IWhereClause>(WhereClauses), new List<GroupByField>(GroupByClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new TableSelectBuilder(From,
+                IdColumn,
+                new List<IWhereClause>(WhereClauses),
+                new List<GroupByField>(GroupByClauses),
+                new List<OrderByField>(OrderByClauses),
+                new List<IOptionClause>(OptionClauses),
+                ColumnSelection,
+                RowSelection);
         }
     }
 }

--- a/source/Nevermore/Advanced/SelectBuilders/UnionSelectBuilder.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/UnionSelectBuilder.cs
@@ -13,13 +13,14 @@ namespace Nevermore.Advanced.SelectBuilders
         public UnionSelectBuilder(ISelect innerSelect, 
             string customAlias, 
             ITableAliasGenerator tableAliasGenerator) 
-            : this(innerSelect, customAlias, tableAliasGenerator, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>())
+            : this(innerSelect, customAlias, tableAliasGenerator, new List<IWhereClause>(), new List<GroupByField>(), new List<OrderByField>(), new List<IOptionClause>())
         {
         }
 
-        UnionSelectBuilder(ISelect innerSelect, string customAlias, ITableAliasGenerator tableAliasGenerator, List<IWhereClause> whereClauses,  List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, 
-            ISelectColumns columnSelection = null, IRowSelection rowSelection = null) 
-            : base(whereClauses, groupByClauses, orderByClauses, columnSelection, rowSelection)
+        UnionSelectBuilder(ISelect innerSelect, string customAlias, ITableAliasGenerator tableAliasGenerator,
+            List<IWhereClause> whereClauses, List<GroupByField> groupByClauses, List<OrderByField> orderByClauses, List<IOptionClause> optionClauses,
+            ISelectColumns columnSelection = null, IRowSelection rowSelection = null)
+            : base(whereClauses, groupByClauses, orderByClauses, optionClauses, columnSelection, rowSelection)
         {
             this.innerSelect = innerSelect;
             this.customAlias = customAlias;
@@ -55,7 +56,13 @@ namespace Nevermore.Advanced.SelectBuilders
 
         public override ISelectBuilder Clone()
         {
-            return new UnionSelectBuilder(innerSelect, customAlias, tableAliasGenerator, new List<IWhereClause>(WhereClauses), new List<GroupByField>(GroupByClauses), new List<OrderByField>(OrderByClauses), ColumnSelection, RowSelection);
+            return new UnionSelectBuilder(innerSelect, customAlias, tableAliasGenerator,
+                new List<IWhereClause>(WhereClauses),
+                new List<GroupByField>(GroupByClauses),
+                new List<OrderByField>(OrderByClauses),
+                new List<IOptionClause>(OptionClauses),
+                ColumnSelection,
+                RowSelection);
         }
     }
 }

--- a/source/Nevermore/IQueryBuilder.cs
+++ b/source/Nevermore/IQueryBuilder.cs
@@ -345,6 +345,13 @@ namespace Nevermore
         /// </summary>
         /// <returns>The row SQL string that well be executed</returns>
         string DebugViewRawQuery();
+
+        /// <summary>
+        /// Adds an Option query hint.
+        /// </summary>
+        /// <param name="queryHint"></param>
+        /// <returns></returns>
+        IQueryBuilder<TRecord> Option(string queryHint);
     }
 
     public class ColumnFromTable

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -26,6 +26,7 @@ namespace Nevermore
         void AddRowNumberColumn(string alias, IReadOnlyList<Column> partitionBys);
         void AddRowNumberColumn(string alias, IReadOnlyList<TableColumn> partitionBys);
         void AddDefaultColumnSelection();
+        void AddOption(string queryHint);
         void RemoveOrderBys();
         ISelect GenerateSelect();
         ISelect GenerateSelectWithoutDefaultOrderBy();

--- a/source/Nevermore/Querying/AST/Option.cs
+++ b/source/Nevermore/Querying/AST/Option.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Nevermore.Querying.AST
+{
+    public interface IOption
+    {
+        string GenerateSql();
+    }
+
+    public interface IOptionClause
+    {
+        string GenerateSql();
+    }
+
+    public class Option : IOption
+    {
+        readonly IReadOnlyList<IOptionClause> optionClauses;
+
+        public Option(IReadOnlyList<IOptionClause> optionClauses)
+        {
+            this.optionClauses = optionClauses;
+        }
+
+        public string GenerateSql()
+        {
+            return optionClauses.Any()
+                ? $@"
+OPTION ({string.Join(@", ", optionClauses.Select(f => f.GenerateSql()))})"
+                : string.Empty;
+        }
+
+        public override string ToString() => GenerateSql();
+    }
+
+    public class OptionClause : IOptionClause
+    {
+        readonly string queryHint;
+
+        public OptionClause(string queryHint)
+        {
+            this.queryHint = queryHint;
+        }
+
+        public string GenerateSql() => queryHint;
+
+        public override string ToString() => GenerateSql();
+    }
+}

--- a/source/Nevermore/Querying/AST/Select.cs
+++ b/source/Nevermore/Querying/AST/Select.cs
@@ -8,8 +8,9 @@
         readonly Where where;
         readonly OrderBy orderBy; // Can be null
         readonly GroupBy groupBy; // Can be null
+        readonly IOption option;
 
-        public Select(IRowSelection rowSelection, ISelectColumns columns, ISelectSource from, Where where, GroupBy groupBy, OrderBy orderBy)
+        public Select(IRowSelection rowSelection, ISelectColumns columns, ISelectSource from, Where where, GroupBy groupBy, OrderBy orderBy, IOption option)
         {
             this.rowSelection = rowSelection;
             this.columns = columns;
@@ -17,6 +18,7 @@
             this.where = where;
             this.orderBy = orderBy;
             this.groupBy = groupBy;
+            this.option = option;
         }
 
         public string Schema => @from.Schema;
@@ -29,7 +31,7 @@
             var groupByString = groupBy?.GenerateSql();
             
             return $@"SELECT {rowSelection.GenerateSql()}{columns.GenerateSql()}
-FROM {from.GenerateSql()}{where.GenerateSql()}{groupByString}{orderByString}";
+FROM {from.GenerateSql()}{where.GenerateSql()}{groupByString}{orderByString}{option.GenerateSql()}";
         }
 
         public override string ToString()


### PR DESCRIPTION
This change adds support for Option query hints as shown below.

The Option clause has support for multiple query hints so I did the same here.

This would allow us to use `OPTIMIZE FOR UNKNOWN` to avoid parameter sniffing issues as described [here](https://techcommunity.microsoft.com/t5/sql-server-blog/optimize-for-unknown-8211-a-little-known-sql-server-2008-feature/ba-p/383498) and [here](https://blog.sqlauthority.com/2019/12/21/sql-server-parameter-sniffing-and-optimize-for-unknown/).

`OPTIMIZE FOR UNKNOWN` can be useful to solve this problem:
"An application that I work with presented me with an interesting dilemma; It wanted to utilize the benefits of plan reuse but the parameter values that the application initially sends to SQL Server are not representative of the values passed in the subsequent re-execution of the statement. SQL Server compiled and cached a ‘good’ plan for the first parameter values. Unfortunately, this had the unintended side effect of caching a poor execution plan for all subsequent parameter values."