### PR TITLE
Add batch processing for insert many transaction 

### DIFF
--- a/source/Nevermore/Util/EnumerableExtensions.cs
+++ b/source/Nevermore/Util/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Nevermore.Util
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> BatchWithBlockSize<T>(this IEnumerable<T> source, int blockSize)
+        {
+            return source
+                .Select((x, index) => new { x, index })
+                .GroupBy(x => x.index / blockSize, y => y.x);
+        }
+    }
+}


### PR DESCRIPTION
It was identified that for `insert many` transaction, there is a good possibility on exceeding 2100 SQL parameters limit, which caused `SQL Exception`.

This update is to process transaction in batches to avoid this issue