### PR TITLE
Make TableColumnsCache public

### DIFF
--- a/source/Nevermore/TableColumnsCache.cs
+++ b/source/Nevermore/TableColumnsCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 
 namespace Nevermore
 {
-    internal class TableColumnsCache : ConcurrentDictionary<string, string[]>, ITableColumnsCache
+    public class TableColumnsCache : ConcurrentDictionary<string, string[]>, ITableColumnsCache
     {
         public string[] GetOrAdd(string schemaName, string tableName, Func<string, string, string[]> valueFactory)
         {


### PR DESCRIPTION
Change `TableColumnsCache` from internal to public, as it can be used with our public contract `CachingTableColumnNameResolver`.