### PR TITLE
Update tests to target net6.0

### DIFF
--- a/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
+++ b/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.10.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.20" />
-        <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nevermore.Benchmarks/Nevermore.Benchmarks.csproj
+++ b/source/Nevermore.Benchmarks/Nevermore.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="dbup-core" Version="4.1.0" />
-      <PackageReference Include="dbup-sqlserver" Version="4.1.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+      <PackageReference Include="dbup-core" Version="4.6.3" />
+      <PackageReference Include="dbup-sqlserver" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nevermore.IntegrationTests/Advanced/InstanceTypesFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/InstanceTypesFixture.cs
@@ -1,10 +1,8 @@
 using System;
-using BenchmarkDotNet.Disassemblers;
 using FluentAssertions;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.IntegrationTests.SetUp;
 using Nevermore.Mapping;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Nevermore.IntegrationTests.Advanced
@@ -140,7 +138,7 @@ namespace Nevermore.IntegrationTests.Advanced
         }
 
         [Test, Order(5)]
-        public void ThrowsWhenUnexpectedTypeIsEncountedByDefault()
+        public void ThrowsWhenUnexpectedTypeIsEncounteredByDefault()
         {
             using var transaction = Store.BeginTransaction();
             transaction.ExecuteNonQuery("update TestSchema.Account set [Type] = 'dunno' where Id = 'Accounts-1'");

--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <IsPackable>false</IsPackable>
     <WarningsAsErrors />
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nevermore\Nevermore.csproj" />
@@ -21,18 +21,17 @@
     <Analyzer Include="..\Nevermore.Analyzers\bin\**\Nevermore.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="dbup-core" Version="4.6.3" />
+    <PackageReference Include="dbup-sqlserver" Version="4.6.0" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.20" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="dbup" Version="4.1.0" />
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/source/Nevermore.Tests/Nevermore.Tests.csproj
+++ b/source/Nevermore.Tests/Nevermore.Tests.csproj
@@ -12,7 +12,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <IsPackable>false</IsPackable>
     <WarningsAsErrors />
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nevermore\Nevermore.csproj" />
@@ -21,18 +21,12 @@
     <Analyzer Include="..\Nevermore.Analyzers\bin\**\Nevermore.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.20" />
-    <PackageReference Include="Assent" Version="1.3.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
+    <PackageReference Include="Assent" Version="1.8.2" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates the test projects to target `net6.0`, as `netcoreapp3.1` is EOL in December.

As part of the update, test NuGet packages were also bumped to the latest versions, and unused packages were removed.