### PR TITLE
cover ToListWithCount where zero results are returned

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -103,34 +103,5 @@ namespace Nevermore.IntegrationTests
             public string CustomerName { get; set; }
             public string ProductName { get; set; }
         }
-
-        [Test]
-        [TestCase(false)]
-        [TestCase(true)] //Temporary test to cover and compare legacy mechanism for loading data. Remove once legacy approach deprecated
-        public async Task WhereToListWithCountAsync(bool useCteOperation)
-        {
-            using (var t = Store.BeginTransaction())
-            {
-                foreach (var c in new[]
-                         {
-                             new Customer {FirstName = "Alice", LastName = "Apple", Nickname = null},
-                             new Customer {FirstName = "Bob", LastName = "Banana", Nickname = ""},
-                             new Customer {FirstName = "Charlie", LastName = "Cherry", Nickname = "Chazza"},
-                             new Customer {FirstName = "David", LastName = "Derkins", Nickname = "Dazza"},
-                             new Customer {FirstName = "Eric", LastName = "Evans", Nickname = "Bob"}
-                         })
-                    t.Insert(c);
-                await t.CommitAsync(CancellationToken.None);
-
-                FeatureFlags.UseCteBasedListWithCount = useCteOperation;
-                var (items, count) = await t.Query<Customer>()
-                    .OrderByDescending(o => o.LastName)
-                    .Where(n => n.Nickname != null)
-                    .ToListWithCountAsync(1, 2, CancellationToken.None);
-
-                CollectionAssert.AreEqual(items.Select(p => p.FirstName), new []{"David", "Charlie"});
-                count.Should().Be(4);
-            }
-        }
     }
 }

--- a/source/Nevermore.IntegrationTests/ToListWithCountAsyncFixture.cs
+++ b/source/Nevermore.IntegrationTests/ToListWithCountAsyncFixture.cs
@@ -1,0 +1,71 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.Advanced;
+using Nevermore.IntegrationTests.Model;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests
+{
+    public class ToListWithCountAsyncFixture: FixtureWithRelationalStore
+    {
+        
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)] //Temporary test to cover and compare legacy mechanism for loading data. Remove once legacy approach deprecated
+        public async Task QueryReturnsCorrectDataPageAndCount(bool useCteOperation)
+        {
+            using (var t = Store.BeginTransaction())
+            {
+                foreach (var c in new[]
+                         {
+                             new Customer {FirstName = "Alice", LastName = "Apple", Nickname = null},
+                             new Customer {FirstName = "Bob", LastName = "Banana", Nickname = ""},
+                             new Customer {FirstName = "Charlie", LastName = "Cherry", Nickname = "Chazza"},
+                             new Customer {FirstName = "David", LastName = "Derkins", Nickname = "Dazza"},
+                             new Customer {FirstName = "Eric", LastName = "Evans", Nickname = "Bob"}
+                         })
+                    t.Insert(c);
+                await t.CommitAsync(CancellationToken.None);
+
+                FeatureFlags.UseCteBasedListWithCount = useCteOperation;
+                var (items, count) = await t.Query<Customer>()
+                    .OrderByDescending(o => o.LastName)
+                    .Where(n => n.Nickname != null)
+                    .ToListWithCountAsync(1, 2, CancellationToken.None);
+
+                CollectionAssert.AreEqual(items.Select(p => p.FirstName), new []{"David", "Charlie"});
+                count.Should().Be(4);
+            }
+        }
+        
+        
+        [Test]
+        [TestCase(1, 0, Description = "Zero sized page")]
+        [TestCase(100, 1, Description = "Skip beyond available")]
+        public async Task WhenPageReturnsNoDataThenNonZeroCountStillReturns(int skip, int take)
+        {
+            using (var t = Store.BeginTransaction())
+            {
+                foreach (var c in new[]
+                         {
+                             new Customer {FirstName = "Alice", LastName = "Apple", Nickname = null},
+                             new Customer {FirstName = "Bob", LastName = "Banana", Nickname = "Bazza"},
+                             new Customer {FirstName = "Charlie", LastName = "Cherry", Nickname = "Chazza"},
+                         })
+                    t.Insert(c);
+                await t.CommitAsync(CancellationToken.None);
+
+                FeatureFlags.UseCteBasedListWithCount = true;
+                var (items, count) = await t.Query<Customer>()
+                    .Where(c => c.Nickname != null)
+                        .ToListWithCountAsync(skip, take, CancellationToken.None);
+
+                items.Should().BeEmpty();
+                count.Should().Be(2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix for a bug in the new single-query-ToListWithCount operation where no results are returned. Since the total count is "piggy-backed" on the result set, if result set is returned then we miss out on the count. 

To work around this we fallback to just calling the count instead. This may result in performing 2 calls as we were originally trying to avoid, however this should be edge-case and no worse than what it already was before.