### PR TITLE
Fix JSON Contract Resolver to support columns from base types

### DIFF
--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithBaseColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.InsertWithBaseColumns.approved.txt
@@ -1,0 +1,9 @@
+DECLARE @InsertedRows TABLE ([RowVersion] binary(8))
+INSERT INTO [dbo].[TestDocumentTbl]  ([Id], [BaseColumn], [DerivedColumn], [JSON]) OUTPUT inserted.[RowVersion] INTO @InsertedRows VALUES 
+(@Id, @BaseColumn, @DerivedColumn, @JSON)
+SELECT [RowVersion] FROM @InsertedRows
+
+@Id=New-Id
+@JSON={}
+@BaseColumn=Base
+@DerivedColumn=Derived

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithBaseColumns.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.UpdateWithBaseColumns.approved.txt
@@ -1,0 +1,6 @@
+UPDATE [dbo].[TestDocumentTbl]  SET [BaseColumn] = @BaseColumn, [DerivedColumn] = @DerivedColumn, [JSON] = @JSON OUTPUT inserted.RowVersion WHERE [Id] = @Id AND [RowVersion] = @RowVersion
+@Id=Doc-1
+@JSON={}
+@BaseColumn=Base
+@DerivedColumn=Derived
+@RowVersion=System.Byte[]

--- a/source/Nevermore/RelationalJsonContractResolver.cs
+++ b/source/Nevermore/RelationalJsonContractResolver.cs
@@ -38,7 +38,7 @@ namespace Nevermore
                 }
 
                 // Indexed properties are stored as columns
-                if (map?.Columns.Any(c => c?.Property.Name == member.Name) ?? false)
+                if (map?.Columns.Any(c => c.Property?.Name == member.Name) ?? false)
                 {
                     property.Ignored = true;
                 }

--- a/source/Nevermore/RelationalJsonContractResolver.cs
+++ b/source/Nevermore/RelationalJsonContractResolver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
-using Nevermore.Mapping;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Linq;
@@ -16,35 +16,44 @@ namespace Nevermore
             this.configuration = configuration;
         }
 
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {
-            configuration.DocumentMaps.ResolveOptional(member.DeclaringType, out var map);
-
-            var property = base.CreateProperty(member, memberSerialization);
-
-            // ID properties are stored as columns
-            if (property.PropertyName == "Id" && map != null)
+            var members = GetSerializableMembers(type);
+            if (members is null)
             {
-                property.Ignored = true;
+                throw new JsonSerializationException("Null collection of serializable members returned.");
             }
 
-            // Indexed properties are stored as columns
-            if (map != null && map.Columns.Any(c => c.Property != null && c.Property.Name == member.Name))
-            {
-                property.Ignored = true;
-            }
+            configuration.DocumentMaps.ResolveOptional(type, out var map);
 
-            if (!property.Writable)
+            var properties = new JsonPropertyCollection(type);
+            foreach (var member in members)
             {
-                var property2 = member as PropertyInfo;
-                if (property2 != null)
+                var property = CreateProperty(member, memberSerialization);
+
+                // ID properties are stored as columns
+                if (map?.IdColumn?.ColumnName == member.Name)
                 {
-                    var hasPrivateSetter = property2.GetSetMethod(true) != null;
+                    property.Ignored = true;
+                }
+
+                // Indexed properties are stored as columns
+                if (map?.Columns.Any(c => c?.Property.Name == member.Name) ?? false)
+                {
+                    property.Ignored = true;
+                }
+
+                if (!property.Writable && member is PropertyInfo propertyMember)
+                {
+                    var hasPrivateSetter = propertyMember.GetSetMethod(true) is not null;
                     property.Writable = hasPrivateSetter;
                 }
+
+                properties.AddProperty(property);
             }
 
-            return property;
+            var orderedProperties = properties.OrderBy(p => p.Order ?? -1).ToList();
+            return orderedProperties;
         }
     }
 }


### PR DESCRIPTION
# Background

The `RelationalJsonContractResolver` is responsible for determining which properties should be serialized in the JSON blob. It does this by using the declaring type of the property to fetch the document map and see whether it's mapped to a column, in which case it should be excluded.

This doesn't work if the property is declared by a base type that doesn't have a document map. In this case, if the derived type maps the property to a column, the property will be written to the JSON blob and the column.

# Result

Fix the resolver to always use the type for the contract being built to find the document map.