### PR TITLE
Add Hint and RawDebugView to Queryable

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -915,6 +915,31 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
+        public void Hint()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple" },
+                new Customer { FirstName = "Bob", LastName = "Banana" },
+                new Customer { FirstName = "Charlie", LastName = "Cherry" }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            t.Commit();
+
+            var a = t.Queryable<Customer>().Where(x => x.FirstName == "Alice").Hint("WITH (ROWLOCK, UPDLOCK, NOWAIT)").RawDebugView();
+            a.Should().Be($"SELECT Id,FirstName,LastName,Nickname,Roles,Balance,IsVip,JSON{Environment.NewLine}" +
+            $"FROM [TestSchema].[Customer] WITH (ROWLOCK, UPDLOCK, NOWAIT){Environment.NewLine}" +
+            "WHERE ([FirstName] = @p1)");
+        }
+
+        [Test]
         public void CountWithPredicate()
         {
             using var t = Store.BeginTransaction();

--- a/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
@@ -53,12 +53,13 @@ namespace Nevermore.Advanced.Queryable
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             
-            var expression = Expression.Call(
-                null,
-                RawDebugViewInfo.MakeGenericMethod(typeof(TSource)),
-                source.Expression);
+            if (source.Provider is QueryProvider queryProvider)
+            {
+                var (command, _) = queryProvider.Translate(source.Expression);
+                return command.Statement;
+            }
 
-            return source.Provider.Execute<string>(expression);
+            throw new NotSupportedException();
         }
 
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default)

--- a/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
@@ -12,7 +12,6 @@ namespace Nevermore.Advanced.Queryable
     {
         static readonly MethodInfo WhereCustomMethodInfo = new Func<IQueryable<object>, string, IQueryable<object>>(WhereCustom).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo HintMethodInfo = new Func<IQueryable<object>, string, IQueryable<object>>(Hint).GetMethodInfo().GetGenericMethodDefinition();
-        static readonly MethodInfo RawDebugViewInfo = new Func<IQueryable<object>, string>(RawDebugView).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo FirstOrDefaultMethodInfo = new Func<IQueryable<object>, object>(System.Linq.Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo FirstOrDefaultWithPredicateMethodInfo = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(System.Linq.Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo CountMethodInfo = new Func<IQueryable<object>, int>(System.Linq.Queryable.Count).GetMethodInfo().GetGenericMethodDefinition();

--- a/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
@@ -11,6 +11,8 @@ namespace Nevermore.Advanced.Queryable
     public static class NevermoreQueryableExtensions
     {
         static readonly MethodInfo WhereCustomMethodInfo = new Func<IQueryable<object>, string, IQueryable<object>>(WhereCustom).GetMethodInfo().GetGenericMethodDefinition();
+        static readonly MethodInfo HintMethodInfo = new Func<IQueryable<object>, string, IQueryable<object>>(Hint).GetMethodInfo().GetGenericMethodDefinition();
+        static readonly MethodInfo RawDebugViewInfo = new Func<IQueryable<object>, string>(RawDebugView).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo FirstOrDefaultMethodInfo = new Func<IQueryable<object>, object>(System.Linq.Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo FirstOrDefaultWithPredicateMethodInfo = new Func<IQueryable<object>, Expression<Func<object, bool>>, object>(System.Linq.Queryable.FirstOrDefault).GetMethodInfo().GetGenericMethodDefinition();
         static readonly MethodInfo CountMethodInfo = new Func<IQueryable<object>, int>(System.Linq.Queryable.Count).GetMethodInfo().GetGenericMethodDefinition();
@@ -30,6 +32,33 @@ namespace Nevermore.Advanced.Queryable
                     null,
                     WhereCustomMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression, Expression.Constant(whereClause)));
+        }
+
+        public static IQueryable<TSource> Hint<TSource>(this IQueryable<TSource> source, string hint)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (string.IsNullOrEmpty(hint))
+                throw new ArgumentNullException(nameof(hint));
+
+            return source.Provider.CreateQuery<TSource>(
+                Expression.Call(
+                    null,
+                    HintMethodInfo.MakeGenericMethod(typeof(TSource)),
+                    source.Expression, Expression.Constant(hint)));
+        }
+
+        public static string RawDebugView<TSource>(this IQueryable<TSource> source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            
+            var expression = Expression.Call(
+                null,
+                RawDebugViewInfo.MakeGenericMethod(typeof(TSource)),
+                source.Expression);
+
+            return source.Provider.Execute<string>(expression);
         }
 
         public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> source, CancellationToken cancellationToken = default)

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -145,6 +145,21 @@ namespace Nevermore.Advanced.Queryable
                 return node;
             }
 
+            if (methodInfo.Name == nameof(NevermoreQueryableExtensions.RawDebugView))
+            {
+                Visit(node.Arguments[0]);
+                sqlBuilder.Debug();
+                return node;
+            }
+
+            if (methodInfo.Name == nameof(NevermoreQueryableExtensions.Hint))
+            {
+                Visit(node.Arguments[0]);
+                var hint = (string)GetValueFromExpression(node.Arguments[1], typeof(string));
+                sqlBuilder.Hint(hint);
+                return node;
+            }
+
             if (methodInfo.Name == nameof(System.Linq.Queryable.Take))
             {
                 Visit(node.Arguments[0]);

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -145,13 +145,6 @@ namespace Nevermore.Advanced.Queryable
                 return node;
             }
 
-            if (methodInfo.Name == nameof(NevermoreQueryableExtensions.RawDebugView))
-            {
-                Visit(node.Arguments[0]);
-                sqlBuilder.Debug();
-                return node;
-            }
-
             if (methodInfo.Name == nameof(NevermoreQueryableExtensions.Hint))
             {
                 Visit(node.Arguments[0]);

--- a/source/Nevermore/Advanced/Queryable/QueryType.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryType.cs
@@ -5,6 +5,7 @@
         SelectMany,
         SelectSingle,
         Count,
-        Exists
+        Exists,
+        Debug
     }
 }

--- a/source/Nevermore/Advanced/Queryable/QueryType.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryType.cs
@@ -5,7 +5,6 @@
         SelectMany,
         SelectSingle,
         Count,
-        Exists,
-        Debug
+        Exists
     }
 }

--- a/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
+++ b/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
@@ -75,11 +75,6 @@ namespace Nevermore.Advanced.Queryable
             queryType = QueryType.Count;
         }
 
-        public void Debug()
-        {
-            queryType = QueryType.Debug;
-        }
-
         public void Skip(int numberOfRows)
         {
             skip = numberOfRows;

--- a/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
+++ b/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
@@ -14,8 +14,9 @@ namespace Nevermore.Advanced.Queryable
 
         readonly List<OrderByField> orderByFields = new();
         readonly List<IWhereClause> whereClauses = new();
+        string hint;
         readonly CommandParameterValues parameterValues = new();
-        ISelectSource from;
+        ITableSource from;
         int? skip;
         int? take;
         QueryType queryType = QueryType.SelectMany;
@@ -74,6 +75,11 @@ namespace Nevermore.Advanced.Queryable
             queryType = QueryType.Count;
         }
 
+        public void Debug()
+        {
+            queryType = QueryType.Debug;
+        }
+
         public void Skip(int numberOfRows)
         {
             skip = numberOfRows;
@@ -82,6 +88,11 @@ namespace Nevermore.Advanced.Queryable
         public void Take(int numberOfRows)
         {
             take = numberOfRows;
+        }
+
+        public void Hint(string hint)
+        {
+            this.hint = hint;
         }
 
         public void From(Type documentType)
@@ -93,6 +104,11 @@ namespace Nevermore.Advanced.Queryable
 
         public (IExpression, CommandParameterValues, QueryType) Build()
         {
+            if (from is ISimpleTableSource simpleTableSource && !string.IsNullOrEmpty(hint))
+            {
+                from = new TableSourceWithHint(simpleTableSource, hint);
+            }
+            
             var sqlExpression = queryType switch
             {
                 QueryType.Exists => CreateExistsQuery(),
@@ -146,6 +162,8 @@ namespace Nevermore.Advanced.Queryable
         IExpression CreateExistsQuery()
         {
             IRowSelection rowSelection = take.HasValue && !skip.HasValue ? new Top(take.Value) : null;
+
+            
             var select = new Select(
                 rowSelection ?? new AllRows(),
                 new SelectAllSource(),


### PR DESCRIPTION
Adds `Hint` extension to `IQueryable` to be able to specify table hints in the query.
Adds `RawDebugQuery` extension to `IQueryable` to be able to see debug view the query like possible with using `Query`.