### PR TITLE
Adding Octopus prefix to avoid references dependency confusion

### DIFF
--- a/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
+++ b/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
@@ -4,7 +4,7 @@
         <!-- At the time of writing anything later than netstandard 2.0 doesn't work in Visual Studio -->
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Nevermore.Analyzers</AssemblyName>
-        <PackageId>Nevermore.Analyzers</PackageId>
+        <PackageId>Octopus.Nevermore.Analyzers</PackageId>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
         <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
         <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/source/Nevermore.Benchmarks/Nevermore.Benchmarks.csproj
+++ b/source/Nevermore.Benchmarks/Nevermore.Benchmarks.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+        <PackageId>Octopus.Nevermore.Benchmarks</PackageId>
     </PropertyGroup>
     
     <ItemGroup>

--- a/source/Nevermore.Contracts/Nevermore.Contracts.csproj
+++ b/source/Nevermore.Contracts/Nevermore.Contracts.csproj
@@ -4,7 +4,7 @@
     <Description>A JSON Document Store library for SQL Server</Description>
     <Authors>Octopus Deploy</Authors>
     <AssemblyName>Nevermore.Contracts</AssemblyName>
-    <PackageId>Nevermore.Contracts</PackageId>
+    <PackageId>Octopus.Nevermore.Contracts</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Nevermore</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/OctopusDeploy/Nevermore/blob/master/LICENSE.txt</PackageLicenseUrl>

--- a/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
+++ b/source/Nevermore.Extensions.DependencyInjection/Nevermore.Extensions.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageId>Nevermore.Extensions.DependencyInjection</PackageId>
+    <PackageId>Octopus.Nevermore.Extensions.DependencyInjection</PackageId>
     <Version>1.0.0.0</Version>
     <Authors>Octopus Deploy and contributors</Authors>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Nevermore</PackageProjectUrl>

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
     <AssemblyName>Nevermore</AssemblyName>
-    <PackageId>Nevermore</PackageId>
+    <PackageId>Octopus.Nevermore</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
This work is to address [issue 216](https://github.com/OctopusDeploy/Nevermore/issues/216).

Updating packages to prepend `Octopus`, a reserved prefix on nuget.org