### PR TITLE
IQueryable - Handle polymorphic documents

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -113,6 +113,38 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
+        public void WhereEqualPolymorphicDocumentColumn()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testProducts = new Product[]
+            {
+                new DodgyProduct { Name = "iPhane", Price = 350.0m, Tax = 35.0m },
+                new SpecialProduct { Name = "OctoPhone", Price = 300.0m },
+            };
+
+            foreach (var p in testProducts)
+            {
+                t.Insert(p);
+            }
+
+            t.Commit();
+
+            // query by base type
+            var dodgyProduct = t.Queryable<Product>()
+                .First(p => p.Name == "iPhane");
+
+            dodgyProduct.Price.Should().Be(350);
+
+            // query by derived type
+            var specialProduct = t
+                .Queryable<SpecialProduct>()
+                .First(p => p.Name == "OctoPhone");
+
+            specialProduct.Price.Should().Be(300);
+        }
+
+        [Test]
         public void WhereEqualJson()
         {
             using var t = Store.BeginTransaction();

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -340,7 +340,7 @@ namespace Nevermore.Advanced.Queryable
                 var documentMap = sqlBuilder.DocumentMap;
                 var parameterExpression = memberExpression.FindChildOfType<ParameterExpression>();
                 var childPropertyExpression = memberExpression.FindChildOfType<MemberExpression>();
-                if (childPropertyExpression == null && parameterExpression.Type == documentMap.Type)
+                if (childPropertyExpression == null && documentMap.Type.IsAssignableFrom(parameterExpression.Type))
                 {
                     if (documentMap.IdColumn!.Property.Matches(propertyInfo))
                     {


### PR DESCRIPTION
Fixes an issue where properties wouldn't map to columns for querying when the queried document type did not exactly match the type defined in the document map. This is a legitimate case for polymorphic document types.