### PR TITLE
Thread-safe access to Nevermore transaction objects.

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -44,12 +44,31 @@ namespace Nevermore.IntegrationTests.Advanced
                     .WithDegreeOfParallelism(512)
                     .Select(i =>
                     {
-                        // ReSharper disable once AccessToDisposedClosure
+                        // ReSharper disable AccessToDisposedClosure
+                        // ReSharper disable ReturnValueOfPureMethodIsNotUsed
+
                         var documents = transaction.Query<DocumentWithIdentityId>()
                             .Where(x => x.Name.StartsWith(namePrefix))
                             .ToArray();
                         documents.Should().HaveCount(numberOfDocuments);
+
+                        var id = documents.First().Id;
+                        var ids = documents.Select(d => d.Id).ToArray();
+
+                         transaction.Load<DocumentWithIdentityId>(id);
+                         transaction.LoadRequired<DocumentWithIdentityId>(id);
+                         transaction.LoadMany<DocumentWithIdentityId>(ids);
+                         transaction.LoadManyRequired<DocumentWithIdentityId>(ids);
+                         transaction.Query<DocumentWithIdentityId>().Any();
+                         transaction.Query<DocumentWithIdentityId>().Count();
+                         transaction.Query<DocumentWithIdentityId>().ToList();
+                         transaction.Query<DocumentWithIdentityId>().ToArray();
+                         transaction.Query<DocumentWithIdentityId>().FirstOrDefault();
+                         transaction.Query<DocumentWithIdentityId>().ToDictionary(x => x.Id.ToString());
+
                         return 0;
+                        // ReSharper restore ReturnValueOfPureMethodIsNotUsed
+                        // ReSharper restore AccessToDisposedClosure
                     })
                     .ToArray();
             }
@@ -80,11 +99,29 @@ namespace Nevermore.IntegrationTests.Advanced
                 await Enumerable.Range(0, 64)
                     .Select(async i =>
                     {
-                        // ReSharper disable once AccessToDisposedClosure
+                        // ReSharper disable AccessToDisposedClosure
+                        // ReSharper disable ReturnValueOfPureMethodIsNotUsed
                         var documents = await transaction.Query<DocumentWithIdentityId>()
                             .Where(x => x.Name.StartsWith(namePrefix))
                             .ToListAsync();
                         documents.Should().HaveCount(numberOfDocuments);
+
+                        var id = documents.First().Id;
+                        var ids = documents.Select(d => d.Id).ToArray();
+
+                        await transaction.LoadAsync<DocumentWithIdentityId>(id);
+                        await transaction.LoadRequiredAsync<DocumentWithIdentityId>(id);
+                        await transaction.LoadManyAsync<DocumentWithIdentityId>(ids);
+                        await transaction.LoadManyRequiredAsync<DocumentWithIdentityId>(ids);
+                        await transaction.Query<DocumentWithIdentityId>().AnyAsync();
+                        await transaction.Query<DocumentWithIdentityId>().CountAsync();
+                        await transaction.Query<DocumentWithIdentityId>().ToListAsync();
+                        await transaction.Query<DocumentWithIdentityId>().FirstOrDefaultAsync();
+                        await transaction.Query<DocumentWithIdentityId>().ToListWithCountAsync(0,numberOfDocuments);
+                        await transaction.Query<DocumentWithIdentityId>().ToDictionaryAsync(x => x.Id.ToString());
+
+                        // ReSharper restore ReturnValueOfPureMethodIsNotUsed
+                        // ReSharper restore AccessToDisposedClosure
                     })
                     .WhenAll();
             }

--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -13,7 +13,7 @@ namespace Nevermore.IntegrationTests.Advanced
 {
     public class ConcurrentAccessFixture : FixtureWithRelationalStore
     {
-        const int NumberOfDocuments = 100;
+        const int NumberOfDocuments = 256;
         const int DegreeOfParallelism = NumberOfDocuments;
 
         [Test]

--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -12,7 +12,7 @@ namespace Nevermore.IntegrationTests.Advanced
     public class ConcurrentAccessFixture : FixtureWithRelationalStore
     {
         const int NumberOfDocuments = 100;
-        const int DegreeOfParallelism = 512;
+        const int DegreeOfParallelism = NumberOfDocuments;
 
         [Test]
         public void ConcurrentAccessDoesNotGoBoom()

--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using Nito.AsyncEx;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class ConcurrentAccessFixture : FixtureWithRelationalStore
+    {
+        [Test]
+        public void ConcurrentAccessDoesNotGoBoom()
+        {
+            NoMonkeyBusiness();
+
+            var namePrefix = $"{Guid.NewGuid()}-";
+            const int numberOfDocuments = 100;
+
+            // Create a bunch of documents so that we can query for them.
+            using (var transaction = Store.BeginTransaction())
+            {
+                Enumerable.Range(0, numberOfDocuments)
+                    .Select(i => new DocumentWithIdentityId {Name = $"{namePrefix}{i}"})
+                    .AsParallel()
+                    .WithDegreeOfParallelism(512)
+                    .Select(document =>
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        transaction.Insert(document);
+                        return 0;
+                    })
+                    .ToArray();
+                transaction.Commit();
+            }
+
+            // Now hit it really hard and see if we can provoke a failure.
+            using (var transaction = Store.BeginTransaction())
+            {
+                Enumerable.Range(0, 64)
+                    .AsParallel()
+                    .WithDegreeOfParallelism(512)
+                    .Select(i =>
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        var documents = transaction.Query<DocumentWithIdentityId>()
+                            .Where(x => x.Name.StartsWith(namePrefix))
+                            .ToArray();
+                        documents.Should().HaveCount(numberOfDocuments);
+                        return 0;
+                    })
+                    .ToArray();
+            }
+        }
+
+        [Test]
+        public async Task AsyncConcurrentAccessDoesNotGoBoom()
+        {
+            NoMonkeyBusiness();
+
+            var namePrefix = $"{Guid.NewGuid()}-";
+            const int numberOfDocuments = 100;
+
+            // Create a bunch of documents so that we can query for them.
+            using (var transaction = await Store.BeginWriteTransactionAsync())
+            {
+                await Enumerable.Range(0, numberOfDocuments)
+                    .Select(i => new DocumentWithIdentityId {Name = $"{namePrefix}{i}"})
+                    // ReSharper disable once AccessToDisposedClosure
+                    .Select(document => transaction.InsertAsync(document))
+                    .WhenAll();
+                await transaction.CommitAsync();
+            }
+
+            // Now hit it really hard and see if we can provoke a failure.
+            using (var transaction = await Store.BeginWriteTransactionAsync())
+            {
+                await Enumerable.Range(0, 64)
+                    .Select(async i =>
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        var documents = await transaction.Query<DocumentWithIdentityId>()
+                            .Where(x => x.Name.StartsWith(namePrefix))
+                            .ToListAsync();
+                        documents.Should().HaveCount(numberOfDocuments);
+                    })
+                    .WhenAll();
+            }
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -25,13 +25,13 @@ namespace Nevermore.IntegrationTests.Advanced
             using (var transaction = Store.BeginTransaction())
             {
                 Enumerable.Range(0, NumberOfDocuments)
-                    .Select(i => new DocumentWithIdentityId {Name = $"{namePrefix}{i}"})
+                    .Select(i => new DocumentWithIdentityId { Name = $"{namePrefix}{i}" })
                     .AsParallel()
-                    .WithDegreeOfParallelism(512)
+                    .WithDegreeOfParallelism(DegreeOfParallelism)
                     .Select(document =>
                     {
-                        // ReSharper disable once AccessToDisposedClosure
-                        transaction.Insert(document);
+                            // ReSharper disable once AccessToDisposedClosure
+                            transaction.Insert(document);
                         return 0;
                     })
                     .ToArray();
@@ -46,10 +46,10 @@ namespace Nevermore.IntegrationTests.Advanced
                     .WithDegreeOfParallelism(DegreeOfParallelism)
                     .Select(i =>
                     {
-                        // ReSharper disable AccessToDisposedClosure
-                        // ReSharper disable ReturnValueOfPureMethodIsNotUsed
+                            // ReSharper disable AccessToDisposedClosure
+                            // ReSharper disable ReturnValueOfPureMethodIsNotUsed
 
-                        var documents = transaction.Query<DocumentWithIdentityId>()
+                            var documents = transaction.Query<DocumentWithIdentityId>()
                             .Where(x => x.Name.StartsWith(namePrefix))
                             .ToArray();
                         documents.Should().HaveCount(NumberOfDocuments);
@@ -69,9 +69,9 @@ namespace Nevermore.IntegrationTests.Advanced
                         transaction.Query<DocumentWithIdentityId>().ToDictionary(x => x.Id.ToString());
 
                         return 0;
-                        // ReSharper restore ReturnValueOfPureMethodIsNotUsed
-                        // ReSharper restore AccessToDisposedClosure
-                    })
+                            // ReSharper restore ReturnValueOfPureMethodIsNotUsed
+                            // ReSharper restore AccessToDisposedClosure
+                        })
                     .ToArray();
             }
         }
@@ -87,7 +87,7 @@ namespace Nevermore.IntegrationTests.Advanced
             using (var transaction = await Store.BeginWriteTransactionAsync())
             {
                 await Enumerable.Range(0, NumberOfDocuments)
-                    .Select(i => new DocumentWithIdentityId {Name = $"{namePrefix}{i}"})
+                    .Select(i => new DocumentWithIdentityId { Name = $"{namePrefix}{i}" })
                     // ReSharper disable once AccessToDisposedClosure
                     .Select(document => transaction.InsertAsync(document))
                     .WhenAll();

--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -30,8 +30,8 @@ namespace Nevermore.IntegrationTests.Advanced
                     .WithDegreeOfParallelism(DegreeOfParallelism)
                     .Select(document =>
                     {
-                            // ReSharper disable once AccessToDisposedClosure
-                            transaction.Insert(document);
+                        // ReSharper disable once AccessToDisposedClosure
+                        transaction.Insert(document);
                         return 0;
                     })
                     .ToArray();
@@ -46,15 +46,16 @@ namespace Nevermore.IntegrationTests.Advanced
                     .WithDegreeOfParallelism(DegreeOfParallelism)
                     .Select(i =>
                     {
-                            // ReSharper disable AccessToDisposedClosure
-                            // ReSharper disable ReturnValueOfPureMethodIsNotUsed
+                        // ReSharper disable AccessToDisposedClosure
+                        // ReSharper disable ReturnValueOfPureMethodIsNotUsed
 
-                            var documents = transaction.Query<DocumentWithIdentityId>()
+                        var documents = transaction.Query<DocumentWithIdentityId>()
                             .Where(x => x.Name.StartsWith(namePrefix))
                             .ToArray();
                         documents.Should().HaveCount(NumberOfDocuments);
 
-                        var id = documents.First().Id;
+                        var firstDocument = documents.First();
+                        var id = firstDocument.Id;
                         var ids = documents.Select(d => d.Id).ToArray();
 
                         transaction.Load<DocumentWithIdentityId>(id);
@@ -67,11 +68,18 @@ namespace Nevermore.IntegrationTests.Advanced
                         transaction.Query<DocumentWithIdentityId>().ToArray();
                         transaction.Query<DocumentWithIdentityId>().FirstOrDefault();
                         transaction.Query<DocumentWithIdentityId>().ToDictionary(x => x.Id.ToString());
+                        transaction.Queryable<DocumentWithIdentityId>().Any();
+                        transaction.Queryable<DocumentWithIdentityId>().Count();
+                        transaction.Queryable<DocumentWithIdentityId>().ToList();
+                        transaction.Queryable<DocumentWithIdentityId>().ToArray();
+                        transaction.Queryable<DocumentWithIdentityId>().FirstOrDefault();
+                        transaction.Queryable<DocumentWithIdentityId>().ToDictionary(x => x.Id.ToString());
+                        transaction.Update(firstDocument);
 
                         return 0;
-                            // ReSharper restore ReturnValueOfPureMethodIsNotUsed
-                            // ReSharper restore AccessToDisposedClosure
-                        })
+                        // ReSharper restore ReturnValueOfPureMethodIsNotUsed
+                        // ReSharper restore AccessToDisposedClosure
+                    })
                     .ToArray();
             }
         }
@@ -107,7 +115,8 @@ namespace Nevermore.IntegrationTests.Advanced
                             .ToListAsync();
                         documents.Should().HaveCount(NumberOfDocuments);
 
-                        var id = documents.First().Id;
+                        var firstDocument = documents.First();
+                        var id = firstDocument.Id;
                         var ids = documents.Select(d => d.Id).ToArray();
 
                         await transaction.LoadAsync<DocumentWithIdentityId>(id);
@@ -120,6 +129,7 @@ namespace Nevermore.IntegrationTests.Advanced
                         await transaction.Query<DocumentWithIdentityId>().FirstOrDefaultAsync();
                         await transaction.Query<DocumentWithIdentityId>().ToListWithCountAsync(0, NumberOfDocuments);
                         await transaction.Query<DocumentWithIdentityId>().ToDictionaryAsync(x => x.Id.ToString());
+                        await transaction.UpdateAsync(firstDocument);
 
                         // ReSharper restore ReturnValueOfPureMethodIsNotUsed
                         // ReSharper restore AccessToDisposedClosure

--- a/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
@@ -13,7 +13,7 @@ namespace Nevermore.IntegrationTests.Advanced
         {
             base.OneTimeSetUp();
             NoMonkeyBusiness();
-            Configuration.TableColumnNameResolver = executor => new JsonLastTableColumnNameResolver(executor);
+            Configuration.TableColumnNameResolver = executor => new JsonLastTableColumnNameResolver(Store);
         }
 
         [Test]

--- a/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/JsonLastTableColumnResolverFixture.cs
@@ -24,5 +24,34 @@ namespace Nevermore.IntegrationTests.Advanced
 
             selectQuery.Should().Be($"SELECT Id,FirstName,LastName,Nickname,Roles,Balance,IsVip,JSON{Environment.NewLine}FROM [TestSchema].[Customer]{Environment.NewLine}ORDER BY [Id]");
         }
+
+        [Test]
+        public void ShouldNotDeadlockWhenRunningAQuery()
+        {
+            // We need at least one customer in the database so that we can trigger another operation while
+            // we're streaming records.
+            using (var writeTransaction = Store.BeginWriteTransaction(retriableOperation: RetriableOperation.None))
+            {
+                var id = writeTransaction.AllocateId<CustomerId>(typeof(Customer));
+                writeTransaction.Insert(new Customer {Id = id});
+                writeTransaction.Commit();
+            }
+
+            using var readTransaction = Store.BeginReadTransaction();
+
+            var customersQuery = readTransaction.Query<Customer>();
+            var customers = customersQuery.Stream();
+
+            foreach (var _ in customers)
+            {
+                // Now that we already have a lock on our queryable, attempt to start building (not running; just building)
+                // another query. This should _not_ provoke a deadlock but if we're hanging here then that means we have one.
+                var brandsQuery = readTransaction.Query<Brand>().Subquery().Alias("b");
+
+                // Attempting to enumerate this _should_ genuinely result in a deadlock as we already have a lock on a reader,
+                // so all we're really asserting here is that the compiler didn't somehow optimize this call away.
+                brandsQuery.Should().NotBeNull();
+            }
+        }
     }
 }

--- a/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
+++ b/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nevermore.Advanced;
+using NUnit.Framework;
+
+namespace Nevermore.Tests
+{
+    public class DeadlockAwareLockFixture
+    {
+        CancellationToken cancellationToken;
+        CancellationTokenSource cts;
+
+        [SetUp]
+        public void SetUp()
+        {
+            cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            cancellationToken = cts.Token;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            cts?.Dispose();
+        }
+
+        [Test]
+        public void MultipleCallsToWait_ShouldThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            deadlockAwareLock.Wait();
+
+            // The second call should immediately throw rather than waiting forever.
+            Assert.Throws<DeadlockException>(() => deadlockAwareLock.Wait());
+        }
+
+        [Test]
+        public void MultipleCallsToWaitWithinATask_ShouldThrow()
+        {
+            Task.Run(() =>
+                {
+                    // ReSharper disable AccessToDisposedClosure
+                    using var deadlockAwareLock = new DeadlockAwareLock();
+
+                    deadlockAwareLock.Wait();
+
+                    // The second call should immediately throw rather than waiting forever.
+                    Assert.Throws<DeadlockException>(() => deadlockAwareLock.Wait());
+
+                    // ReSharper restore AccessToDisposedClosure
+                }, cancellationToken)
+                .Wait(cancellationToken);
+        }
+
+        [Test]
+        public void AcquiringThenReleasingThenAcquiring_ShouldNotThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            deadlockAwareLock.Wait();
+            deadlockAwareLock.Release();
+            deadlockAwareLock.Wait();
+        }
+
+        [Test]
+        public void AcquiringThenReleasingThenAcquiringInATask_ShouldNotThrow()
+        {
+            Task.Run(() =>
+                {
+                    // ReSharper disable AccessToDisposedClosure
+                    using var deadlockAwareLock = new DeadlockAwareLock();
+
+                    deadlockAwareLock.Wait();
+                    deadlockAwareLock.Release();
+                    deadlockAwareLock.Wait();
+
+                    // ReSharper restore AccessToDisposedClosure
+                }, cancellationToken)
+                .Wait(cancellationToken);
+        }
+
+        [Test]
+        public async Task MultipleCallsToWaitAsync_ShouldThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            await deadlockAwareLock.WaitAsync(cancellationToken);
+
+            // The second call should immediately throw rather than waiting forever.
+            Assert.ThrowsAsync<DeadlockException>(async () => await deadlockAwareLock.WaitAsync(cancellationToken));
+        }
+
+        [Test]
+        public async Task AcquiringAsyncThenReleasingThenAcquiringAsync_ShouldNotThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            await deadlockAwareLock.WaitAsync(cancellationToken);
+            deadlockAwareLock.Release();
+            await deadlockAwareLock.WaitAsync(cancellationToken);
+        }
+
+        [Test]
+        public async Task MultipleTasksContending_ShouldNotThrow()
+        {
+            // ReSharper disable AccessToDisposedClosure
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            // Loop so that we increase the probability that two different tasks are scheduled onto
+            // the same worker thread. This helps us guarantee that we're not accidentally relying
+            // on thread IDs or thread locals anywhere.
+            for (var i = 0; i < 1000; i++)
+            {
+                var task0 = Task.Run(async () =>
+                {
+                    await deadlockAwareLock.WaitAsync(cancellationToken);
+                    await Task.Yield();
+                    deadlockAwareLock.Release();
+                }, cancellationToken);
+
+                var task1 = Task.Run(async () =>
+                {
+                    await deadlockAwareLock.WaitAsync(cancellationToken);
+                    await Task.Yield();
+                    deadlockAwareLock.Release();
+                }, cancellationToken);
+
+                await Task.WhenAll(task0, task1);
+            }
+
+            // ReSharper restore AccessToDisposedClosure
+        }
+    }
+}

--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -1,12 +1,20 @@
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nevermore.Advanced
 {
+    /// <summary>
+    ///     This class provides a best-effort deadlock detection mechanism. It will identify re-entrant calls from the same
+    ///     task (if there is a task) or the same thread (if there is no task). While it does not _guarantee_ deadlock
+    ///     detection,
+    ///     it does provide a pretty good guarantee that _if_ a DeadlockException is thrown then there was almost certainly
+    ///     going to be a deadlock. In other words: very few false positives; probably some false negatives; better than
+    ///     nothing.
+    /// </summary>
     public class DeadlockAwareLock : SemaphoreSlim
     {
         int? taskWhichAsAcquiredLock;
-
         int? threadWhichHasAcquiredLock;
 
         public DeadlockAwareLock() : base(1, 1)
@@ -27,31 +35,41 @@ namespace Nevermore.Advanced
             RecordLockAcquisition();
         }
 
-        void AssertNoDeadlock()
-        {
-            if (taskWhichAsAcquiredLock is not null)
-            {
-                if (taskWhichAsAcquiredLock == Task.CurrentId) throw new DeadlockException("This task context has already acquired this lock and has attempted to do so again.");
-            }
-            else
-            {
-                if (threadWhichHasAcquiredLock is not null)
-                    if (threadWhichHasAcquiredLock == Thread.CurrentThread.ManagedThreadId)
-                        throw new DeadlockException("This thread has already acquired this lock and has attempted to do so again.");
-            }
-        }
-
-        void RecordLockAcquisition()
-        {
-            threadWhichHasAcquiredLock = Thread.CurrentThread.ManagedThreadId;
-            taskWhichAsAcquiredLock = Task.CurrentId;
-        }
-
         public new void Release()
         {
             threadWhichHasAcquiredLock = null;
             taskWhichAsAcquiredLock = null;
             base.Release();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void AssertNoDeadlock()
+        {
+            if (taskWhichAsAcquiredLock is not null)
+            {
+                // If we have a task then we can rely on the task ID. It's not guaranteed (one task can still spawn another) but it's better than nothing.
+                // If it's a different task which has acquired the lock then there's at least _some_ hope that that task might complete without requiring
+                // this task to complete. If this task has the lock and is attempting to acquire it again then there's no way out - deadlock.
+                if (taskWhichAsAcquiredLock == Task.CurrentId)
+                    throw new DeadlockException("This task context has already acquired this lock and has attempted to do so again.");
+            }
+            else
+            {
+                // If we have no task then our best guess is that we're using sync-only code, which means that the thread ID _should_ be
+                // a good indicator of the call context.
+                if (threadWhichHasAcquiredLock is not null)
+                    // If this thread has already acquired a lock and it's trying to do so again then
+                    // it's very unlikely that the first lock will be released, hence deadlock.
+                    if (threadWhichHasAcquiredLock == Thread.CurrentThread.ManagedThreadId)
+                        throw new DeadlockException("This thread has already acquired this lock and has attempted to do so again.");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void RecordLockAcquisition()
+        {
+            threadWhichHasAcquiredLock = Thread.CurrentThread.ManagedThreadId;
+            taskWhichAsAcquiredLock = Task.CurrentId;
         }
     }
 }

--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nevermore.Advanced
+{
+    public class DeadlockAwareLock : SemaphoreSlim
+    {
+        int? taskWhichAsAcquiredLock;
+
+        int? threadWhichHasAcquiredLock;
+
+        public DeadlockAwareLock() : base(1, 1)
+        {
+        }
+
+        public new void Wait()
+        {
+            AssertNoDeadlock();
+            base.Wait();
+            RecordLockAcquisition();
+        }
+
+        public new async Task WaitAsync(CancellationToken cancellationToken)
+        {
+            AssertNoDeadlock();
+            await base.WaitAsync(cancellationToken);
+            RecordLockAcquisition();
+        }
+
+        void AssertNoDeadlock()
+        {
+            if (taskWhichAsAcquiredLock is not null)
+            {
+                if (taskWhichAsAcquiredLock == Task.CurrentId) throw new DeadlockException("This task context has already acquired this lock and has attempted to do so again.");
+            }
+            else
+            {
+                if (threadWhichHasAcquiredLock is not null)
+                    if (threadWhichHasAcquiredLock == Thread.CurrentThread.ManagedThreadId)
+                        throw new DeadlockException("This thread has already acquired this lock and has attempted to do so again.");
+            }
+        }
+
+        void RecordLockAcquisition()
+        {
+            threadWhichHasAcquiredLock = Thread.CurrentThread.ManagedThreadId;
+            taskWhichAsAcquiredLock = Task.CurrentId;
+        }
+
+        public new void Release()
+        {
+            threadWhichHasAcquiredLock = null;
+            taskWhichAsAcquiredLock = null;
+            base.Release();
+        }
+    }
+}

--- a/source/Nevermore/Advanced/DeadlockException.cs
+++ b/source/Nevermore/Advanced/DeadlockException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nevermore.Advanced
+{
+    [Serializable]
+    public class DeadlockException : Exception
+    {
+        public DeadlockException()
+        {
+        }
+
+        public DeadlockException(string message) : base(message)
+        {
+        }
+
+        public DeadlockException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected DeadlockException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -18,6 +18,7 @@ using Nevermore.Diagnostics;
 using Nevermore.Querying.AST;
 using Nevermore.TableColumnNameResolvers;
 using Nevermore.Transient;
+using Nito.AsyncEx;
 
 namespace Nevermore.Advanced
 {
@@ -35,6 +36,7 @@ namespace Nevermore.Advanced
         SqlConnection? connection;
 
         protected IUniqueParameterNameGenerator ParameterNameGenerator { get; } = new UniqueParameterNameGenerator();
+        protected SemaphoreSlim Semaphore { get; } = new(1, 1);
 
         // To help track deadlocks
         readonly List<string> commandTrace;
@@ -438,16 +440,26 @@ namespace Nevermore.Advanced
 
         public IEnumerable<TRecord> Stream<TRecord>(PreparedCommand command)
         {
-            using var reader = ExecuteReader(command);
-            foreach (var item in ProcessReader<TRecord>(reader, command))
-                yield return item;
+            IEnumerable<TRecord> Execute()
+            {
+                using var reader = ExecuteReader(command);
+                foreach (var item in ProcessReader<TRecord>(reader, command))
+                    yield return item;
+            }
+
+            return new ThreadSafeEnumerable<TRecord>(Execute, Semaphore);
         }
 
-        public async IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand command, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public IAsyncEnumerable<TRecord> StreamAsync<TRecord>(PreparedCommand command, CancellationToken cancellationToken = default)
         {
-            await using var reader = await ExecuteReaderAsync(command, cancellationToken);
-            await foreach (var result in ProcessReaderAsync<TRecord>(reader, command, cancellationToken))
-                yield return result;
+            async IAsyncEnumerable<TRecord> Execute()
+            {
+                await using var reader = await ExecuteReaderAsync(command, cancellationToken);
+                await foreach (var result in ProcessReaderAsync<TRecord>(reader, command, cancellationToken))
+                    yield return result;
+            }
+
+            return new ThreadSafeAsyncEnumerable<TRecord>(Execute, Semaphore);
         }
 
         IEnumerable<TRecord> ProcessReader<TRecord>(DbDataReader reader, PreparedCommand command)
@@ -521,12 +533,14 @@ namespace Nevermore.Advanced
 
         public int ExecuteNonQuery(PreparedCommand preparedCommand)
         {
+            using var mutex = Semaphore.Lock();
             using var command = CreateCommand(preparedCommand);
             return command.ExecuteNonQuery();
         }
 
         public async Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default)
         {
+            using var mutex = await Semaphore.LockAsync(cancellationToken);
             using var command = CreateCommand(preparedCommand);
             return await command.ExecuteNonQueryAsync(cancellationToken);
         }
@@ -543,6 +557,7 @@ namespace Nevermore.Advanced
 
         public TResult ExecuteScalar<TResult>(PreparedCommand preparedCommand)
         {
+            using var mutex = Semaphore.Lock();
             using var command = CreateCommand(preparedCommand);
             var result = command.ExecuteScalar();
             if (result == DBNull.Value)
@@ -552,6 +567,7 @@ namespace Nevermore.Advanced
 
         public async Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default)
         {
+            using var mutex = await Semaphore.LockAsync(cancellationToken);
             using var command = CreateCommand(preparedCommand);
             var result = await command.ExecuteScalarAsync(cancellationToken);
             if (result == DBNull.Value)
@@ -583,12 +599,16 @@ namespace Nevermore.Advanced
 
         protected TResult[] ReadResults<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper)
         {
+            using var mutex = Semaphore.Lock();
+
             using var command = CreateCommand(preparedCommand);
             return command.ReadResults(mapper);
         }
 
         protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, Task<TResult>> mapper, CancellationToken cancellationToken)
         {
+            using var mutex = await Semaphore.LockAsync(cancellationToken);
+
             using var command = CreateCommand(preparedCommand);
             return await command.ReadResultsAsync(mapper, cancellationToken);
         }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -36,7 +36,7 @@ namespace Nevermore.Advanced
         SqlConnection? connection;
 
         protected IUniqueParameterNameGenerator ParameterNameGenerator { get; } = new UniqueParameterNameGenerator();
-        protected SemaphoreSlim Semaphore { get; } = new(1, 1);
+        protected DeadlockAwareLock Semaphore { get; } = new();
 
         // To help track deadlocks
         readonly List<string> commandTrace;

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -46,7 +46,7 @@ namespace Nevermore.Advanced
 
         public IDictionary<string, object> State { get; }
 
-        public ReadTransaction(RelationalTransactionRegistry registry, RetriableOperation operationsToRetry, IRelationalStoreConfiguration configuration, string? name = null)
+        public ReadTransaction(IRelationalStore store, RelationalTransactionRegistry registry, RetriableOperation operationsToRetry, IRelationalStoreConfiguration configuration, string? name = null)
         {
             State = new Dictionary<string, object>();
             this.registry = registry;
@@ -61,7 +61,7 @@ namespace Nevermore.Advanced
             this.name = transactionName;
             registry.Add(this);
 
-            columnNameResolver = configuration.TableColumnNameResolver(this);
+            columnNameResolver = configuration.TableColumnNameResolver(store);
         }
 
         protected DbTransaction? Transaction { get; private set; }

--- a/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
+++ b/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Nito.AsyncEx;
+
+namespace Nevermore.Advanced
+{
+    public class ThreadSafeAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+        readonly Func<IAsyncEnumerable<T>> innerFunc;
+        readonly SemaphoreSlim semaphore;
+
+        public ThreadSafeAsyncEnumerable(IAsyncEnumerable<T> inner, SemaphoreSlim semaphore) : this(() => inner, semaphore)
+        {
+        }
+
+        public ThreadSafeAsyncEnumerable(Func<IAsyncEnumerable<T>> innerFunc, SemaphoreSlim semaphore)
+        {
+            this.innerFunc = innerFunc;
+            this.semaphore = semaphore;
+        }
+
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
+        {
+            using var mutex = await semaphore.LockAsync(cancellationToken);
+            var inner = innerFunc();
+            await foreach (var item in inner.WithCancellation(cancellationToken)) yield return item;
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ThreadSafeEnumerable.cs
+++ b/source/Nevermore/Advanced/ThreadSafeEnumerable.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Nevermore.Advanced
+{
+    internal class ThreadSafeEnumerable<T> : IEnumerable<T>
+    {
+        readonly Func<IEnumerable<T>> innerFunc;
+        readonly SemaphoreSlim semaphore;
+
+        public ThreadSafeEnumerable(IEnumerable<T> inner, SemaphoreSlim semaphore) : this(() => inner, semaphore)
+        {
+        }
+
+        public ThreadSafeEnumerable(Func<IEnumerable<T>> innerFunc, SemaphoreSlim semaphore)
+        {
+            this.innerFunc = innerFunc;
+            this.semaphore = semaphore;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            semaphore.Wait();
+            var inner = innerFunc();
+            return new ThreadSafeEnumerator(inner.GetEnumerator(), () => semaphore.Release());
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        internal class ThreadSafeEnumerator : IEnumerator<T>
+        {
+            readonly IEnumerator<T> inner;
+            readonly Action onDisposed;
+
+            public ThreadSafeEnumerator(IEnumerator<T> inner, Action onDisposed)
+            {
+                this.inner = inner;
+                this.onDisposed = onDisposed;
+            }
+
+            public bool MoveNext()
+            {
+                var moveNext = inner.MoveNext();
+                return moveNext;
+            }
+
+            public void Reset()
+            {
+                inner.Reset();
+            }
+
+            public T Current => inner.Current;
+
+            object IEnumerator.Current => ((IEnumerator) inner).Current;
+
+            public void Dispose()
+            {
+                inner.Dispose();
+                onDisposed();
+            }
+        }
+    }
+}

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -125,8 +125,6 @@ namespace Nevermore.Advanced
 
         public async Task UpdateAsync<TDocument>(TDocument document, UpdateOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
-            using var mutex = await Semaphore.LockAsync(cancellationToken);
-
             var command = builder.PrepareUpdate(document, options);
             await configuration.Hooks.BeforeUpdateAsync(document, command.Mapping, this);
 

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -10,7 +10,6 @@ using Nevermore.Diagnostics;
 using Nevermore.Mapping;
 using Nevermore.Querying;
 using Nevermore.Util;
-using Nito.AsyncEx;
 
 namespace Nevermore.Advanced
 {
@@ -22,12 +21,13 @@ namespace Nevermore.Advanced
         readonly DataModificationQueryBuilder builder;
 
         public WriteTransaction(
+            IRelationalStore store,
             RelationalTransactionRegistry registry,
             RetriableOperation operationsToRetry,
             IRelationalStoreConfiguration configuration,
             IKeyAllocator keyAllocator,
             string name = null
-        ) : base(registry, operationsToRetry, configuration, name)
+        ) : base(store, registry, operationsToRetry, configuration, name)
         {
             this.configuration = configuration;
             this.keyAllocator = keyAllocator;

--- a/source/Nevermore/Advanced/WriteTransaction.cs
+++ b/source/Nevermore/Advanced/WriteTransaction.cs
@@ -10,6 +10,7 @@ using Nevermore.Diagnostics;
 using Nevermore.Mapping;
 using Nevermore.Querying;
 using Nevermore.Util;
+using Nito.AsyncEx;
 
 namespace Nevermore.Advanced
 {
@@ -124,6 +125,8 @@ namespace Nevermore.Advanced
 
         public async Task UpdateAsync<TDocument>(TDocument document, UpdateOptions options, CancellationToken cancellationToken = default) where TDocument : class
         {
+            using var mutex = await Semaphore.LockAsync(cancellationToken);
+
             var command = builder.PrepareUpdate(document, options);
             await configuration.Hooks.BeforeUpdateAsync(document, command.Mapping, this);
 

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -30,7 +30,7 @@ namespace Nevermore
         string DefaultSchema { get; set; }
 
         IDocumentMapRegistry DocumentMaps { get; }
-        public Func<IReadQueryExecutor, ITableColumnNameResolver> TableColumnNameResolver { get; set; }
+        public Func<IRelationalStore, ITableColumnNameResolver> TableColumnNameResolver { get; set; }
         IDocumentSerializer DocumentSerializer { get; set; }
         IReaderStrategyRegistry ReaderStrategies { get; }
         ITypeHandlerRegistry TypeHandlers { get; }

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -5,7 +5,6 @@ using System.Data.SqlClient;
 #else
 using Microsoft.Data.SqlClient;
 #endif
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
@@ -134,12 +133,12 @@ namespace Nevermore
 
         ReadTransaction CreateReadTransaction(RetriableOperation retriableOperation, string name)
         {
-            return new ReadTransaction(registry.Value, retriableOperation, Configuration, name);
+            return new ReadTransaction(this, registry.Value, retriableOperation, Configuration, name);
         }
 
         WriteTransaction CreateWriteTransaction(RetriableOperation retriableOperation, string name)
         {
-            return new WriteTransaction(registry.Value, retriableOperation, Configuration, keyAllocator.Value, name);
+            return new WriteTransaction(this, registry.Value, retriableOperation, Configuration, keyAllocator.Value, name);
         }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -73,7 +73,7 @@ namespace Nevermore
 
         public IDocumentMapRegistry DocumentMaps { get; set; }
         
-        public Func<IReadQueryExecutor, ITableColumnNameResolver> TableColumnNameResolver { get; set; }
+        public Func<IRelationalStore, ITableColumnNameResolver> TableColumnNameResolver { get; set; }
 
         public IDocumentSerializer DocumentSerializer { get; set; }
 


### PR DESCRIPTION
# Background

Applications consuming Nevermore transactions have previously not been able to perform concurrent operations on a single Nevermore transaction (unless, in some cases, MARS was emabled). This has led to operations which _should_ have been transactional being split into multiple transactions for mostly performance reasons, at the cost of atomicity.

E.g.

```
machines
  .Do(m => healthCheckService.CheckHealthFor(m))
  .Done()
// No worries, but also slow.
```
but simply adding `.AsParallel()` or a `Task.WhenAll(...)` equivalent for performance improvement is not feasible.
```
machines
  .AsParallel()  // Not going to end well.
  .Do(m => healthCheckService.CheckHealthFor(m))
  .Done()
```

This leads to constructs like this:
```
machines
  .AsParallel()
  .Do(m => {
    using var transaction = store.BeginTransaction();
    healthCheckService.CheckHealthFor(m, transaction);
    transaction.Commit();  // No longer actually transactional as every loop iteration gets its own transaction.
  })
  .Done();
```

This has a significant cost in terms of atomicity, especially when operations are expected to be audited with audit records being recorded in the same transaction.

It also has a cost in terms of the number of transactions and underlying `SqlConnection` objects being created and/or allocated from the connection pool, which significantly increases the probability of deadlock when pool resources are exhausted. Concrete example: creating a tenanted deployment in Octopus runs a transaction in parallel for each tenant for this exact non-thread-safe reason. With the default SQL connection pool size limit being 100, any tenanted deployment involving 100+ tenants is liable to deadlock.

# Results

This PR allows for the _appearance_ of concurrent operations, in that it creates thread safety when accessing a Nevermore transaction. It does not give _actual_ support for concurrent operations but it does make it safe to use a Nevermore transaction concurrently.

For the most part, truly concurrent SQL operations in downstream consuming applications seem to be quite rare. We have encountered quite a number of bugs where a Nevermore transaction actually was being used in parallel and it only occasionally failed, suggesting that the actual degree of parallelism was relatively low. This also made things quite difficult to debug as reproducing race/failure conditions is difficult when we don't know where they actually are and every single parallel piece of code becomes suspect.

Nevermore (or the underlying `SqlConnection`) would have previously thrown an exception about "multiple active data sets" when concurrent operations were performed. As a result of the locking around SQL command/query execution, this is no longer the case - which introduces the possibility of a deadlock instead. This is reasonably well resolved (but not perfectly) via the `DeadlockAwareLock` class uses for such a lock, which will throw a `DeadlockException` if the same thread or task attempts to perform interleaved operations, e.g. a nested `foreach` streaming two different resultsets.

# Quality

Two tests have been added, using transactions in parallel with a bunch of concurrent `Insert` and `InsertAsync` operations followed by all of the materialisation options (e.g. `.ToList()`, `.Count()`, `.Any()`, `.Stream()` and their respective async overloads.

ReSharper's "Run test until fail" feature has been used to stress-test these, with runs of 10+ minutes not yielding a failure.

<img width="418" alt="image" src="https://user-images.githubusercontent.com/375332/159189820-b2600ee3-81db-47a7-a873-a6ec6fea5120.png">
