### PR TITLE
Add SQL Error Code 10936 to list of transient error codes

### DIFF
--- a/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
+++ b/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
@@ -69,6 +69,9 @@ namespace Nevermore.Transient
             // Resource ID: %d. The %s limit for the database is %d and has been reached. For more information,
             // see http://go.microsoft.com/fwlink/?LinkId=267637.
             10928,
+            // SQL Error Code: 10936
+            // Resource ID: %d. The request limit for the elastic pool is %d and has been reached. See 'http://go.microsoft.com/fwlink/?LinkId=267637' for assistance.
+            10936,
             // SQL Error Code: 10060
             // A network-related or instance-specific error occurred while establishing a connection to SQL Server.
             // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server


### PR DESCRIPTION
We (Cloud Platform) are frequently hitting the following error/exception when executing our E2E tests which utilise a SQL Azure Elastic Pool. 

`SQL Error 10936 - Resource ID : %d. The request limit for the elastic pool is %d and has been reached.`

There is little information on this specific error code available although there is an open [PR](https://github.com/MicrosoftDocs/azure-docs/issues/54599) on the Azure Docs repo for this to be documented.

This PR adds this specific error code to the list of `SimpleTransientErrorCodes` 

[EF Core treats this as a transient error](https://github.com/dotnet/efcore/pull/20970) and as such I would expect this to be a safe addition to Nevermore.

It is worth noting that the list of transient error codes in EF Core (where these were originally sourced from based on code comments) now includes a number of additional codes not reflected in Nevermore. I'm happy to submit another PR to update this if this would be preferred?
