### PR TITLE
Add retry for BeginTransaction

### DIFF
--- a/source/Nevermore.Benchmarks/SetUp/IntegrationTestDatabase.cs
+++ b/source/Nevermore.Benchmarks/SetUp/IntegrationTestDatabase.cs
@@ -13,7 +13,7 @@ namespace Nevermore.Benchmarks.SetUp
             var username = Environment.GetEnvironmentVariable("NevermoreTestUsername");
             var password = Environment.GetEnvironmentVariable("NevermoreTestPassword");
             testDatabaseName = Environment.GetEnvironmentVariable("NevermoreBenchmarkDatabase") ?? "Nevermore-Benchmarks";
-            var builder = new SqlConnectionStringBuilder($"Server={sqlInstance};Database={testDatabaseName};{(username == null ? "Trusted_connection=true;" : string.Empty)}")
+            var builder = new SqlConnectionStringBuilder($"Server={sqlInstance};Database={testDatabaseName};{(username == null ? "Trusted_connection=true;" : string.Empty)}; Encrypt=False;")
             {
                 ApplicationName = testDatabaseName,
             };

--- a/source/Nevermore.IntegrationTests/SetUp/IntegrationTestDatabase.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/IntegrationTestDatabase.cs
@@ -14,7 +14,7 @@ namespace Nevermore.IntegrationTests.SetUp
             var username = Environment.GetEnvironmentVariable("NevermoreTestUsername");
             var password = Environment.GetEnvironmentVariable("NevermoreTestPassword");
             testDatabaseName = Environment.GetEnvironmentVariable("NevermoreTestDatabase") ?? "Nevermore-IntegrationTests";
-            var builder = new SqlConnectionStringBuilder($"Server={sqlInstance};Database={testDatabaseName};{(username == null ? "Trusted_connection=true;" : string.Empty)}")
+            var builder = new SqlConnectionStringBuilder($"Server={sqlInstance};Database={testDatabaseName};{(username == null ? "Trusted_connection=true;" : string.Empty)}; Encrypt=False;")
             {
                 ApplicationName = testDatabaseName,
             };

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -80,7 +80,7 @@ namespace Nevermore.Advanced
         public void Open(IsolationLevel isolationLevel)
         {
             Open();
-            Transaction = connection!.BeginTransaction(isolationLevel, SqlServerTransactionName);
+            Transaction = connection!.BeginTransactionWithRetry(isolationLevel, SqlServerTransactionName);
         }
 
         public async Task OpenAsync(IsolationLevel isolationLevel)
@@ -89,7 +89,7 @@ namespace Nevermore.Advanced
 
             // We use the synchronous overload here even though there is an async one, because the BeginTransactionAsync calls
             // the synchronous version anyway, and the async overload doesn't accept a name parameter.
-            Transaction = connection!.BeginTransaction(isolationLevel, SqlServerTransactionName);
+            Transaction = connection!.BeginTransactionWithRetry(isolationLevel, SqlServerTransactionName);
         }
 
         [Pure]

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/source/Nevermore/Transient/RetryManagerSqlExtensions.cs
+++ b/source/Nevermore/Transient/RetryManagerSqlExtensions.cs
@@ -6,6 +6,7 @@ namespace Nevermore.Transient
     {
         public static readonly string DefaultStrategyCommandTechnologyName = "SQL";
         public static readonly string DefaultStrategyConnectionTechnologyName = "SQLConnection";
+        public static readonly string DefaultStrategyTransactionTechnologyName = "SQLTransaction";
 
         public static RetryPolicy GetDefaultSqlCommandRetryPolicy(this RetryManager retryManager)
         {
@@ -40,6 +41,20 @@ namespace Nevermore.Transient
             {
                 return retryManager.GetDefaultRetryStrategy(DefaultStrategyCommandTechnologyName);
             }
+        }
+
+        public static RetryPolicy GetDefaultSqlTransactionRetryPolicy(this RetryManager retryManager)
+        {
+            if (retryManager == null) throw new ArgumentNullException("retryManager");
+
+            return new RetryPolicy(new SqlDatabaseTransientErrorDetectionStrategy(), retryManager.GetDefaultSqlTransactionRetryStrategy());
+        }
+
+        public static RetryStrategy GetDefaultSqlTransactionRetryStrategy(this RetryManager retryManager)
+        {
+            if (retryManager == null) throw new ArgumentNullException("retryManager");
+
+            return retryManager.GetDefaultRetryStrategy(DefaultStrategyTransactionTechnologyName);
         }
     }
 }

--- a/source/Nevermore/Transient/TransactionExtensions.cs
+++ b/source/Nevermore/Transient/TransactionExtensions.cs
@@ -14,7 +14,7 @@ namespace Nevermore.Transient
 
         public static DbTransaction BeginTransactionWithRetry(this SqlConnection connection, IsolationLevel isolationLevel, string sqlServerTransactionName, RetryPolicy retryPolicy)
         {
-            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Beginning Database Transaction").ExecuteAction(() => connection.BeginTransaction());
+            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Beginning Database Transaction").ExecuteAction(() => connection.BeginTransaction(isolationLevel, sqlServerTransactionName));
         }
     }
 }

--- a/source/Nevermore/Transient/TransactionExtensions.cs
+++ b/source/Nevermore/Transient/TransactionExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+
+
+namespace Nevermore.Transient
+{
+    public static class TransactionExtensions
+    {
+        public static DbTransaction BeginTransactionWithRetry(this SqlConnection connection, IsolationLevel isolationLevel, string sqlServerTransactionName)
+        {
+            return BeginTransactionWithRetry(connection, isolationLevel, sqlServerTransactionName, RetryManager.Instance.GetDefaultSqlTransactionRetryPolicy());
+        }
+
+        public static DbTransaction BeginTransactionWithRetry(this SqlConnection connection, IsolationLevel isolationLevel, string sqlServerTransactionName, RetryPolicy retryPolicy)
+        {
+            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Beginning Database Transaction").ExecuteAction(() => connection.BeginTransaction());
+        }
+    }
+}

--- a/source/Nevermore/TransientFaultHandling.cs
+++ b/source/Nevermore/TransientFaultHandling.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Nevermore.Transient;
 
 namespace Nevermore
@@ -36,6 +33,7 @@ namespace Nevermore
                 {
                     {RetryManagerSqlExtensions.DefaultStrategyConnectionTechnologyName, DefaultExponentialStrategyName},
                     {RetryManagerSqlExtensions.DefaultStrategyCommandTechnologyName, DefaultExponentialStrategyName},
+                    {RetryManagerSqlExtensions.DefaultStrategyTransactionTechnologyName, DefaultExponentialStrategyName}
                 }));
         }
     }}


### PR DESCRIPTION
Octopus Deploy dev teams have noticed transient connectivity issues when calling `BeginTransaction` in `ReacTransaction.cs`. 
We are also behind 2 versions of SqlClient that may have beneficial bug fixes or performance improvements..

The objective of this PR is to:

 - Bump the version of SqlClient
 - Wrap these calls with retry logic provided by the RetryManager

[Slack Thread](https://octopusdeploy.slack.com/archives/C02SY496BAM/p1644994741806619)

## Benchmark Results

### Before

TODO: get these running (currently hitting errors)

### After
TODO: Same