### PR TITLE
Change default TableColumnNameResolver back to Select All

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.TableColumnNameResolvers;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class JsonLastTableColumnResolverFixture : FixtureWithRelationalStore
+    {
+        public override void OneTimeSetUp()
+        {
+            base.OneTimeSetUp();
+            NoMonkeyBusiness();
+            Configuration.TableColumnNameResolver = executor => new JsonLastTableColumnNameResolver(executor);
+        }
+
+        [Test]
+        public void ShouldSelectAllColumnNamesWithJsonLast()
+        {
+            using var readTransaction = Store.BeginReadTransaction();
+            var selectQuery = readTransaction.Query<Customer>().DebugViewRawQuery();
+
+            selectQuery.Should().Be($"SELECT Id,FirstName,LastName,Nickname,Roles,Balance,IsVip,JSON{Environment.NewLine}FROM [TestSchema].[Customer]{Environment.NewLine}ORDER BY [Id]");
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/MissingTableFixture.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using Nevermore.IntegrationTests.SetUp;
 using Nevermore.Mapping;
+using Nevermore.TableColumnNameResolvers;
 using NUnit.Framework;
 
 namespace Nevermore.IntegrationTests.Advanced
@@ -26,6 +27,7 @@ namespace Nevermore.IntegrationTests.Advanced
             base.OneTimeSetUp();
             NoMonkeyBusiness();
             Configuration.DocumentMaps.Register(new MissingMap());
+            Configuration.TableColumnNameResolver = queryExecutor => new JsonLastTableColumnNameResolver(queryExecutor);
         }
 
         [Test]

--- a/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
+++ b/source/Nevermore.IntegrationTests/SetUp/SchemaGenerator.cs
@@ -17,14 +17,12 @@ namespace Nevermore.IntegrationTests.SetUp
             var identity = mapping.IsIdentityId ? " IDENTITY(1,1)" : null;
             result.Append($"  [Id] {GetDatabaseType(mapping.IdColumn)}{identity} NOT NULL CONSTRAINT [PK_{tableName}_Id] PRIMARY KEY CLUSTERED, ").AppendLine();
 
-            // purposely put the [JSON] column second as we want to ensure that tables don't have to be created
-            // with the type before the [JSON] column as was a previous restriction
-            result.AppendFormat("  [JSON] NVARCHAR(MAX) NOT NULL").AppendLine(); 
-            
             foreach (var column in mapping.WritableIndexedColumns())
             {
-                result.AppendFormat("  ,[{0}] {1} {2} ", column.ColumnName, GetDatabaseType(column).ToUpperInvariant(), IsNullable(column) ? "NULL" : "NOT NULL").AppendLine();
+                result.AppendFormat("  [{0}] {1} {2}, ", column.ColumnName, GetDatabaseType(column).ToUpperInvariant(), IsNullable(column) ? "NULL" : "NOT NULL").AppendLine();
             }
+            
+            result.AppendFormat("  [JSON] NVARCHAR(MAX) NOT NULL").AppendLine(); 
 
             if (mapping.IsRowVersioningEnabled)
                 result.Append("  ,[RowVersion] TIMESTAMP").AppendLine();

--- a/source/Nevermore.Tests/CachingTableColumnNamesFixture.cs
+++ b/source/Nevermore.Tests/CachingTableColumnNamesFixture.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Nevermore.TableColumnNameResolvers;
+using NUnit.Framework;
+
+namespace Nevermore.Tests
+{
+    public class CachingTableColumnNamesFixture
+    {
+        class MockTableNameResolverForCaching : ITableColumnNameResolver
+        {
+            public static int TimesQueried;
+            
+            readonly Dictionary<string, string[]> tableToColumnNames;
+
+            public MockTableNameResolverForCaching(Dictionary<string, string[]> tableToColumnNames)
+            {
+                this.tableToColumnNames = tableToColumnNames;
+            }
+            
+            public string[] GetColumnNames(string schemaName, string tableName)
+            {
+                TimesQueried++;
+                if (tableToColumnNames.ContainsKey(tableName))
+                {
+                    return tableToColumnNames[tableName];    
+                }
+
+                throw new Exception($"Column names for table {tableName} were not specified in creation");
+            }
+        }
+        
+        [Test]
+        public void ShouldCacheColumnNameForSchema()
+        {
+            const string tableName = "VideoGame";
+            var columnNames = new[] {"Title", "Genre", "ReleaseDate"};
+            
+            var tableCache = new TableColumnsCache();
+            var map = new Dictionary<string, string[]>();
+            map.Add(tableName, columnNames);
+            var cachingColumnNameResolvers = new CachingTableColumnNameResolver(
+                new MockTableNameResolverForCaching(map), tableCache);
+            
+            var columns = cachingColumnNameResolvers.GetColumnNames("", tableName);
+            columns.Should().BeEquivalentTo(columnNames);
+            
+            // Query again to hit the caching
+            cachingColumnNameResolvers.GetColumnNames("", tableName);
+            columns.Should().BeEquivalentTo(columnNames);
+            
+            MockTableNameResolverForCaching.TimesQueried.Should().Be(1);
+        }
+    }
+}

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -17,14 +17,12 @@ namespace Nevermore
     {
         readonly Lazy<RelationalTransactionRegistry> registry;
         readonly Lazy<KeyAllocator> keyAllocator;
-        readonly ITableColumnsCache tableColumnsCache;
 
         public RelationalStore(IRelationalStoreConfiguration configuration)
         {
             Configuration = configuration;
             registry = new Lazy<RelationalTransactionRegistry>(() => new RelationalTransactionRegistry(new SqlConnectionStringBuilder(configuration.ConnectionString)));
             keyAllocator = new Lazy<KeyAllocator>(() => new KeyAllocator(this, configuration.KeyBlockSize));
-            tableColumnsCache = new TableColumnsCache();
         }
 
         public void WriteCurrentTransactions(StringBuilder output) => registry.Value.WriteCurrentTransactions(output);

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -50,8 +50,7 @@ namespace Nevermore
 
             DocumentMaps = new DocumentMapRegistry(PrimaryKeyHandlers);
 
-            var tableColumnsCache = new TableColumnsCache();
-            TableColumnNameResolver = queryExecutor => new CachingTableColumnNameResolver(new JsonLastTableColumnNameResolver(queryExecutor), tableColumnsCache);
+            TableColumnNameResolver = _ => new SelectAllColumnsTableResolver();
 
             AllowSynchronousOperations = true;
 

--- a/source/Nevermore/TableColumnNameResolvers/CachingTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/CachingTableColumnNameResolver.cs
@@ -2,7 +2,7 @@
 
 namespace Nevermore.TableColumnNameResolvers
 {
-    internal class CachingTableColumnNameResolver : ITableColumnNameResolver
+    public class CachingTableColumnNameResolver : ITableColumnNameResolver
     {
         readonly ITableColumnNameResolver inner;
         readonly ITableColumnsCache tableColumnsCache;

--- a/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Nevermore.TableColumnNameResolvers
 {
-    internal class JsonLastTableColumnNameResolver : ITableColumnNameResolver
+    public class JsonLastTableColumnNameResolver : ITableColumnNameResolver
     {
         readonly IReadQueryExecutor queryExecutor;
 


### PR DESCRIPTION
Previously in https://github.com/OctopusDeploy/Nevermore/pull/169 we changed the default behaviour of Nevermore to use a JSON last column table name resolver, which means queries would look like:

`SELECT Name,Age,Type,JSON FROM Person` instead of `SELECT * FROM Person` to avoid the issue of having to have the JSON column last when using the Type column in a polymorphic document structure.

After some discussion https://octopusdeploy.slack.com/archives/C020HNMNT3L/p1643763058763589 (internal link), I proposed that having this as the default behaviour probably isn't correct https://octopusdeploy.slack.com/archives/C02KHED7RRU/p1643837352093699 (internal link), and we're going back to the previous behaviour, with us overriding that in Octopus Server where we needed this change. 

Since we no longer have json last or caching as our default, I've added some tests around their behaviour.

Possible concerns: We had an issue with this behaviour around scoping https://github.com/OctopusDeploy/Nevermore/pull/175 . It's possible we could fall back into this issue. We will need to be careful when re-implementing in Octopus Server. 

- [x] Update the docs (https://github.com/OctopusDeploy/Nevermore/wiki/Configuration#table-column-name-resolver) around the usage of changing the default behaviour of `TableColumnNameResolver`  