### PR TITLE
Fix analyzer crash when CommandType is set on CommandParameterValues

### DIFF
--- a/source/Nevermore.Analyzers.Tests/NevermoreEmbeddedSqlExpressionAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreEmbeddedSqlExpressionAnalyzerFixture.cs
@@ -61,5 +61,22 @@ namespace Nevermore.Analyzers.Tests
 	        var results = CodeCompiler.Compile<NevermoreEmbeddedSqlExpressionAnalyzer>(code);
 	        AssertPassed(results);
         }
+
+        [Test]
+        public void ShouldHandlePropertiesSetOnCommandParameterValuesAsWellAsParameters()
+        {
+            var code = @"
+                var parameters = new CommandParameterValues
+                {
+                    [""searchParam""] = ""abc"",
+                    CommandType = System.Data.CommandType.StoredProcedure
+                };
+
+                var results = transaction.Stream<string>(""FullTextSearch"", parameters).ToList();
+            ";
+
+            var results = CodeCompiler.Compile<NevermoreEmbeddedSqlExpressionAnalyzer>(code);
+            AssertPassed(results);
+        }
    }
 }

--- a/source/Nevermore.Analyzers/NevermoreEmeddedSqlExpressionAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreEmeddedSqlExpressionAnalyzer.cs
@@ -300,7 +300,7 @@ namespace Nevermore.Analyzers
                             values.AddRange(creationExpressionSyntax.ArgumentList.Arguments.Select(e => GetStringValue(e.Expression, model)));
                         }
 
-                        return string.Join(", ", values.Select(v => '@' + v.TrimStart('@')));
+                        return string.Join(", ", values.Where(x => x != null).Select(v => '@' + v.TrimStart('@')));
                     }
 
                     return "???? " + typeSymbol.Name;


### PR DESCRIPTION
Fix analyzer crash when CommandType is set on CommandParameterValues, as part of an object initializer.

Analyzer was crashing with:

```
Analyzer 'Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.
```

Full stack trace from diagnostic build log was:
```
CSC : warning AD0001: Analyzer 'Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.
Exception occurred with following context: (TaskId:134)
Compilation: Octofront.Core (TaskId:134)
SyntaxTree: /Users/anon/myproject/Persistence/TransactionExtensions.cs (TaskId:134)
SyntaxNode: transaction.Stream<PageContent> ... [InvocationExpressionSyntax]@[2745..2820) (69,19)-(69,94) (TaskId:134)
 (TaskId:134)
System.NullReferenceException: Object reference not set to an instance of an object. (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.<>c.<GetStringValue>b__7_5(String v) (TaskId:134)
   at System.Linq.Enumerable.SelectListIterator`2.MoveNext() (TaskId:134)
   at System.String.Join(String separator, IEnumerable`1 values) (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.GetStringValue(ExpressionSyntax expression, SemanticModel model) (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.GetStringValue(ExpressionSyntax expression, SemanticModel model) (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.FindCommandValueParameters(ExpressionSyntax expression, SemanticModel model, QueryAnalysisUnit currentQuery) (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.ProcessInvocation(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext context, ConcurrentDictionary`2 discovered) (TaskId:134)
   at Nevermore.Analyzers.NevermoreEmbeddedSqlExpressionAnalyzer.<>c__DisplayClass3_0.<AnalyzeCompilation>b__1(SyntaxNodeAnalysisContext invocationContext) (TaskId:134)
   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.<>c__62`1.<ExecuteSyntaxNodeAction>b__62_0(ValueTuple`2 data) (TaskId:134)
   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info) (TaskId:134)
----- (TaskId:134)
```