### PR TITLE
Ensured rethrown SqlExceptions are being wrapped to preserve consumer exception handling assumptions

### DIFF
--- a/source/Nevermore/CommandExecutor.cs
+++ b/source/Nevermore/CommandExecutor.cs
@@ -215,7 +215,7 @@ namespace Nevermore
                 builder.AppendLine(ex.Message);
                 builder.AppendLine("Current transactions: ");
                 transaction.WriteCurrentTransactions(builder);
-                throw new Exception(builder.ToString());
+                throw new Exception(builder.ToString(), ex);
             }
 
             Log.DebugException($"Error while executing SQL command in transaction '{transaction.Name}'", ex);


### PR DESCRIPTION
# Background
The `WrapException` method rethrows an `Exception` when a `SqlException` is encountered. However, for certain types of `SqlExceptions`, it doesn't include the original `SqlException` as part of the rethrown `Exception`.

There are instances of consuming code that depends on the presence of this `SqlException` as an inner exception that break when more `Number`s are captured by this condition
```
if (ex is SqlException {Number: 1205 or 1222 or -2})
```
as it causes the raised `Exception` to exclude wrapping any inner exception.

# Before
No inner exception when deadlocks, timeouts and row lock timeouts are encountered. If other types of `SqlException`s are added in the same fashion, when those exceptions are raised, they will also stop containing inner exceptions.

# After
`SqlException` as an inner exception for all types of `SqlException`s



