### PR TITLE
Allow translation of Hint extension by EnumerableQuery

### DIFF
--- a/source/Nevermore.Tests/Queryable/QueryableExtensionsFixture.cs
+++ b/source/Nevermore.Tests/Queryable/QueryableExtensionsFixture.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nevermore.Advanced.Queryable;
+using NUnit.Framework;
+
+namespace Nevermore.Tests.Queryable
+{
+    public class QueryableExtensionsFixture
+    {
+        [Test]
+        public void HintCanBeTranslatedByEnumerableQuery()
+        {
+            var list = new List<string>()
+            {
+                "hello",
+                "there"
+            }.AsQueryable();
+
+            var thing = list.Hint("ABC").FirstOrDefault(s => s == "hello");
+
+            thing.Should().Be("hello");
+        }
+    }
+}

--- a/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
@@ -47,6 +47,14 @@ namespace Nevermore.Advanced.Queryable
                     source.Expression, Expression.Constant(hint)));
         }
 
+        // This method does nothing, but is necessary to support using this extension with
+        // an EnumerableQuery-backed IQueryable<T>.
+        // ReSharper disable once UnusedParameter.Global
+        public static IEnumerable<TSource> Hint<TSource>(this IEnumerable<TSource> source, string hint)
+        {
+            return source;
+        }
+
         public static string RawDebugView<TSource>(this IQueryable<TSource> source)
         {
             if (source == null)


### PR DESCRIPTION
# Background

When using the `Enumerable.AsQueryable` extension method, the returned `IQueryable` will be backed by an [`EnumerableQuery`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs) provider. This class executes queries by walking the expression tree looking for `IQueryable` extension method calls (`Where()`, `Select()`, etc.), and translates them to their `IEnumerable` counterparts. It then compiles the expression and executes it directly.

The `Hint()` extension method that Nevermore provides doesn't have an `IEnumerable` counterpart, so when it's encountered the translation fails with the following exception:

```
System.InvalidOperationException: There is no method 'Hint' on type 'Nevermore.Advanced.Queryable.NevermoreQueryableExtensions' that matches the specified arguments
```

This typically would happen in a test scenario where the `IQueryable` is being mocked, rather than going through the Nevermore query provider.

# Result

Add a pretty useless `IEnumerable` version of the `Hint()` extension method, which allows the `EnumerableQuery` to do its translation successfully.