### PR TITLE
Update global.json to explicitly use .NET 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
     "sdk": {
-        "version": "3.1.100",
-        "rollForward": "latestMajor"
+        "version": "6.0.300",
+        "rollForward": "latestMajor",
+        "allowPrerelease": false
     }
 }


### PR DESCRIPTION
Also turn off building with a pre-release .NET version if one ever showed up