### PR TITLE
Fixing issue with casting for types that inherit from base type with FirstOrDefaultAsync

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nevermore.Advanced.Queryable;
@@ -113,7 +114,7 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
-        public void WhereEqualPolymorphicDocumentColumn()
+        public async Task WhereEqualPolymorphicDocumentColumn()
         {
             using var t = Store.BeginTransaction();
 
@@ -132,14 +133,14 @@ namespace Nevermore.IntegrationTests
 
             // query by base type
             var dodgyProduct = t.Queryable<Product>()
-                .First(p => p.Name == "iPhane");
+                .FirstOrDefault(p => p.Name == "iPhane");
 
             dodgyProduct.Price.Should().Be(350);
 
             // query by derived type
-            var specialProduct = t
+            var specialProduct = await t
                 .Queryable<SpecialProduct>()
-                .First(p => p.Name == "OctoPhone");
+                .FirstOrDefaultAsync(p => p.Name == "OctoPhone", CancellationToken.None);
 
             specialProduct.Price.Should().Be(300);
         }

--- a/source/Nevermore/Advanced/Queryable/QueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryProvider.cs
@@ -93,7 +93,7 @@ namespace Nevermore.Advanced.Queryable
                 {
                     if (typeof(TResult).IsValueType)
                     {
-                        throw new InvalidCastException("");
+                        throw new InvalidCastException("Null object cannot be converted to a value type");
                     }
 
                     // TODO: This NEEDS to go away when we turn nullable on in Nevermore

--- a/source/Nevermore/Advanced/Queryable/QueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryProvider.cs
@@ -89,25 +89,13 @@ namespace Nevermore.Advanced.Queryable
                     .Invoke(queryExecutor, new object[] { command, cancellationToken });
                 var firstOrDefaultAsync = await FirstOrDefaultAsync(asyncStream, cancellationToken);
 
-                if (firstOrDefaultAsync is null)
-                {
-                    if (typeof(TResult).IsValueType)
-                    {
-                        throw new InvalidCastException("Null object cannot be converted to a value type");
-                    }
+                if (firstOrDefaultAsync is not null) return (TResult) firstOrDefaultAsync;
 
-                    // TODO: This NEEDS to go away when we turn nullable on in Nevermore
-                    // This method needs to be able to return null for instances like `FirstOrDefaultAsync` 
-                    object GetNull() => null;
-                    return (TResult) GetNull();
-                }
-                
-                if (!firstOrDefaultAsync.GetType().IsAssignableFrom(typeof(TResult)))
-                {
-                    throw new InvalidCastException($"Type {firstOrDefaultAsync.GetType()} is not castable to type {typeof(TResult)}");
-                }
-                
-                return (TResult) firstOrDefaultAsync;
+                // TODO: This NEEDS to go away when we turn nullable on in Nevermore
+                // This method needs to be able to return null for instances like `FirstOrDefaultAsync` 
+                object GetNull() => null;
+                return (TResult) GetNull();
+
             }
 
             return await (Task<TResult>)GenericExecuteScalarAsyncMethod.MakeGenericMethod(expression.Type)

--- a/source/Nevermore/CommandExecutor.cs
+++ b/source/Nevermore/CommandExecutor.cs
@@ -209,7 +209,7 @@ namespace Nevermore
 
         Exception WrapException(Exception ex)
         {
-            if (ex is SqlException sqlEx && sqlEx.Number == 1205) // deadlock
+            if (ex is SqlException {Number: 1205 or 1222 or -2}) // 1205 deadlock, 1222 row lock timeout, -2 timeout
             {
                 var builder = new StringBuilder();
                 builder.AppendLine(ex.Message);


### PR DESCRIPTION
When doing the following query:

`tx.Query<DodgyProduct>().Where(x => x.Name == "iphane").FirstOrDefaultAsync()`

We'd get an exception: `System.InvalidCastException: Object must implement IConvertable`. This was bubbling up from `(TResult)Convert.ChangeType(await FirstOrDefaultAsync(asyncStream, cancellationToken), typeof(TResult))` in the `QueryProvider.ExecuteAsync` which is only excercised through `IQueryable.GetFirstOrDefaultAsync` which we didn't have a test that hit. 

When it tries to convert from `DodgyProduct` to `Product`, it does a type comparison and `typeof(DodgyProduct) != typeof(Product)` so it was failing the convert type. The solution here is to not use ConvertType (which we believe was chosen as IAsyncEnumerable doesn't have a `.Cast` method like IEnumerable does, which is how `Execute` casts). Our work around here is horrible, but required. Since we don't have nullables enabled for Nevermore we can't convert `ExecuteAsync` to return `TResult?` which is _should_ be as it _does_ return null when no results are found. You can't return `(TResult) null` as it doesn't know how to convert a null to `TResult`, so the work around is hacky and yuck but works. 

We've also added sql timeout (-2) and row lock timeout (1222) to the command handler wrap exception so that when the sql exceptions are thrown, they will also be populated with open transactions at the time to help better diagnose the concurrency issues we're facing in Server. 