### PR TITLE
Ensure a schema is passed to column name resolvers even if one isn't specified in a document map

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.Mapping;
+using Nevermore.TableColumnNameResolvers;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced
+{
+    public class ReadTransactionFixture : FixtureWithDatabase
+    {
+        const string DefaultSchemaName = "TestSchema";
+        const string DifferentSchemaName = "DifferentSchema";
+
+        IRelationalStoreConfiguration configuration;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            configuration = new RelationalStoreConfiguration(ConnectionString)
+            {
+                CommandFactory = new SqlCommandFactory(),
+                ApplicationName = "Nevermore-IntegrationTests",
+                DefaultSchema = DefaultSchemaName
+            };
+            configuration.DocumentMaps.Register(new TableDocumentMap());
+
+            ExecuteSql($"create table {DefaultSchemaName}.{nameof(TableDocument)} (Id nvarchar(50), ColumnName nvarchar(10))");
+
+            ExecuteSql($"create schema {DifferentSchemaName}");
+            ExecuteSql($"create table {DifferentSchemaName}.{nameof(TableDocument)} (ColumnInOtherSchema nvarchar(10))");
+        }
+
+        [Test]
+        public async Task LoadRequired_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
+        {
+            await AssertSchemaIsCorrectAfterMethodCall(async t =>
+            {
+                await Task.CompletedTask;
+                return t.LoadRequired<TableDocument, string>("MyId");
+            });
+        }
+
+        [Test]
+        public async Task LoadRequiredAsync_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
+        {
+            await AssertSchemaIsCorrectAfterMethodCall(async t => await t.LoadRequiredAsync<TableDocument, string>("MyId"));
+        }
+
+        [Test]
+        public async Task LoadStream_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
+        {
+            await AssertSchemaIsCorrectAfterMethodCall(async t =>
+            {
+                await Task.CompletedTask;
+                return t.LoadStream<TableDocument, string>("MyId", "TheirId").GetEnumerator().MoveNext();
+            });
+        }
+
+        [Test]
+        public async Task LoadStreamAsync_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
+        {
+            await AssertSchemaIsCorrectAfterMethodCall(async t => await t.LoadStreamAsync<TableDocument, string>(new[] { "MyId", "TheirId" }).GetAsyncEnumerator().MoveNextAsync());
+        }
+
+        async Task AssertSchemaIsCorrectAfterMethodCall<T>(Func<IRelationalTransaction, Task<T>> func)
+        {
+            var store = new RelationalStore(configuration);
+
+            var recordingColumnResolver = new TableColumnNameResolverThatRecordsTheSchema();
+            configuration.TableColumnNameResolver = _ => recordingColumnResolver;
+            using var transaction = store.BeginTransaction();
+            try {
+                await func(transaction);
+            }
+            catch{} //We don't care about any exceptions here (but we're going to have some for resources not found)
+
+            recordingColumnResolver.SchemaNameAsProvided.Should().BeEquivalentTo(configuration.DefaultSchema);
+        }
+
+        class TableColumnNameResolverThatRecordsTheSchema : ITableColumnNameResolver
+        {
+            public string SchemaNameAsProvided;
+
+            public string[] GetColumnNames(string schemaName, string tableName)
+            {
+                SchemaNameAsProvided = schemaName;
+                return new[] { "Id", "ColumnName" };
+            }
+        }
+
+        class TableDocument
+        {
+            public string Id { get; set; }
+            public string ColumnName { get; set; }
+        }
+
+        class TableDocumentMap : DocumentMap<TableDocument>
+        {
+            public TableDocumentMap()
+            {
+                Id(x => x.Id);
+                Column(x => x.ColumnName);
+                JsonStorageFormat = JsonStorageFormat.NoJson;
+            }
+        }
+    }
+}

--- a/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
@@ -34,36 +34,37 @@ namespace Nevermore.IntegrationTests.Advanced
         [Test]
         public async Task LoadRequired_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
         {
-            await AssertSchemaIsCorrectAfterMethodCall(async t =>
+            await AssertSchemaIsCorrectAfterMethodCall(async relationalTransaction =>
             {
                 await Task.CompletedTask;
-                return t.LoadRequired<TableDocument, string>("MyId");
+                return relationalTransaction.LoadRequired<TableDocument, string>("MyId");
             });
         }
 
         [Test]
         public async Task LoadRequiredAsync_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
         {
-            await AssertSchemaIsCorrectAfterMethodCall(async t => await t.LoadRequiredAsync<TableDocument, string>("MyId"));
+            await AssertSchemaIsCorrectAfterMethodCall(async relationalTransaction => await relationalTransaction.LoadRequiredAsync<TableDocument, string>("MyId"));
         }
 
         [Test]
         public async Task LoadStream_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
         {
-            await AssertSchemaIsCorrectAfterMethodCall(async t =>
+            await AssertSchemaIsCorrectAfterMethodCall(async relationalTransaction =>
             {
                 await Task.CompletedTask;
-                return t.LoadStream<TableDocument, string>("MyId", "TheirId").GetEnumerator().MoveNext();
+                return relationalTransaction.LoadStream<TableDocument, string>("MyId", "TheirId").GetEnumerator().MoveNext();
             });
         }
 
         [Test]
         public async Task LoadStreamAsync_WhenNoSchemaSpecifiedThenResolveTableColumnsFromDefaultSchema()
         {
-            await AssertSchemaIsCorrectAfterMethodCall(async t => await t.LoadStreamAsync<TableDocument, string>(new[] { "MyId", "TheirId" }).GetAsyncEnumerator().MoveNextAsync());
+            await AssertSchemaIsCorrectAfterMethodCall(async relationalTransaction =>
+                await relationalTransaction.LoadStreamAsync<TableDocument, string>(new[] { "MyId", "TheirId" }).GetAsyncEnumerator().MoveNextAsync());
         }
 
-        async Task AssertSchemaIsCorrectAfterMethodCall<T>(Func<IRelationalTransaction, Task<T>> func)
+        async Task AssertSchemaIsCorrectAfterMethodCall<T>(Func<IRelationalTransaction, Task<T>> relationalTransactionMethod)
         {
             var store = new RelationalStore(configuration);
             var recordingColumnResolver = new TableColumnNameResolverThatRecordsTheSchema();
@@ -72,7 +73,7 @@ namespace Nevermore.IntegrationTests.Advanced
             using var transaction = store.BeginTransaction();
             
             try {
-                await func(transaction);
+                await relationalTransactionMethod(transaction);
             }
             catch{} //We don't care about any exceptions here (but we're going to have some for resources not found)
 

--- a/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/ReadTransactionFixture.cs
@@ -27,7 +27,6 @@ namespace Nevermore.IntegrationTests.Advanced
             configuration.DocumentMaps.Register(new TableDocumentMap());
 
             ExecuteSql($"create table {DefaultSchemaName}.{nameof(TableDocument)} (Id nvarchar(50), ColumnName nvarchar(10))");
-
             ExecuteSql($"create schema {DifferentSchemaName}");
             ExecuteSql($"create table {DifferentSchemaName}.{nameof(TableDocument)} (ColumnInOtherSchema nvarchar(10))");
         }
@@ -67,10 +66,11 @@ namespace Nevermore.IntegrationTests.Advanced
         async Task AssertSchemaIsCorrectAfterMethodCall<T>(Func<IRelationalTransaction, Task<T>> func)
         {
             var store = new RelationalStore(configuration);
-
             var recordingColumnResolver = new TableColumnNameResolverThatRecordsTheSchema();
             configuration.TableColumnNameResolver = _ => recordingColumnResolver;
+
             using var transaction = store.BeginTransaction();
+            
             try {
                 await func(transaction);
             }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -628,7 +628,7 @@ namespace Nevermore.Advanced
             if (mapping.IdColumn.Type != typeof(TKey))
                 throw new ArgumentException($"Provided Id of type '{id?.GetType().FullName}' does not match configured type of '{mapping.IdColumn?.Type.FullName}'.");
 
-            var columnNames = GetColumnNames(mapping.SchemaName, mapping.TableName);
+            var columnNames = GetColumnNames(configuration.GetSchemaNameOrDefault(mapping), mapping.TableName);
             var tableName = mapping.TableName;
             var args = new CommandParameterValues { { "Id", mapping.IdColumn.PrimaryKeyHandler.ConvertToPrimitiveValue(id) } };
 
@@ -642,7 +642,7 @@ namespace Nevermore.Advanced
             if (mapping.IdColumn?.Type != typeof(TKey))
                 throw new ArgumentException($"Provided Id of type '{typeof(TKey).FullName}' does not match configured type of '{mapping.IdColumn?.Type.FullName}'.");
 
-            var columnNames = GetColumnNames(mapping.SchemaName, mapping.TableName);
+            var columnNames = GetColumnNames(configuration.GetSchemaNameOrDefault(mapping), mapping.TableName);
             var param = new CommandParameterValues();
             param.AddTable("criteriaTable", idList.ToList(), configuration);
             var statement = $"SELECT s.{string.Join(',', columnNames)} FROM [{configuration.GetSchemaNameOrDefault(mapping)}].[{mapping.TableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -649,7 +649,7 @@ namespace Nevermore.Advanced
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }
 
-        public string[] GetColumnNames(string? schemaName, string tableName)
+        public string[] GetColumnNames(string schemaName, string tableName)
         {
             return columnNameResolver.GetColumnNames(schemaName, tableName);
         }

--- a/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
+++ b/source/Nevermore/TableColumnNameResolvers/JsonLastTableColumnNameResolver.cs
@@ -14,10 +14,6 @@ namespace Nevermore.TableColumnNameResolvers
 
         public string[] GetColumnNames(string schemaName, string tableName)
         {
-            var schemaClause = string.IsNullOrEmpty(schemaName)
-                ? ""
-                : "AND s.name = @schemaName";
-
             var getColumnNamesWithJsonLastQuery = @$"
 SELECT c.name
 FROM (
@@ -27,7 +23,7 @@ FROM (
 ) as t
 INNER JOIN sys.all_columns AS c ON c.object_id = t.object_id
 INNER JOIN sys.schemas AS s ON t.schema_id = s.schema_id
-WHERE t.name = @tableName {schemaClause}
+WHERE t.name = @tableName AND s.name = @schemaName
 ORDER BY (CASE WHEN c.name = 'JSON' THEN 1 ELSE 0 END) ASC, c.column_id";
 
             var parameters = new CommandParameterValues


### PR DESCRIPTION
# Background #
If two tables with the same name exist in different schemas, and a schema name isn't provided for related document mappings, the `ReadTransaction` will pass a null schema name to any column resolvers.
In the case of `JsonLastTableColumnNameResolver`, this means columns from _both_ tables will be resolved💥 

This fix just changes `mapping.SchemaName` to `configuration.GetSchemaNameOrDefault(mapping)` in `ReadTransaction.PrepareLoad(..)` and `ReadTransaction.PrepareLoadMany(..)`.

## Notes ##
This issue could also be fixed by changing `JsonLastTableColumnNameResolver`, however I decided against that, for a couple of reasons:
- We have to get the schema from the map in `ReadTransaction` anyway, so it would be odd to get the schema there, then replace it in column name resolver if it's null.
- The `.Query()` method has to do (and already does) the same thing in this same class.
- And finally, if we do it in `JsonLastTableColumnNameResolver`, other column name resolvers could potentially have the same issue. 

Ideally testing for this would be done as unit tests, but given the design of the `ReadTransaction` class and its dependencies, we'd end up with a million mocks.
