### PR TITLE
Fix bug where we accept any SemaphoreSlim instead of a DeadlockAwareLock

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ConcurrentAccessFixture.cs
@@ -27,7 +27,7 @@ namespace Nevermore.IntegrationTests.Advanced
             using (var transaction = Store.BeginTransaction())
             {
                 Enumerable.Range(0, NumberOfDocuments)
-                    .Select(i => new DocumentWithIdentityId {Name = $"{namePrefix}{i}"})
+                    .Select(i => new DocumentWithIdentityId { Name = $"{namePrefix}{i}" })
                     .AsParallel()
                     .WithDegreeOfParallelism(DegreeOfParallelism)
                     .Select(document =>

--- a/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
+++ b/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
+using Nito.AsyncEx;
 using NUnit.Framework;
 
 namespace Nevermore.Tests
@@ -130,6 +131,34 @@ namespace Nevermore.Tests
             }
 
             // ReSharper restore AccessToDisposedClosure
+        }
+
+        [Test]
+        public void UsingSyncExtensionMethods_AndReleasingLocksCorrectly_ShouldNotThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            using (var _ = deadlockAwareLock.Lock())
+            {
+            }
+
+            using (var _ = deadlockAwareLock.Lock())
+            {
+            }
+        }
+
+        [Test]
+        public async Task UsingAsyncExtensionMethods_AndReleasingLocksCorrectly_ShouldNotThrow()
+        {
+            using var deadlockAwareLock = new DeadlockAwareLock();
+
+            using (var _ = await deadlockAwareLock.LockAsync(cancellationToken))
+            {
+            }
+
+            using (var _ = await deadlockAwareLock.LockAsync(cancellationToken))
+            {
+            }
         }
     }
 }

--- a/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
+++ b/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
@@ -9,21 +9,21 @@ namespace Nevermore.Advanced
     public class ThreadSafeAsyncEnumerable<T> : IAsyncEnumerable<T>
     {
         readonly Func<IAsyncEnumerable<T>> innerFunc;
-        readonly SemaphoreSlim semaphore;
+        readonly DeadlockAwareLock deadlockAwareLock;
 
-        public ThreadSafeAsyncEnumerable(IAsyncEnumerable<T> inner, SemaphoreSlim semaphore) : this(() => inner, semaphore)
+        public ThreadSafeAsyncEnumerable(IAsyncEnumerable<T> inner, DeadlockAwareLock deadlockAwareLock) : this(() => inner, deadlockAwareLock)
         {
         }
 
-        public ThreadSafeAsyncEnumerable(Func<IAsyncEnumerable<T>> innerFunc, SemaphoreSlim semaphore)
+        public ThreadSafeAsyncEnumerable(Func<IAsyncEnumerable<T>> innerFunc, DeadlockAwareLock deadlockAwareLock)
         {
             this.innerFunc = innerFunc;
-            this.semaphore = semaphore;
+            this.deadlockAwareLock = deadlockAwareLock;
         }
 
         public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
         {
-            using var mutex = await semaphore.LockAsync(cancellationToken);
+            using var mutex = await deadlockAwareLock.LockAsync(cancellationToken);
             var inner = innerFunc();
             await foreach (var item in inner.WithCancellation(cancellationToken)) yield return item;
         }


### PR DESCRIPTION
This bug was noticed by @pawelpabich [here](https://github.com/OctopusDeploy/Nevermore/pull/192#pullrequestreview-957294089).

It's currently a non-functional bug as it _just so happens_ that the type we're passing in is actually a `DeadlockAwareLock` but things will go sneakily bad if we pass in a bare `SemaphoreSlim` at any later date.

We'd initially intended to remove the inheritance of `SemaphoreSlim` from `DeadlockAwareLock` but we get too many nice extensions on `SemaphoreSlim` from `Nito.AsyncEx` which we'd have to reimplement so it actually looks safer to keep the inheritance but have the compiler make it impossible to pass an incorrect type around.