### PR TITLE
Robe/cte count

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -1,5 +1,8 @@
 ﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Nevermore.Advanced;
 using Nevermore.IntegrationTests.Model;
 using Nevermore.IntegrationTests.SetUp;
 using NUnit.Framework;
@@ -60,8 +63,7 @@ namespace Nevermore.IntegrationTests
                 customersNotNull.Select(c => c.FirstName).Should().BeEquivalentTo("Bob", "Charlie");
             }
         }
-        
-        
+
         [Test]
         public void CrossJoin()
         {
@@ -100,6 +102,35 @@ namespace Nevermore.IntegrationTests
         {
             public string CustomerName { get; set; }
             public string ProductName { get; set; }
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)] //Temporary test to cover and compare legacy mechanism for loading data. Remove once legacy approach deprecated
+        public async Task WhereToListWithCountAsync(bool useCteOperation)
+        {
+            using (var t = Store.BeginTransaction())
+            {
+                foreach (var c in new[]
+                         {
+                             new Customer {FirstName = "Alice", LastName = "Apple", Nickname = null},
+                             new Customer {FirstName = "Bob", LastName = "Banana", Nickname = ""},
+                             new Customer {FirstName = "Charlie", LastName = "Cherry", Nickname = "Chazza"},
+                             new Customer {FirstName = "David", LastName = "Derkins", Nickname = "Dazza"},
+                             new Customer {FirstName = "Eric", LastName = "Evans", Nickname = "Bob"}
+                         })
+                    t.Insert(c);
+                await t.CommitAsync(CancellationToken.None);
+
+                FeatureFlags.UseCteBasedListWithCount = useCteOperation;
+                var (items, count) = await t.Query<Customer>()
+                    .OrderByDescending(o => o.LastName)
+                    .Where(n => n.Nickname != null)
+                    .ToListWithCountAsync(1, 2, CancellationToken.None);
+
+                CollectionAssert.AreEqual(items.Select(p => p.FirstName), new []{"David", "Charlie"});
+                count.Should().Be(4);
+            }
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Assent;
 using FluentAssertions;
+using Nevermore.Advanced;
 using Nevermore.Advanced.QueryBuilders;
 using Nevermore.Querying.AST;
 using NSubstitute;
@@ -1745,6 +1748,54 @@ FROM (
 WHERE ([RowNum] >= @_minrow)
 AND ([RowNum] <= @_maxrow)
 ORDER BY [RowNum]");
+
+            parameterValues.Should().HaveCount(3);
+            parameterValues["id"].Should().BeEquivalentTo("1");
+            parameterValues["_minrow"].Should().BeEquivalentTo(11);
+            parameterValues["_maxrow"].Should().BeEquivalentTo(30);
+        }
+
+        //TODO: Call into contract defined ToListWithCountAsync once legacy mechanism is deprecated
+        [Test]
+        public async Task ShouldCreateIncludeTotalListCount()
+        {
+            CommandParameterValues parameterValues = null;
+            string query = null;
+            transaction.StreamAsync<object>(
+                Arg.Do<string>(q => query = q),
+                Arg.Do<CommandParameterValues>(pv => parameterValues = pv),
+                Arg.Any<Func<IProjectionMapper, object>>(), 
+                null,
+                Arg.Any<CancellationToken>());
+
+            FeatureFlags.UseCteBasedListWithCount = true; 
+            await CreateQueryBuilder<object>("Orders")
+                .OrderByDescending("LastModified")
+                .Where("Id", UnarySqlOperand.Equal, "1")
+                .ToListWithCountAsync(10, 20);
+
+                query.Should().BeEquivalentTo(@"With  ALIAS_GENERATED_1 as (
+    SELECT *
+    FROM [dbo].[Orders]
+    WHERE ([Id] = @id)
+)
+SELECT ALIAS_GENERATED_3.*,
+ALIAS_GENERATED_4.[CrossJoinCount]
+FROM (
+    SELECT *
+    FROM (
+        SELECT *,
+        ROW_NUMBER() OVER (ORDER BY [LastModified] DESC) AS RowNum
+        FROM [ALIAS_GENERATED_1]
+    ) ALIAS_GENERATED_2
+    WHERE ([RowNum] >= @_minrow)
+    AND ([RowNum] <= @_maxrow)
+) ALIAS_GENERATED_3
+CROSS JOIN (
+    SELECT COUNT(*) AS CrossJoinCount
+    FROM [ALIAS_GENERATED_1]
+) ALIAS_GENERATED_4
+ORDER BY ALIAS_GENERATED_3.[RowNum]");
 
             parameterValues.Should().HaveCount(3);
             parameterValues["id"].Should().BeEquivalentTo("1");

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -1774,7 +1774,7 @@ ORDER BY [RowNum]");
                 .Where("Id", UnarySqlOperand.Equal, "1")
                 .ToListWithCountAsync(10, 20);
 
-                query.Should().BeEquivalentTo(@"With  ALIAS_GENERATED_1 as (
+                query.Should().BeEquivalentTo(@"With ALIAS_GENERATED_1 as (
     SELECT *
     FROM [dbo].[Orders]
     WHERE ([Id] = @id)
@@ -1792,7 +1792,7 @@ FROM (
     AND ([RowNum] <= @_maxrow)
 ) ALIAS_GENERATED_3
 CROSS JOIN (
-    SELECT COUNT(*) AS CrossJoinCount
+    SELECT COUNT(*) AS [CrossJoinCount]
     FROM [ALIAS_GENERATED_1]
 ) ALIAS_GENERATED_4
 ORDER BY ALIAS_GENERATED_3.[RowNum]");

--- a/source/Nevermore/Advanced/FeatureFlags.cs
+++ b/source/Nevermore/Advanced/FeatureFlags.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Nevermore.Advanced
+{
+    internal static class FeatureFlags
+    {
+        static FeatureFlags()
+        {
+            UseCteBasedListWithCount = Environment.GetEnvironmentVariable("NEVERMORE__UseCteBasedListWithCount") == "true";
+        }
+
+        public static bool UseCteBasedListWithCount { get; set; }
+    }
+}

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -438,7 +438,7 @@ namespace Nevermore.Advanced
             var primaryQuery = CreateSubQueryFromCte(cteTableBuilder);
             var innerCountSubQuery = CreateCountQueryFromCte(cteTableReference);
             var crossJoinPrimaryWithCount = CrossJoinDataWithTotalCount(primaryQuery, innerCountSubQuery);
-            return new CteSelectSource(originalSelectBuilder.GenerateSelectWithoutDefaultOrderBy(), cteTableReference.TableName, crossJoinPrimaryWithCount);
+            return new CteSelectSource(originalSelectBuilder.GenerateSelectWithoutDefaultOrderBy(), cteTableReference.TableName, crossJoinPrimaryWithCount.GenerateSelect());
 
             TableSelectBuilder CreateCteQuery(SchemalessTableSource cteTableSource, OrderByField[] orderBys)
             {
@@ -487,8 +487,8 @@ namespace Nevermore.Advanced
             SubquerySource CreateCountQueryFromCte(SchemalessTableSource cteTableSource)
             {
                 var innerCountTableBuilder = new TableSelectBuilder(cteTableSource, new Column(totalCountColumnName));
-                innerCountTableBuilder.AddColumnSelection(new SelectCountSource(totalCountColumnName));
-                return new SubquerySource(innerCountTableBuilder.GenerateSelect(), tableAliasGenerator.GenerateTableAlias());
+                innerCountTableBuilder.AddColumnSelection(new AliasedColumn(new SelectCountSource(), totalCountColumnName));
+                return new SubquerySource(innerCountTableBuilder.GenerateSelectWithoutDefaultOrderBy(), tableAliasGenerator.GenerateTableAlias());
             }
         }
 

--- a/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
+++ b/source/Nevermore/Advanced/SelectBuilders/SelectBuilderBase.cs
@@ -38,9 +38,11 @@ namespace Nevermore.Advanced.SelectBuilders
 
         protected abstract IEnumerable<OrderByField> GetDefaultOrderByFields();
 
-        public void RemoveOrderBys()
+        public OrderByField[] RemoveOrderBys()
         {
+            var originalClauses = OrderByClauses.ToArray();
             OrderByClauses.Clear();
+            return originalClauses;
         }
 
         public ISelect GenerateSelect()
@@ -115,6 +117,11 @@ namespace Nevermore.Advanced.SelectBuilders
         {
             GroupByClauses.Add(new GroupByField(new TableColumn(new Column(fieldName), tableAlias)));
         }
+
+        public virtual void AddOrder(OrderByField orderBy)
+        {
+            OrderByClauses.Add(orderBy);
+        }
         
         public virtual void AddOrder(string fieldName, bool @descending)
         {
@@ -172,6 +179,11 @@ namespace Nevermore.Advanced.SelectBuilders
         public virtual void AddRowNumberColumn(string alias, IReadOnlyList<Column> partitionBys)
         {
             InnerAddRowNumberColumn(alias, partitionBys);
+        }
+        
+        public void AddRowNumberColumn(string alias)
+        {
+            InnerAddRowNumberColumn(alias, Array.Empty<IColumn>());
         }
 
         public void AddRowNumberColumn(string alias, IReadOnlyList<TableColumn> partitionBys)

--- a/source/Nevermore/ISelectBuilder.cs
+++ b/source/Nevermore/ISelectBuilder.cs
@@ -12,7 +12,8 @@ namespace Nevermore
         
         void AddGroupBy(string fieldName);
         void AddGroupBy(string fieldName, string tableAlias);
-        
+
+        void AddOrder(OrderByField orderBy);
         void AddOrder(string fieldName, bool descending);
         void AddOrder(string fieldName, string tableAlias, bool descending);
         void AddWhere(UnaryWhereParameter whereParams);
@@ -28,7 +29,7 @@ namespace Nevermore
         void AddDefaultColumnSelection();
         void AddOption(string queryHint);
         void AddOptions(IReadOnlyList<string> queryHints);
-        void RemoveOrderBys();
+        OrderByField[] RemoveOrderBys();
         ISelect GenerateSelect();
         ISelect GenerateSelectWithoutDefaultOrderBy();
 

--- a/source/Nevermore/Querying/AST/CteSelectSource.cs
+++ b/source/Nevermore/Querying/AST/CteSelectSource.cs
@@ -5,26 +5,25 @@ namespace Nevermore.Querying.AST
     public class CteSelectSource : IAliasedSelectSource
     {
         
-        readonly ISelect source;
-        readonly ISelectBuilder inner;
+        readonly ISelect cteSelect;
+        readonly ISelect querySelect;
 
-        public CteSelectSource(ISelect source, string alias, ISelectBuilder inner)
+        public CteSelectSource(ISelect cteSelect, string alias, ISelect querySelect)
         {
             Alias = alias;
-            this.source = source;
-            this.inner = inner;
+            this.cteSelect = cteSelect;
+            this.querySelect = querySelect;
         }
 
         public string Alias { get; }
 
-        public string Schema => source.Schema;
+        public string Schema => cteSelect.Schema;
 
         public string GenerateSql()
         {
-            var alias = string.IsNullOrEmpty(Alias) ? string.Empty : $" {Alias}";
-            return $@"With {alias} as (
-{Format.IndentLines(source.GenerateSql())}
-){Environment.NewLine}{inner.GenerateSelect()}";
+            return $@"With {Alias} as (
+{Format.IndentLines(cteSelect.GenerateSql())}
+){Environment.NewLine}{querySelect.GenerateSql()}";
         }
 
         public override string ToString() => GenerateSql();

--- a/source/Nevermore/Querying/AST/CteSelectSource.cs
+++ b/source/Nevermore/Querying/AST/CteSelectSource.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Nevermore.Querying.AST
+{
+    public class CteSelectSource : IAliasedSelectSource
+    {
+        
+        readonly ISelect source;
+        readonly ISelectBuilder inner;
+
+        public CteSelectSource(ISelect source, string alias, ISelectBuilder inner)
+        {
+            Alias = alias;
+            this.source = source;
+            this.inner = inner;
+        }
+
+        public string Alias { get; }
+
+        public string Schema => source.Schema;
+
+        public string GenerateSql()
+        {
+            var alias = string.IsNullOrEmpty(Alias) ? string.Empty : $" {Alias}";
+            return $@"With {alias} as (
+{Format.IndentLines(source.GenerateSql())}
+){Environment.NewLine}{inner.GenerateSelect()}";
+        }
+
+        public override string ToString() => GenerateSql();
+    }
+}

--- a/source/Nevermore/Querying/AST/IColumn.cs
+++ b/source/Nevermore/Querying/AST/IColumn.cs
@@ -34,17 +34,17 @@
 
     public class TableColumn : IColumn
     {
-        readonly Column column;
-        readonly string tableAlias;
+        public readonly Column Column;
+        public readonly string TableAlias;
 
         public TableColumn(Column column, string tableAlias)
         {
-            this.column = column;
-            this.tableAlias = tableAlias;
+            this.Column = column;
+            this.TableAlias = tableAlias;
         }
 
         public bool AggregatesRows => false;
-        public string GenerateSql() => $"{tableAlias}.{column.GenerateSql()}";
+        public string GenerateSql() => $"{TableAlias}.{Column.GenerateSql()}";
         public override string ToString() => GenerateSql();
     }
 }

--- a/source/Nevermore/Querying/AST/IColumn.cs
+++ b/source/Nevermore/Querying/AST/IColumn.cs
@@ -47,4 +47,11 @@
         public string GenerateSql() => $"{TableAlias}.{Column.GenerateSql()}";
         public override string ToString() => GenerateSql();
     }
+
+    public class SelectCountSource : IColumn
+    {
+        public bool AggregatesRows => true;
+        public string GenerateSql() =>  "COUNT(*)";
+        public override string ToString() => GenerateSql();
+    }
 }

--- a/source/Nevermore/Querying/AST/ISelectColumns.cs
+++ b/source/Nevermore/Querying/AST/ISelectColumns.cs
@@ -96,8 +96,18 @@ namespace Nevermore.Querying.AST
 
     public class SelectCountSource : ISelectColumns
     {
+        readonly string alias;
+        public SelectCountSource(string alias): this()
+        {
+            this.alias = alias;
+        }
+        
+        public SelectCountSource()
+        {
+        }
+        
         public bool AggregatesRows => true;
-        public string GenerateSql() => "COUNT(*)";
+        public string GenerateSql() => string.IsNullOrEmpty(alias) ? "COUNT(*)" : $"COUNT(*) AS {alias}";
         public override string ToString() => GenerateSql();
     }
 

--- a/source/Nevermore/Querying/AST/ISelectColumns.cs
+++ b/source/Nevermore/Querying/AST/ISelectColumns.cs
@@ -94,23 +94,6 @@ namespace Nevermore.Querying.AST
         public override string ToString() => GenerateSql();
     }
 
-    public class SelectCountSource : ISelectColumns
-    {
-        readonly string alias;
-        public SelectCountSource(string alias): this()
-        {
-            this.alias = alias;
-        }
-        
-        public SelectCountSource()
-        {
-        }
-        
-        public bool AggregatesRows => true;
-        public string GenerateSql() => string.IsNullOrEmpty(alias) ? "COUNT(*)" : $"COUNT(*) AS {alias}";
-        public override string ToString() => GenerateSql();
-    }
-
     public class SelectRowNumber : ISelectColumns
     {
         readonly Over over;

--- a/source/Nevermore/Querying/AST/ITableSource.cs
+++ b/source/Nevermore/Querying/AST/ITableSource.cs
@@ -15,7 +15,7 @@ namespace Nevermore.Querying.AST
 
     public class SchemalessTableSource : ISimpleTableSource
     {
-        public string Schema => throw new NotImplementedException();
+        public string Schema => throw new InvalidOperationException("Schemaless Tables do not have a schema");
         public string GenerateSql() => $"[{TableName}]";
 
         public SchemalessTableSource(string tableOrViewName)

--- a/source/Nevermore/Querying/AST/ITableSource.cs
+++ b/source/Nevermore/Querying/AST/ITableSource.cs
@@ -1,4 +1,5 @@
-﻿using Nevermore.Advanced;
+﻿using System;
+using Nevermore.Advanced;
 
 namespace Nevermore.Querying.AST
 {
@@ -10,6 +11,20 @@ namespace Nevermore.Querying.AST
 
     public interface ISimpleTableSource : ITableSource
     {
+    }
+
+    public class SchemalessTableSource : ISimpleTableSource
+    {
+        public string Schema => throw new NotImplementedException();
+        public string GenerateSql() => $"[{TableName}]";
+
+        public SchemalessTableSource(string tableOrViewName)
+        {
+            TableName = tableOrViewName;
+        }
+        
+        public string TableName { get; }
+        public string[] ColumnNames => Array.Empty<string>();
     }
 
     public class SimpleTableSource : ISimpleTableSource

--- a/source/Nevermore/Querying/AST/OrderBy.cs
+++ b/source/Nevermore/Querying/AST/OrderBy.cs
@@ -27,23 +27,4 @@ namespace Nevermore.Querying.AST
         Ascending,
         Descending
     }
-
-    public class OrderByField
-    {
-        readonly IColumn column;
-        readonly OrderByDirection direction;
-
-        public OrderByField(IColumn column, OrderByDirection direction = OrderByDirection.Ascending)
-        {
-            this.column = column;
-            this.direction = direction;
-        }
-
-        public string GenerateSql()
-        {
-            return $"{column.GenerateSql()}{(direction == OrderByDirection.Descending ? " DESC" : string.Empty)}";
-        }
-
-        public override string ToString() => GenerateSql();
-    }
 }

--- a/source/Nevermore/Querying/AST/OrderByField.cs
+++ b/source/Nevermore/Querying/AST/OrderByField.cs
@@ -1,0 +1,21 @@
+namespace Nevermore.Querying.AST
+{
+    public class OrderByField
+    {
+        public readonly IColumn Column;
+        public readonly OrderByDirection Direction;
+
+        public OrderByField(IColumn column, OrderByDirection direction = OrderByDirection.Ascending)
+        {
+            this.Column = column;
+            this.Direction = direction;
+        }
+
+        public string GenerateSql()
+        {
+            return $"{Column.GenerateSql()}{(Direction == OrderByDirection.Descending ? " DESC" : string.Empty)}";
+        }
+
+        public override string ToString() => GenerateSql();
+    }
+}


### PR DESCRIPTION
# Background
The `ToListWithCount()` operation is used in many different locations within Octopus Server. This operation as it is currently written results in 2 different operations, a paged query and a count query. Although the query is _largely_ the same for both, this is still 2 operations to the DBMS. 

## Solution
From some simple testing, converting the 2 queries into a single query via a CTE results in an improvement in test databases. This CTE includes the underlying data, paging, and crucially, another column which contains the _same_ count value on every record. This total count value is provided by a `CROSS APPLY` subquery with a `COUNT(*)` statement. In testing, including the count as a subquery directly in the `SELECT` statemen appeared to provide similar stats.

## Key Changes
- For testing and evaluation purposes, an [environment variable](https://github.com/OctopusDeploy/Nevermore/pull/200/files#diff-73f84433172c2736b07de81ebdaa986bee229c0be90da4f760b16bdc3eaee465R9) `NEVERMORE__UseCteBasedListWithCount` is added to allow opting into the new algorithm.
- New `ToListWithCount()` [operation](https://github.com/OctopusDeploy/Nevermore/pull/200/files#diff-5e2cb95109160b57b6e3671f113274fb13cea2fc6333f5cb55c6a76f62a49570R564) has been updated to [build](https://github.com/OctopusDeploy/Nevermore/pull/200/files#diff-5e2cb95109160b57b6e3671f113274fb13cea2fc6333f5cb55c6a76f62a49570R420) a CTE query
- ThreadSafe support extended to `StreamAsync` when [custom mapper is used](https://github.com/OctopusDeploy/Nevermore/pull/200/files#diff-cb574f356346d8539d664d75fd6253faf8ab060fb248df62fd320b0f5842214fR501).

## Take Note ⚠️
As noted, this change makes use of an environment-variable provided feature flag to opt into the new behavior. This will be turned on for some of our larger customers so we can assess if this actually provides better performance. Lower data sets result in almost like-for-like performance characteristics between the CTE and 2-query approach however there appeared to be a 50% improvement when working with larger datasets. Once we have confirmed the improvements we will remove the flag in the next few months. At that point we may also elevate CTE operations up as a more standard operation.