### PR TITLE
Support IQueryable Projection

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1410,10 +1410,11 @@ namespace Nevermore.IntegrationTests
 
             var customers = t.Queryable<Customer>().Select(c => new { c.FirstName, c.IsEmployee });
 
-            customers.Should().BeEquivalentTo(
+            customers.Should().BeEquivalentTo(new [] {
                 new { FirstName = "Alice", IsEmployee = true },
                 new { FirstName = "Bob", IsEmployee = false },
-                new { FirstName = "Charlie", IsEmployee = true });
+                new { FirstName = "Charlie", IsEmployee = true }
+            });
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1364,5 +1364,56 @@ namespace Nevermore.IntegrationTests
 
             customers.Select(c => c.LastName).Should().BeEquivalentTo("Apple");
         }
+
+        [Test]
+        public async Task ProjectColumnField()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", Roles = { "Admin" }},
+                new Customer { FirstName = "Bob", LastName = "Banana", Roles = { "Boss" } },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", Roles = { "Editor", "Bum" } }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = t.Queryable<Customer>().Select(c => c.FirstName);
+
+            customers.Should().BeEquivalentTo("Alice", "Bob", "Charlie");
+        }
+
+        [Test]
+        public async Task ProjectJsonField()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", IsEmployee = true },
+                new Customer { FirstName = "Bob", LastName = "Banana", IsEmployee = false },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", IsEmployee = true }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = t.Queryable<Customer>().Select(c => new { c.FirstName, c.IsEmployee });
+
+            customers.Should().BeEquivalentTo(
+                new { FirstName = "Alice", IsEmployee = true },
+                new { FirstName = "Bob", IsEmployee = false },
+                new { FirstName = "Charlie", IsEmployee = true });
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1416,5 +1416,29 @@ namespace Nevermore.IntegrationTests
                 new { FirstName = "Charlie", IsEmployee = true }
             });
         }
+
+        [Test]
+        public async Task ProjectValueType()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", IsEmployee = true },
+                new Customer { FirstName = "Bob", LastName = "Banana", IsEmployee = false },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", IsEmployee = true }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = await t.Queryable<Customer>().Select(c => c.IsEmployee).ToListAsync();
+
+            customers.Should().BeEquivalentTo(new[] { true, false, true });
+        }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
+++ b/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nevermore.Advanced.Queryable
+{
+    internal static class AsyncEnumerableAdapter
+    {
+        public static async Task<IEnumerable> ConvertToEnumerable(object asyncEnumerable, Type sequenceType, CancellationToken cancellationToken)
+        {
+            var asyncEnumerableType = typeof(IAsyncEnumerable<>).MakeGenericType(sequenceType);
+            var asyncEnumeratorType = typeof(IAsyncEnumerator<>).MakeGenericType(sequenceType);
+
+            var getAsyncEnumeratorMethod = asyncEnumerableType.GetRuntimeMethod("GetAsyncEnumerator", new[] { typeof(CancellationToken) });
+            var moveNextAsyncMethod = asyncEnumeratorType.GetRuntimeMethod("MoveNextAsync", Array.Empty<Type>());
+            var currentProperty = asyncEnumeratorType.GetRuntimeProperty("Current");
+
+            var asyncEnumerator = getAsyncEnumeratorMethod.Invoke(asyncEnumerable, new object[] { cancellationToken });
+
+            var list = CreateList(sequenceType);
+            while (await (ValueTask<bool>)moveNextAsyncMethod.Invoke(asyncEnumerator, Array.Empty<object>()))
+            {
+                var item = currentProperty.GetValue(asyncEnumerator);
+                list.Add(item);
+            }
+
+            return list;
+        }
+
+        static IList CreateList(Type elementType)
+        {
+            var listType = typeof(List<>).MakeGenericType(elementType);
+            var list = (IList)Activator.CreateInstance(listType);
+            return list;
+        }
+    }
+}

--- a/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
+++ b/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
@@ -21,7 +21,7 @@ namespace Nevermore.Advanced.Queryable
             var asyncEnumerator = getAsyncEnumeratorMethod.Invoke(asyncEnumerable, new object[] { cancellationToken });
 
             var list = CreateList(sequenceType);
-            while (await (ValueTask<bool>)moveNextAsyncMethod.Invoke(asyncEnumerator, Array.Empty<object>()))
+            while (await ((ValueTask<bool>)moveNextAsyncMethod.Invoke(asyncEnumerator, Array.Empty<object>())).ConfigureAwait(false))
             {
                 var item = currentProperty.GetValue(asyncEnumerator);
                 list.Add(item);

--- a/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
@@ -10,14 +10,5 @@ namespace Nevermore.Advanced.Queryable
             return propertyInfo.Name.Equals(other.Name) &&
                    propertyInfo.PropertyType.IsAssignableFrom(other.PropertyType);
         }
-
-        public static bool IsScalar(this PropertyInfo propertyInfo)
-        {
-            return Type.GetTypeCode(propertyInfo.PropertyType) switch
-            {
-                TypeCode.Object => false,
-                _ => true
-            };
-        }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/QueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryProvider.cs
@@ -71,12 +71,12 @@ namespace Nevermore.Advanced.Queryable
             if (queryType == QueryType.SelectMany)
             {
                 var sequenceType = expression.Type.GetSequenceType();
-                return (TResult)await ExecuteStreamAsync(command, sequenceType, cancellationToken);
+                return (TResult)await ExecuteStreamAsync(command, sequenceType, cancellationToken).ConfigureAwait(false);
             }
 
             if (queryType == QueryType.SelectSingle)
             {
-                return (TResult)FirstOrDefault(await ExecuteStreamAsync(command, expression.Type, cancellationToken));
+                return (TResult)FirstOrDefault(await ExecuteStreamAsync(command, expression.Type, cancellationToken).ConfigureAwait(false));
             }
 
             return await ((Task<TResult>)GenericExecuteScalarAsyncMethod.MakeGenericMethod(expression.Type)
@@ -100,7 +100,7 @@ namespace Nevermore.Advanced.Queryable
             var stream = GenericStreamAsyncMethod.MakeGenericMethod(elementType)
                 .Invoke(queryExecutor, new object[] { command, cancellationToken });
 
-            return await AsyncEnumerableAdapter.ConvertToEnumerable(stream, elementType, cancellationToken);
+            return await AsyncEnumerableAdapter.ConvertToEnumerable(stream, elementType, cancellationToken).ConfigureAwait(false);
         }
 
         object ExecuteScalar(PreparedCommand command, Type resultType)

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -182,9 +182,37 @@ namespace Nevermore.Advanced.Queryable
                     sqlBuilder.Skip(skip);
                     return node;
                 }
+                case nameof(System.Linq.Queryable.Select):
+                {
+                    Visit(node.Arguments[0]);
+                    AddProjection(node.Arguments[1]);
+                    return node;
+                }
                 default:
                     throw new NotSupportedException();
             }
+        }
+
+        void AddProjection(Expression expression)
+        {
+            expression = StripQuotes(expression);
+            if (expression is LambdaExpression { Body: MemberExpression { NodeType: ExpressionType.MemberAccess } memberExpression })
+            {
+                var (selectColumns, _) = GetSelectFieldReferenceAndType(memberExpression);
+                sqlBuilder.Select(selectColumns);
+                return;
+            }
+
+            if (expression is LambdaExpression { Body: NewExpression newExpression })
+            {
+                foreach (var arg in newExpression.Arguments)
+                {
+                    var (selectColumn, _) = GetSelectFieldReferenceAndType(arg);
+                    sqlBuilder.Select(selectColumn);
+                }
+            }
+
+            throw new NotSupportedException();
         }
 
         static string GetMemberNameFromKeySelectorExpression(Expression expression)
@@ -346,6 +374,41 @@ namespace Nevermore.Advanced.Queryable
                 return Enum.ToObject(propertyType, result);
 
             return result;
+        }
+
+        (ISelectColumns, Type) GetSelectFieldReferenceAndType(Expression expression)
+        {
+            if (expression is UnaryExpression unaryExpression)
+                expression = unaryExpression.Operand;
+
+            if (expression is MemberExpression { Member: PropertyInfo propertyInfo } memberExpression)
+            {
+                var documentMap = sqlBuilder.DocumentMap;
+                var parameterExpression = memberExpression.FindChildOfType<ParameterExpression>();
+                var childPropertyExpression = memberExpression.FindChildOfType<MemberExpression>();
+                if (childPropertyExpression == null && documentMap.Type.IsAssignableFrom(parameterExpression.Type))
+                {
+                    if (documentMap.IdColumn!.Property.Matches(propertyInfo))
+                    {
+                        return (new SelectColumn(documentMap.IdColumn.ColumnName), documentMap.IdColumn.Type);
+                    }
+
+                    var column = documentMap.Columns.Where(c => c.Property is not null).FirstOrDefault(c => c.Property.Matches(propertyInfo));
+                    if (column is not null)
+                    {
+                        return (new SelectColumn(column.ColumnName), propertyInfo.PropertyType);
+                    }
+                }
+
+                if (documentMap.HasJsonColumn())
+                {
+                    var jsonPath = GetJsonPath(memberExpression);
+                    var fieldReference = new SelectJsonValue(jsonPath, propertyInfo.PropertyType);
+                    return (fieldReference, propertyInfo.PropertyType);
+                }
+            }
+
+            throw new NotSupportedException();
         }
 
         (IWhereFieldReference, Type) GetFieldReferenceAndType(Expression expression)

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -198,8 +198,8 @@ namespace Nevermore.Advanced.Queryable
             expression = StripQuotes(expression);
             if (expression is LambdaExpression { Body: MemberExpression { NodeType: ExpressionType.MemberAccess } memberExpression })
             {
-                var (selectColumns, _) = GetSelectFieldReferenceAndType(memberExpression);
-                sqlBuilder.Select(selectColumns);
+                var selectColumn = GetSelectFieldReference(memberExpression);
+                sqlBuilder.Select(selectColumn);
                 return;
             }
 
@@ -207,7 +207,7 @@ namespace Nevermore.Advanced.Queryable
             {
                 foreach (var arg in newExpression.Arguments)
                 {
-                    var (selectColumn, _) = GetSelectFieldReferenceAndType(arg);
+                    var selectColumn = GetSelectFieldReference(arg);
                     sqlBuilder.Select(selectColumn);
                 }
             }
@@ -246,7 +246,7 @@ namespace Nevermore.Advanced.Queryable
 
             if (expression is MemberExpression { Member: { MemberType: MemberTypes.Property } and PropertyInfo propertyInfo } && propertyInfo.PropertyType == typeof(bool))
             {
-                var (fieldReference, _) = GetFieldReferenceAndType(expression);
+                var (fieldReference, _) = GetWhereFieldReferenceAndType(expression);
                 return sqlBuilder.CreateWhere(fieldReference, UnarySqlOperand.Equal, !invert);
             }
 
@@ -267,7 +267,7 @@ namespace Nevermore.Advanced.Queryable
 
                 if (left is MemberExpression { Member: PropertyInfo propertyInfo } memberExpressionL && memberExpressionL.IsBasedOff<ParameterExpression>())
                 {
-                    var (fieldReference, type) = GetFieldReferenceAndType(left);
+                    var (fieldReference, type) = GetWhereFieldReferenceAndType(left);
                     var value = GetValueFromExpression(right, type);
 
                     if (fieldReference is WhereFieldReference)
@@ -285,7 +285,7 @@ namespace Nevermore.Advanced.Queryable
                 else if (right is MemberExpression memberExpressionR && memberExpressionR.IsBasedOff<ParameterExpression>())
                 {
                     var values = (IEnumerable)GetValueFromExpression(left, typeof(IEnumerable));
-                    var (fieldReference, _) = GetFieldReferenceAndType(right);
+                    var (fieldReference, _) = GetWhereFieldReferenceAndType(right);
                     return sqlBuilder.CreateWhere(fieldReference, invert ? ArraySqlOperand.NotIn : ArraySqlOperand.In, values);
                 }
             }
@@ -295,7 +295,7 @@ namespace Nevermore.Advanced.Queryable
 
         IWhereClause CreateStringMethodWhere(MethodCallExpression expression, bool invert = false)
         {
-            var (fieldReference, _) = GetFieldReferenceAndType(expression.Object);
+            var (fieldReference, _) = GetWhereFieldReferenceAndType(expression.Object);
             var value = (string)GetValueFromExpression(expression.Arguments[0], typeof(string));
 
             if (expression.Method.Name == nameof(string.Contains))
@@ -343,7 +343,7 @@ namespace Nevermore.Advanced.Queryable
                 _ => throw new NotSupportedException()
             };
 
-            var (fieldReference, propertyType) = GetFieldReferenceAndType(expression.Left);
+            var (fieldReference, propertyType) = GetWhereFieldReferenceAndType(expression.Left);
             var value = GetValueFromExpression(expression.Right, propertyType);
 
             if (value == null && op is UnarySqlOperand.Equal or UnarySqlOperand.NotEqual)
@@ -376,42 +376,29 @@ namespace Nevermore.Advanced.Queryable
             return result;
         }
 
-        (ISelectColumns, Type) GetSelectFieldReferenceAndType(Expression expression)
+        ISelectColumns GetSelectFieldReference(Expression expression)
         {
-            if (expression is UnaryExpression unaryExpression)
-                expression = unaryExpression.Operand;
+            var (reference, type, isJson) = FindField(expression);
 
-            if (expression is MemberExpression { Member: PropertyInfo propertyInfo } memberExpression)
-            {
-                var documentMap = sqlBuilder.DocumentMap;
-                var parameterExpression = memberExpression.FindChildOfType<ParameterExpression>();
-                var childPropertyExpression = memberExpression.FindChildOfType<MemberExpression>();
-                if (childPropertyExpression == null && documentMap.Type.IsAssignableFrom(parameterExpression.Type))
-                {
-                    if (documentMap.IdColumn!.Property.Matches(propertyInfo))
-                    {
-                        return (new SelectColumn(documentMap.IdColumn.ColumnName), documentMap.IdColumn.Type);
-                    }
-
-                    var column = documentMap.Columns.Where(c => c.Property is not null).FirstOrDefault(c => c.Property.Matches(propertyInfo));
-                    if (column is not null)
-                    {
-                        return (new SelectColumn(column.ColumnName), propertyInfo.PropertyType);
-                    }
-                }
-
-                if (documentMap.HasJsonColumn())
-                {
-                    var jsonPath = GetJsonPath(memberExpression);
-                    var fieldReference = new SelectJsonValue(jsonPath, propertyInfo.PropertyType);
-                    return (fieldReference, propertyInfo.PropertyType);
-                }
-            }
-
-            throw new NotSupportedException();
+            return isJson ? new SelectJsonValue(reference, type) : new SelectColumn(reference);
         }
 
-        (IWhereFieldReference, Type) GetFieldReferenceAndType(Expression expression)
+        (IWhereFieldReference, Type) GetWhereFieldReferenceAndType(Expression expression)
+        {
+            var (reference, type, isJson) = FindField(expression);
+
+            if (!isJson)
+            {
+                return (new WhereFieldReference(reference), type);
+            }
+
+            IWhereFieldReference fieldReference = type.IsScalar()
+                ? new JsonValueFieldReference(reference)
+                : new JsonQueryFieldReference(reference);
+            return (fieldReference, type);
+        }
+
+        (string, Type, bool) FindField(Expression expression)
         {
             if (expression is UnaryExpression unaryExpression)
                 expression = unaryExpression.Operand;
@@ -425,23 +412,20 @@ namespace Nevermore.Advanced.Queryable
                 {
                     if (documentMap.IdColumn!.Property.Matches(propertyInfo))
                     {
-                        return (new WhereFieldReference(documentMap.IdColumn.ColumnName), documentMap.IdColumn.Type);
+                        return (documentMap.IdColumn.ColumnName, documentMap.IdColumn.Type, false);
                     }
 
                     var column = documentMap.Columns.Where(c => c.Property is not null).FirstOrDefault(c => c.Property.Matches(propertyInfo));
                     if (column is not null)
                     {
-                        return (new WhereFieldReference(column.ColumnName), propertyInfo.PropertyType);
+                        return (column.ColumnName, propertyInfo.PropertyType, false);
                     }
                 }
 
                 if (documentMap.HasJsonColumn())
                 {
                     var jsonPath = GetJsonPath(memberExpression);
-                    IWhereFieldReference fieldReference = propertyInfo.IsScalar()
-                        ? new JsonValueFieldReference(jsonPath)
-                        : new JsonQueryFieldReference(jsonPath);
-                    return (fieldReference, propertyInfo.PropertyType);
+                    return (jsonPath, propertyInfo.PropertyType, true);
                 }
             }
 

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -210,6 +210,8 @@ namespace Nevermore.Advanced.Queryable
                     var selectColumn = GetSelectFieldReference(arg);
                     sqlBuilder.Select(selectColumn);
                 }
+
+                return;
             }
 
             throw new NotSupportedException();

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderContext.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    public class AnonymousTypeReaderContext
+    {
+        public int Column = -1;
+    }
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderFunc.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderFunc.cs
@@ -1,0 +1,6 @@
+﻿using System.Data.Common;
+
+namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    internal delegate TRecord AnonymousTypeReaderFunc<TRecord>(DbDataReader reader, AnonymousTypeReaderContext context);
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderStrategy.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Nevermore.Advanced.ReaderStrategies.Compilation;
+
+namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    public class AnonymousTypeReaderStrategy : IReaderStrategy
+    {
+        readonly RelationalStoreConfiguration configuration;
+
+        public AnonymousTypeReaderStrategy(RelationalStoreConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public bool CanRead(Type type)
+        {
+            return type.IsGenericType &&
+                   type.Namespace == null &&
+                   type.IsSealed &&
+                   type.BaseType == typeof(object) &&
+                   !type.IsPublic &&
+                   type.GetCustomAttribute<CompilerGeneratedAttribute>() != null &&
+                   type.Name.Contains("AnonymousType");
+        }
+
+        public Func<PreparedCommand, Func<DbDataReader, (TRecord, bool)>> CreateReader<TRecord>()
+        {
+            return command =>
+            {
+                CompiledExpression<AnonymousTypeReaderFunc<TRecord>> compiled = null;
+                var rowNumber = 0;
+                var context = new AnonymousTypeReaderContext();
+
+                return reader =>
+                {
+                    rowNumber++;
+
+                    if (compiled == null)
+                    {
+                        compiled = Compile<TRecord>(reader);
+                    }
+
+                    try
+                    {
+                        var instance = compiled.Execute(reader, context);
+                        return (instance, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ReaderException(rowNumber, context.Column, compiled.ExpressionSource, ex);
+                    }
+                };
+            };
+        }
+
+        CompiledExpression<AnonymousTypeReaderFunc<TRecord>> Compile<TRecord>(IDataRecord record)
+        {
+            var constructor = typeof(TRecord).GetConstructors().Single();
+            var constructorParams = constructor.GetParameters();
+
+            var readerArg = Expression.Parameter(typeof(DbDataReader), "reader");
+            var contextArg = Expression.Parameter(typeof(AnonymousTypeReaderContext), "context");
+
+            var locals = new List<ParameterExpression>();
+            var body = new List<Expression>();
+
+            var expectedFieldCount = record.FieldCount;
+            for (var i = 0; i < expectedFieldCount; i++)
+            {
+                var param = constructorParams[i];
+                var paramLocal = Expression.Variable(param.ParameterType, $"p{i}");
+                locals.Add(paramLocal);
+                body.Add(Expression.Assign(Expression.Field(contextArg, nameof(AnonymousTypeReaderContext.Column)), Expression.Constant(i)));
+                body.Add(Expression.Assign(paramLocal, ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), param.ParameterType, configuration.TypeHandlers)));
+            }
+
+            body.Add(Expression.New(constructor, locals));
+
+            var block = Expression.Block(locals, body);
+
+            var lambda = Expression.Lambda<AnonymousTypeReaderFunc<TRecord>>(block, readerArg, contextArg);
+
+            return ExpressionCompiler.Compile(lambda);
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/ArbitraryClasses/ArbitraryClassReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/ArbitraryClasses/ArbitraryClassReaderStrategy.cs
@@ -14,7 +14,7 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
     /// This strategy is used for "POCO", or "Plain-Old-CLR-Objects" classes (those that don't have a document map).
     /// They will be read from the reader automatically. Our requirements are:
     /// 
-    ///  - The class must provide a constructor (declared or not) with no parameters.
+    ///  - The class must provide a constructor (declared or not) with no parameters, or a list of parameters that exactly matches the fields on the reader by type
     ///  - We only bind public, settable properties
     ///  - Column names must match property names, but the casing does not need to match
     ///  - If a column exists in the results, a property must exist on the class
@@ -31,10 +31,7 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
         
         public bool CanRead(Type type)
         {
-            return 
-                type.IsClass 
-                && type.GetConstructors().Any(c => c.IsPublic && c.GetParameters().Length == 0)
-                && !configuration.DocumentMaps.ResolveOptional(type, out _);
+            return type.IsClass && !configuration.DocumentMaps.ResolveOptional(type, out _);
         }
         
         public Func<PreparedCommand, Func<DbDataReader, (TRecord, bool)>> CreateReader<TRecord>()
@@ -81,18 +78,31 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
         //         result.LastName = reader.GetString(1);
         //         return result;
         //     }
+        //
+        //   -- OR --
+        //
+        //     (DbDataReader reader, ArbitraryClassReaderContext context) =>
+        //     {
+        //         var result = new Person(reader.GetString(0), reader.GetString(1));
+        //         return result;
+        //     }
         CompiledExpression<ArbitraryClassReaderFunc<TRecord>> Compile<TRecord>(IDataRecord record)
         {
             // To make it fast - as fast as if we wrote it by hand - we generate and compile C# expression trees for
             // each property on the class, and one to call the constructor.
-            
-            // Find the parameter-less constructor
+
             var constructors = typeof(TRecord).GetConstructors();
-            var defaultConstructor = constructors.FirstOrDefault(p => p.GetParameters().Length == 0) ?? throw new InvalidOperationException("When reading query results to a class, the class must provide a default constructor with no parameters.");
-            
-            // Create fast setters for all properties on the type
-            var properties = typeof(TRecord).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty);
-            
+            // Find the parameter-less constructor
+            var defaultConstructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            // Find a parameterized constructor that matches the data reader
+            var parameterizedConstructor = (from ctor in constructors
+                let parameters = ctor.GetParameters()
+                where parameters.Length == record.FieldCount && MatchesTypes(parameters, record)
+                select ctor).FirstOrDefault();
+            var selectedConstructor = parameterizedConstructor
+                                      ?? defaultConstructor
+                                      ?? throw new InvalidOperationException("No default constructor or constructor that exactly matches the number and types of the reader fields was found.");
+
             var readerArg = Expression.Parameter(typeof(DbDataReader), "reader");
             var contextArg = Expression.Parameter(typeof(ArbitraryClassReaderContext), "context");
 
@@ -101,18 +111,46 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
             
             var resultLocalVariable = Expression.Variable(typeof(TRecord), "result");
             locals.Add(resultLocalVariable);
-            body.Add(Expression.Assign(resultLocalVariable, Expression.New(defaultConstructor)));
-                        
+
+            if (selectedConstructor.GetParameters().Any())
+            {
+                BuildParameterizedConstructorExpression(selectedConstructor, readerArg, body, resultLocalVariable);
+            }
+            else
+            {
+                BuildParameterlessConstructorExpression<TRecord>(record, body, resultLocalVariable, selectedConstructor, contextArg, readerArg);
+            }
+
+            // Return it
+            body.Add(resultLocalVariable);
+
+            var block = Expression.Block(
+                locals,
+                body
+            );
+
+            var lambda = Expression.Lambda<ArbitraryClassReaderFunc<TRecord>>(block, readerArg, contextArg);
+
+            return ExpressionCompiler.Compile(lambda);
+        }
+
+        void BuildParameterlessConstructorExpression<TRecord>(IDataRecord record, List<Expression> body, ParameterExpression resultLocalVariable, ConstructorInfo selectedConstructor, ParameterExpression contextArg, ParameterExpression readerArg)
+        {
+            // Create fast setters for all properties on the type
+            var properties = typeof(TRecord).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty);
+
+            body.Add(Expression.Assign(resultLocalVariable, Expression.New(selectedConstructor)));
+
             var expectedFieldCount = record.FieldCount;
             for (var i = 0; i < expectedFieldCount; i++)
             {
                 var name = record.GetName(i);
-                
+
                 var property = properties.FirstOrDefault(p => p.Name == name);
                 if (property != null)
                 {
                     body.Add(Expression.Assign(Expression.Field(contextArg, nameof(ArbitraryClassReaderContext.Column)), Expression.Constant(i)));
-                    
+
                     body.Add(Expression.Assign(
                         Expression.Property(resultLocalVariable, property),
                         ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), property.PropertyType, configuration.TypeHandlers)));
@@ -122,18 +160,19 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
                     throw new Exception($"The query returned a column named '{name}' but no property by that name exists on the target type '{typeof(TRecord).Name}'. When reading to an arbitrary type, all columns must have a matching settable property.");
                 }
             }
+        }
 
-            // Return it
-            body.Add(resultLocalVariable);
-                        
-            var block = Expression.Block(
-                locals,
-                body
-            );
+        void BuildParameterizedConstructorExpression(ConstructorInfo selectedConstructor, ParameterExpression readerArg, List<Expression> body, ParameterExpression resultLocalVariable)
+        {
+            var arguments = selectedConstructor
+                .GetParameters()
+                .Select((p, i) => ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), p.ParameterType, configuration.TypeHandlers));
+            body.Add(Expression.Assign(resultLocalVariable, Expression.New(selectedConstructor, arguments)));
+        }
 
-            var lambda = Expression.Lambda<ArbitraryClassReaderFunc<TRecord>>(block, readerArg, contextArg);
-            
-            return ExpressionCompiler.Compile(lambda);
+        static bool MatchesTypes(IEnumerable<ParameterInfo> parameters, IDataRecord record)
+        {
+            return !parameters.Where((t, i) => t.ParameterType != record.GetFieldType(i)).Any();
         }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -4,6 +4,7 @@ using Nevermore.Advanced;
 using Nevermore.Advanced.Hooks;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.Advanced.ReaderStrategies;
+using Nevermore.Advanced.ReaderStrategies.AnonymousTypes;
 using Nevermore.Advanced.ReaderStrategies.ArbitraryClasses;
 using Nevermore.Advanced.ReaderStrategies.Documents;
 using Nevermore.Advanced.ReaderStrategies.Primitives;
@@ -39,6 +40,7 @@ namespace Nevermore
             ReaderStrategies.Register(new ValueTupleReaderStrategy(this));
             ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
             ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
+            ReaderStrategies.Register(new AnonymousTypeReaderStrategy(this));
 
             Hooks = new HookRegistry();
 

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -38,9 +38,9 @@ namespace Nevermore
             ReaderStrategies = new ReaderStrategyRegistry();
             ReaderStrategies.Register(new DocumentReaderStrategy(this));
             ReaderStrategies.Register(new ValueTupleReaderStrategy(this));
-            ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
-            ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
             ReaderStrategies.Register(new AnonymousTypeReaderStrategy(this));
+            ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
+            ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
 
             Hooks = new HookRegistry();
 

--- a/source/Nevermore/Util/TypeExtensions.cs
+++ b/source/Nevermore/Util/TypeExtensions.cs
@@ -22,5 +22,12 @@ namespace Nevermore.Util
 
             return enumerableType.GetGenericArguments().Single();
         }
+
+        public static object GetDefaultValue(this Type type)
+        {
+            return type.IsValueType
+                ? Activator.CreateInstance(type)
+                : null;
+        }
     }
 }

--- a/source/Nevermore/Util/TypeExtensions.cs
+++ b/source/Nevermore/Util/TypeExtensions.cs
@@ -29,5 +29,14 @@ namespace Nevermore.Util
                 ? Activator.CreateInstance(type)
                 : null;
         }
+
+        public static bool IsScalar(this Type type)
+        {
+            return Type.GetTypeCode(type) switch
+            {
+                TypeCode.Object => false,
+                _ => true
+            };
+        }
     }
 }


### PR DESCRIPTION
# Background

Add basic support for projection in `IQueryable` queries.

## Project a single column

``` csharp
transaction.Queryable<Document>().Select(d => d.Id);
```

## Project a set of properties as an anonymous type

``` csharp
transaction.Queryable<Document>().Select(d => new { d.Id, d.Name });
```
