### PR TITLE
Throw an exception when the table/view doesn't exist

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
@@ -1,0 +1,43 @@
+using System;
+using FluentAssertions;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.Mapping;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class MissingTableFixture : FixtureWithRelationalStore
+    {
+        class Missing
+        {
+            public string Id { get; set; }
+        }
+
+        class MissingMap : DocumentMap<Missing>
+        {
+            public MissingMap()
+            {
+                Id(u => u.Id);
+            }
+        }
+
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            NoMonkeyBusiness();
+            Configuration.DocumentMaps.Register(new MissingMap());
+        }
+
+        [Test]
+        public void QueryShouldThrowAUsefulException()
+        {
+            using var transaction = Store.BeginTransaction();
+
+            void Run()
+                => transaction.Query<Missing>().ToArray();
+
+            ((Action)Run).Should().Throw<Exception>()
+                .WithMessage("No columns found for table or view 'TestSchema.Missing'. The table or view likely does not exist in that schema.");
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
@@ -37,7 +37,7 @@ namespace Nevermore.IntegrationTests.Advanced
                 => transaction.Query<Missing>().ToArray();
 
             ((Action)Run).Should().Throw<Exception>()
-                .WithMessage("No columns found for table or view 'TestSchema.Missing'. The table or view likely does not exist in that schema.");
+                .WithMessage("No columns found for table or view 'TestSchema.Missing'. The table or view likely does not exist in that schema, or the user does not have view definition SQL permission.");
         }
     }
 }

--- a/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
@@ -35,7 +35,7 @@ ORDER BY (CASE WHEN c.name = 'JSON' THEN 1 ELSE 0 END) ASC, c.column_id";
             var columnNames = queryExecutor.Stream<string>(getColumnNamesWithJsonLastQuery, parameters).ToArray();
 
             if (!columnNames.Any())
-                throw new Exception($"No columns found for table or view '{schemaName}.{tableName}'. The table or view likely does not exist in that schema.");
+                throw new Exception($"No columns found for table or view '{schemaName}.{tableName}'. The table or view likely does not exist in that schema, or the user does not have view definition SQL permission.");
 
             return columnNames;
         }

--- a/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Nevermore.TableColumnNameResolvers
 {
@@ -31,7 +32,12 @@ ORDER BY (CASE WHEN c.name = 'JSON' THEN 1 ELSE 0 END) ASC, c.column_id";
                 { nameof(schemaName), schemaName }
             };
 
-            return queryExecutor.Stream<string>(getColumnNamesWithJsonLastQuery, parameters).ToArray();
+            var columnNames = queryExecutor.Stream<string>(getColumnNamesWithJsonLastQuery, parameters).ToArray();
+
+            if (!columnNames.Any())
+                throw new Exception($"No columns found for table or view '{schemaName}.{tableName}'. The table or view likely does not exist in that schema.");
+
+            return columnNames;
         }
     }
 }


### PR DESCRIPTION
Previously it would run the query with no column specification, resulting in the following error:

```
No columns found for table or view 'TestSchema.Missing'. The table or view likely does not exist in that schema.", but "Error while executing SQL command in transaction 'NonParallelWorker': Incorrect syntax near the keyword 'FROM'.
The command being executed was:
SELECT 
FROM [TestSchema].[Missing]
ORDER BY [Id]
```