### PR TITLE
Fix SQL generation bug when using DistinctAsync

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -456,6 +456,24 @@ WHERE ([Price] > 5)";
             actual.Should().Be(expected);
         }
 
+        [Test]
+        public void ShouldGenerateDistinctAsync()
+        {
+            string actual = null;
+            transaction.StreamAsync<object>(Arg.Do<string>(s => actual = s), Arg.Any<CommandParameterValues>());
+            CreateQueryBuilder<object>("Orders")
+                .NoLock()
+                .Where("[Price] > 5")
+                .Column("Name")
+                .DistinctAsync();
+
+            var expected = @"SELECT DISTINCT [Name]
+FROM [dbo].[Orders] NOLOCK
+WHERE ([Price] > 5)";
+
+            actual.Should().Be(expected);
+        }
+
 
         [Test]
         public void ShouldGenerateDistinctForJoin()

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -373,7 +373,7 @@ namespace Nevermore.Advanced
             var clonedSelectBuilder = selectBuilder.Clone();
             clonedSelectBuilder.AddDistinct();
             clonedSelectBuilder.AddOptions(optionClauses);
-            var stream = readQueryExecutor.StreamAsync<TRecord>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, commandTimeout, cancellationToken);
+            var stream = readQueryExecutor.StreamAsync<TRecord>(clonedSelectBuilder.GenerateSelectWithoutDefaultOrderBy().GenerateSql(), paramValues, commandTimeout, cancellationToken);
             return stream;
         }
 


### PR DESCRIPTION
# Background

The `DistinctAsync()` method of the query builder does not exclude the default ORDER BY clause, like its synchronous counterpart.

Fixes https://github.com/OctopusDeploy/Nevermore/issues/201