### PR TITLE
Re-enable the querying of views

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/ViewMappingFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ViewMappingFixture.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.Mapping;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class ViewMappingFixture : FixtureWithRelationalStore
+    {
+        class ExtinctAnimal
+        {
+            public string Name { get; set; }
+            public int LivedInMillionsAgo { get; set; }
+            public string Class { get; set; }
+        }
+
+        class ExtinctAnimalMap : DocumentMap<ExtinctAnimal>
+        {
+            public ExtinctAnimalMap()
+            {
+                Id(u => u.Name);
+                Column(u => u.LivedInMillionsAgo);
+                Column(u => u.Class);
+                JsonStorageFormat = JsonStorageFormat.NoJson;
+            }
+        }
+
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+
+            NoMonkeyBusiness();
+
+            ExecuteSql(@"create view TestSchema.ExtinctAnimal as 
+                            select 
+	                            'Longisquama' as 'Name',
+	                            242 as 'LivedInMillionsAgo',
+	                            'Reptilia' as 'Class'
+                            union
+                            select 
+	                            'Helicoprion' as 'Name',
+	                            290 as 'LivedInMillionsAgo',
+	                            'Chondrichthyes' as 'Class' 
+                            ");
+            Configuration.DocumentMaps.Register(new ExtinctAnimalMap());
+        }
+
+        [Test]
+        public void ShouldLoad()
+        {
+            using var transaction = Store.BeginTransaction();
+
+            var animals = transaction.Query<ExtinctAnimal>().ToArray();
+            animals.Should().BeEquivalentTo(
+                new[]
+                {
+                    new ExtinctAnimal()
+                    {
+                        Name = "Longisquama",
+                        LivedInMillionsAgo = 242,
+                        Class = "Reptilia"
+                    },
+                    new ExtinctAnimal()
+                    {
+                        Name = "Helicoprion",
+                        LivedInMillionsAgo = 290,
+                        Class = "Chondrichthyes"
+                    }
+                }
+            );
+        }
+    }
+}

--- a/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
@@ -19,7 +19,11 @@ namespace Nevermore.TableColumnNameResolvers
 
             var getColumnNamesWithJsonLastQuery = @$"
 SELECT c.name
-FROM sys.tables AS t
+FROM (
+    SELECT object_id, schema_id, name FROM sys.tables
+    UNION ALL 
+    SELECT object_id, schema_id, name FROM sys.views
+) as t
 INNER JOIN sys.all_columns AS c ON c.object_id = t.object_id
 INNER JOIN sys.schemas AS s ON t.schema_id = s.schema_id
 WHERE t.name = @tableName {schemaClause}


### PR DESCRIPTION
In Nevermore 15.0.1 (Jul 2021) and earlier it was possible to map and query a view. However with the change where it looks at the schema for what columns exist, it fails to add columns to the query (despite them being included in the mapping).

This re-enabled this functionality and allows for querying of views.

Let me know if there is a different preferred way to query views.