### PR TITLE
Wrap SQL exceptions in a more useful way

### DIFF
--- a/source/Nevermore/NevermoreCommandException.cs
+++ b/source/Nevermore/NevermoreCommandException.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Data.Common;
+using System.Text;
+using Microsoft.Data.SqlClient;
+
+namespace Nevermore
+{
+    public class NevermoreCommandException : Exception
+    {
+        readonly ITransactionDiagnostic transactionDiagnostic;
+
+        internal NevermoreCommandException(DbCommand command, ITransactionDiagnostic transactionDiagnostic, SqlException innerException)
+            : base($"Error while executing SQL command in transaction '{transactionDiagnostic.Name}': {innerException.Message}{Environment.NewLine}The command being executed was:{Environment.NewLine}{command.CommandText}", innerException)
+        {
+            Command = command;
+            this.transactionDiagnostic = transactionDiagnostic;
+        }
+
+        public DbCommand Command { get; }
+        public byte Class => SqlException.Class;
+        public Guid ClientConnectionId => SqlException.ClientConnectionId;
+        public SqlErrorCollection Errors => SqlException.Errors;
+        public int LineNumber => SqlException.LineNumber;
+        public int Number => SqlException.Number;
+        public string Procedure => SqlException.Procedure;
+        public string Server => SqlException.Server;
+        public override string Source => SqlException.Source;
+        public byte State => SqlException.State;
+
+        public void WriteCurrentTransactions(StringBuilder output) => transactionDiagnostic.WriteCurrentTransactions(output);
+
+        SqlException SqlException => InnerException as SqlException;
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(Message);
+            if (Number is 1205 or 1222 or -2)
+            {
+                builder.AppendLine("Current transactions: ");
+                WriteCurrentTransactions(builder);
+            }
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
# Background

When encountering certain kinds of `SqlException`, Nevermore will wrap it in a generic `Exception` with a custom message. In some cases, the original `SqlException` won't be retained, forcing the consumer to inspect the text to figure out what happened.

In some cases the exception message would be populated with a potentially large list of all currently active transactions, which may or may not have ever been read.

# Result

Introduce a custom Nevermore exception type to wrap the `SqlException`, providing access to useful context about what happened, but still supporting the previous behaviour.