### PR TITLE
Allow query generator to discriminate by type

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/InstanceTypesFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/InstanceTypesFixture.cs
@@ -46,7 +46,7 @@ namespace Nevermore.IntegrationTests.Advanced
 
         class AwsAccountTypeResolver : IInstanceTypeResolver
         {
-            public Type Resolve(Type baseType, object typeColumnValue)
+            public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
             {
                 if (!typeof(Account).IsAssignableFrom(baseType))
                     return null;
@@ -56,11 +56,20 @@ namespace Nevermore.IntegrationTests.Advanced
 
                 return null;
             }
+
+            public object ResolveValueFromType(Type type)
+            {
+                if (!typeof(Account).IsAssignableFrom(type))
+                    return null;
+
+                if (type == typeof(AwsAccount)) return "AWS";
+                return null;
+            }
         }
 
         class AzureAccountTypeResolver : IInstanceTypeResolver
         {
-            public Type Resolve(Type baseType, object typeColumnValue)
+            public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
             {
                 if (!typeof(Account).IsAssignableFrom(baseType))
                     return null;
@@ -68,6 +77,15 @@ namespace Nevermore.IntegrationTests.Advanced
                 if ((string) typeColumnValue == "Azure")
                     return typeof(AzureAccount);
                 
+                return null;
+            }
+
+            public object ResolveValueFromType(Type type)
+            {
+                if (!typeof(Account).IsAssignableFrom(type))
+                    return null;
+
+                if (type == typeof(AzureAccount)) return "Azure";
                 return null;
             }
         }
@@ -166,12 +184,18 @@ namespace Nevermore.IntegrationTests.Advanced
             // Runs after all other type handlers
             public int Order => int.MaxValue;
             
-            public Type Resolve(Type baseType, object typeColumnValue)
+            public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
             {
                 if (!typeof(Account).IsAssignableFrom(baseType))
                     return null;
 
                 return typeof(UnknownAccount);
+            }
+
+            public object ResolveValueFromType(Type type)
+            {
+                if (type == typeof(UnknownAccount)) return "?";
+                return null;
             }
         }
         

--- a/source/Nevermore.IntegrationTests/Model/BrandTypeResolver.cs
+++ b/source/Nevermore.IntegrationTests/Model/BrandTypeResolver.cs
@@ -5,7 +5,7 @@ namespace Nevermore.IntegrationTests.Model
 {
     public class BrandTypeResolver : IInstanceTypeResolver
     {
-        public Type Resolve(Type baseType, object typeColumnValue)
+        public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
         {
             if (typeof(Brand).IsAssignableFrom(baseType) && typeColumnValue is string type)
             {
@@ -13,6 +13,15 @@ namespace Nevermore.IntegrationTests.Model
                 if (type == BrandB.BrandType) return typeof(BrandB);
             }
 
+            return null;
+        }
+
+        public object ResolveValueFromType(Type type)
+        {
+            if (type == typeof(BrandA))
+                return BrandA.BrandType;
+            if (type == typeof(BrandB))
+                return BrandB.BrandType;
             return null;
         }
     }

--- a/source/Nevermore.IntegrationTests/Model/ProductConverter.cs
+++ b/source/Nevermore.IntegrationTests/Model/ProductConverter.cs
@@ -5,7 +5,7 @@ namespace Nevermore.IntegrationTests.Model
 {
     public class ProductTypeResolver : IInstanceTypeResolver
     {
-        public Type Resolve(Type baseType, object typeColumnValue)
+        public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
         {
             if (typeof(Product).IsAssignableFrom(baseType) && typeColumnValue is ProductType productType)
             {
@@ -13,6 +13,17 @@ namespace Nevermore.IntegrationTests.Model
                 if (productType == ProductType.Dodgy) return typeof(DodgyProduct);
                 if (productType == ProductType.Special) return typeof(SpecialProduct);
                 if (productType == ProductType.Normal) return typeof(Product);
+            }
+
+            return null;
+        }
+
+        public object ResolveValueFromType(Type type)
+        {
+            if (typeof(Product).IsAssignableFrom(type))
+            {
+                if (type == typeof(DodgyProduct)) return ProductType.Dodgy;
+                if (type == typeof(SpecialProduct)) return ProductType.Special;
             }
 
             return null;

--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -98,6 +98,26 @@ namespace Nevermore.IntegrationTests
             }
         }
 
+        [Test]
+        public async Task CountAsyncPolymorphic()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testBrands = new Brand[]
+            {
+                new BrandA { Name = "Brand 1" },
+                new BrandB { Name = "Brand 2" },
+                new BrandA { Name = "Brand 3" }
+            };
+
+            await t.InsertManyAsync(testBrands);
+            await t.CommitAsync();
+
+            var count = await t.Query<BrandB>().CountAsync();
+
+            count.Should().Be(1);
+        }
+
         class CustomerProductCross
         {
             public string CustomerName { get; set; }

--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -98,26 +98,6 @@ namespace Nevermore.IntegrationTests
             }
         }
 
-        [Test]
-        public async Task CountAsyncPolymorphic()
-        {
-            using var t = Store.BeginTransaction();
-
-            var testBrands = new Brand[]
-            {
-                new BrandA { Name = "Brand 1" },
-                new BrandB { Name = "Brand 2" },
-                new BrandA { Name = "Brand 3" }
-            };
-
-            await t.InsertManyAsync(testBrands);
-            await t.CommitAsync();
-
-            var count = await t.Query<BrandB>().CountAsync();
-
-            count.Should().Be(1);
-        }
-
         class CustomerProductCross
         {
             public string CustomerName { get; set; }

--- a/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryBuilderIntegrationFixture.cs
@@ -98,6 +98,26 @@ namespace Nevermore.IntegrationTests
             }
         }
 
+        [Test]
+        public async Task CountAsyncPolymorphic()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testBrands = new Brand[]
+            {
+                new BrandA { Name = "Best Brand" },
+                new BrandB { Name = "Worst Brand" },
+                new BrandA { Name = "Somebody Else" }
+            };
+
+            await t.InsertManyAsync(testBrands);
+            await t.CommitAsync();
+
+            var count = await t.Query<BrandB>().Where(b => b.Name.Contains("Brand")).CountAsync();
+
+            count.Should().Be(1);
+        }
+
         class CustomerProductCross
         {
             public string CustomerName { get; set; }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -948,6 +948,30 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
+        public async Task CountAsyncPolymorphic()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testBrands = new Brand[]
+            {
+                new BrandA { Name = "Brand 1" },
+                new BrandB { Name = "Brand 2" },
+                new BrandA { Name = "Brand 3" }
+            };
+
+            foreach (var b in testBrands)
+            {
+                t.Insert(b);
+            }
+
+            await t.CommitAsync();
+
+            var count = await t.Queryable<BrandB>().CountAsync();
+
+            count.Should().Be(1);
+        }
+
+        [Test]
         public void Hint()
         {
             using var t = Store.BeginTransaction();
@@ -1016,6 +1040,30 @@ namespace Nevermore.IntegrationTests
             await t.CommitAsync();
 
             var count = await t.Queryable<Customer>().CountAsync(c => c.Nickname.StartsWith("C"));
+
+            count.Should().Be(2);
+        }
+
+        [Test]
+        public async Task CountWithPredicateAsyncPolymorphic()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testBrands = new Brand[]
+            {
+                new BrandA { Name = "Brand 1" },
+                new BrandB { Name = "Brand 2" },
+                new BrandA { Name = "Brand 3" }
+            };
+
+            foreach (var b in testBrands)
+            {
+                t.Insert(b);
+            }
+
+            await t.CommitAsync();
+
+            var count = await t.Queryable<BrandA>().CountAsync(b => b.Name.StartsWith("Brand"));
 
             count.Should().Be(2);
         }

--- a/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalStoreFixture.cs
@@ -84,8 +84,8 @@ namespace Nevermore.IntegrationTests
         [Test]
         public void ShouldBuildJoinSelectsWithJsonColumnLast()
         {
-            var product1 = new DodgyProduct {Name = "iphane", Price = 350.0M, Tax = 35.0M, Type = ProductType.Dodgy};
-            var product2 = new SpecialProduct {Name = "octophone", Type = ProductType.Special, Price = 350.0M};
+            var product1 = new DodgyProduct {Name = "samename", Price = 350.0M, Tax = 35.0M, Type = ProductType.Dodgy};
+            var product2 = new SpecialProduct {Name = "samename", Type = ProductType.Special, Price = 350.0M};
             using (var transaction = Store.BeginTransaction())
             {
                 transaction.Insert(product1);
@@ -97,11 +97,11 @@ namespace Nevermore.IntegrationTests
             {
                 var products = transaction.Query<DodgyProduct>().Alias("dodgyProductTable")
                     .InnerJoin(transaction.Query<SpecialProduct>().Alias("specialProductTable"))
-                    .On(nameof(DodgyProduct.Type), JoinOperand.Equal, nameof(SpecialProduct.Type))
+                    .On(nameof(DodgyProduct.Name), JoinOperand.Equal, nameof(SpecialProduct.Name))
                     .AsType<Product>()
                     .ToList();
 
-                products.Should().BeEquivalentTo(new List<Product> {product1, product2});
+                products.Should().BeEquivalentTo(new List<Product> {product1});
             }
         }
 

--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -68,8 +68,6 @@ ORDER BY [Id]");
             return new TableSourceQueryBuilder<Record>("Records",
                 "dbo",
                 "Id",
-                null,
-                null,
                 Substitute.For<IRelationalTransaction>(),
                 new TableAliasGenerator(),
                 new UniqueParameterNameGenerator(),

--- a/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
+++ b/source/Nevermore.Tests/Column/ColumnExpressionTests.cs
@@ -68,6 +68,8 @@ ORDER BY [Id]");
             return new TableSourceQueryBuilder<Record>("Records",
                 "dbo",
                 "Id",
+                null,
+                null,
                 Substitute.For<IRelationalTransaction>(),
                 new TableAliasGenerator(),
                 new UniqueParameterNameGenerator(),

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -30,12 +30,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
             transaction.ClearReceivedCalls();
         }
         
-        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(
-            string tableName,
-            string schemaName = "dbo",
-            string idColumnName = "Id",
-            string typeColumnName = null,
-            object typeColumnValue = null) where TDocument : class
+        ITableSourceQueryBuilder<TDocument> CreateQueryBuilder<TDocument>(string tableName, string schemaName = "dbo", string idColumnName = "Id") where TDocument : class
         {
             var columns = new[] {"*"};
             if (typeof(TDocument) != typeof(object))
@@ -46,18 +41,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
             transaction.GetColumnNames(Arg.Any<string>(), Arg.Any<string>()).Returns(columns);
             
-            return new TableSourceQueryBuilder<TDocument>(
-            tableName,
-            schemaName,
-            idColumnName,
-            typeColumnName,
-            typeColumnValue,
-            transaction,
-            tableAliasGenerator,
-            uniqueParameterNameGenerator,
-            new CommandParameterValues(),
-            new Parameters(),
-            new ParameterDefaults());
+            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, idColumnName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
         
         [Test]
@@ -1948,21 +1932,6 @@ ORDER BY [Id]";
                 .GenerateSql();
 
             this.Assent(subquerySql);
-        }
-
-        [Test]
-        public void ShouldGenerateSelectWithTypeFilter()
-        {
-            var sql = CreateQueryBuilder<object>("Account", typeColumnName: "Type", typeColumnValue: "VipAccount")
-                .GetSelectBuilder()
-                .GenerateSelectWithoutDefaultOrderBy()
-                .GenerateSql();
-
-            const string expected = @"SELECT *
-FROM [dbo].[Account]
-WHERE ([Type] = @__type)";
-
-            sql.Should().Be(expected);
         }
     }
 

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -41,7 +41,18 @@ namespace Nevermore.Tests.QueryBuilderFixture
 
             transaction.GetColumnNames(Arg.Any<string>(), Arg.Any<string>()).Returns(columns);
             
-            return new TableSourceQueryBuilder<TDocument>(tableName, schemaName, idColumnName, transaction, tableAliasGenerator, uniqueParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TDocument>(
+                tableName,
+                schemaName,
+                idColumnName,
+                null,
+                null,
+                transaction,
+                 tableAliasGenerator,
+                uniqueParameterNameGenerator,
+                new CommandParameterValues(),
+                new Parameters(),
+                new ParameterDefaults());
         }
         
         [Test]

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -320,7 +320,18 @@ ORDER BY [Id]");
 
         ITableSourceQueryBuilder<object> TableQueryBuilder(string tableName)
         {
-            return new TableSourceQueryBuilder<object>(tableName, "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(
+                tableName,
+                "dbo",
+                "Id",
+                null,
+                null,
+                transaction,
+                new TableAliasGenerator(),
+                new UniqueParameterNameGenerator(),
+                new CommandParameterValues(),
+                new Parameters(),
+                new ParameterDefaults());
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderStateFixture.cs
@@ -320,18 +320,7 @@ ORDER BY [Id]");
 
         ITableSourceQueryBuilder<object> TableQueryBuilder(string tableName)
         {
-            return new TableSourceQueryBuilder<object>(
-                tableName,
-                "dbo",
-                "Id",
-                null,
-                null,
-                transaction,
-                new TableAliasGenerator(),
-                new UniqueParameterNameGenerator(),
-                new CommandParameterValues(),
-                new Parameters(),
-                new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(tableName, "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
     }
 }

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -33,18 +33,7 @@ namespace Nevermore.Tests.QueryBuilderFixture
             var memberInfos = Activator.CreateInstance<object>().GetType().GetProperties();
             var columnNames = memberInfos.Select(x => x.Name).ToList();
             
-            return new TableSourceQueryBuilder<object>(
-            "Order",
-            "dbo",
-            "Id",
-            null,
-            null,
-            transaction,
-            new TableAliasGenerator(),
-            new UniqueParameterNameGenerator(),
-            new CommandParameterValues(),
-            new Parameters(),
-            new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>("Order", "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -33,7 +33,18 @@ namespace Nevermore.Tests.QueryBuilderFixture
             var memberInfos = Activator.CreateInstance<object>().GetType().GetProperties();
             var columnNames = memberInfos.Select(x => x.Name).ToList();
             
-            return new TableSourceQueryBuilder<object>("Order", "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(
+                "Order",
+                "dbo",
+                "Id",
+                null,
+                null,
+                transaction,
+                new TableAliasGenerator(),
+                new UniqueParameterNameGenerator(),
+                new CommandParameterValues(),
+                new Parameters(),
+                new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/VariableCasingFixture.cs
@@ -33,7 +33,18 @@ namespace Nevermore.Tests.QueryBuilderFixture
             var memberInfos = Activator.CreateInstance<object>().GetType().GetProperties();
             var columnNames = memberInfos.Select(x => x.Name).ToList();
             
-            return new TableSourceQueryBuilder<object>("Order", "dbo", "Id", transaction, new TableAliasGenerator(), new UniqueParameterNameGenerator(), new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<object>(
+            "Order",
+            "dbo",
+            "Id",
+            null,
+            null,
+            transaction,
+            new TableAliasGenerator(),
+            new UniqueParameterNameGenerator(),
+            new CommandParameterValues(),
+            new Parameters(),
+            new ParameterDefaults());
         }
 
         [Test]

--- a/source/Nevermore/Advanced/InstanceTypeResolvers/IInstanceTypeRegistry.cs
+++ b/source/Nevermore/Advanced/InstanceTypeResolvers/IInstanceTypeRegistry.cs
@@ -12,6 +12,7 @@ namespace Nevermore.Advanced.InstanceTypeResolvers
         /// </summary>
         /// <param name="resolver"></param>
         void Register(IInstanceTypeResolver resolver);
-        Type Resolve(Type baseType, object typeColumnValue);
+        Type ResolveTypeFromValue(Type baseType, object typeColumnValue);
+        object ResolveValueFromType(Type type);
     }
 }

--- a/source/Nevermore/Advanced/InstanceTypeResolvers/IInstanceTypeResolver.cs
+++ b/source/Nevermore/Advanced/InstanceTypeResolvers/IInstanceTypeResolver.cs
@@ -22,6 +22,8 @@ namespace Nevermore.Advanced.InstanceTypeResolvers
         /// <param name="baseType"></param>
         /// <param name="typeColumnValue"></param>
         /// <returns></returns>
-        Type Resolve(Type baseType, object typeColumnValue);
+        Type ResolveTypeFromValue(Type baseType, object typeColumnValue);
+
+        object ResolveValueFromType(Type type);
     }
 }

--- a/source/Nevermore/Advanced/InstanceTypeResolvers/InstanceTypeRegistry.cs
+++ b/source/Nevermore/Advanced/InstanceTypeResolvers/InstanceTypeRegistry.cs
@@ -15,24 +15,42 @@ namespace Nevermore.Advanced.InstanceTypeResolvers
             resolvers.Add(resolver);
         }
 
-        public Type Resolve(Type baseType, object typeColumnValue)
+        public Type ResolveTypeFromValue(Type baseType, object typeColumnValue)
         {
             var key = (baseType, typeColumnValue);
             if (cache.TryGetValue(key, out var existing))
                 return existing;
 
-            var concreteType = Find(baseType, typeColumnValue);
+            var concreteType = FindTypeByValue(baseType, typeColumnValue);
             if (concreteType != null)
                 // Only cache if we found a value
                 cache.TryAdd(key, concreteType);
             return concreteType;
         }
 
-        Type Find(Type baseType, object typeColumnValue)
+        public object ResolveValueFromType(Type type)
+        {
+            // TODO: Caching
+            return FindValueByType(type);
+        }
+
+        Type FindTypeByValue(Type baseType, object typeColumnValue)
         {
             foreach (var resolver in resolvers.OrderBy(r => r.Order))
             {
-                var result = resolver.Resolve(baseType, typeColumnValue);
+                var result = resolver.ResolveTypeFromValue(baseType, typeColumnValue);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+
+        object FindValueByType(Type type)
+        {
+            foreach (var resolver in resolvers.OrderBy(r => r.Order))
+            {
+                var result = resolver.ResolveValueFromType(type);
                 if (result != null)
                     return result;
             }

--- a/source/Nevermore/Advanced/InstanceTypeResolvers/InstanceTypeRegistry.cs
+++ b/source/Nevermore/Advanced/InstanceTypeResolvers/InstanceTypeRegistry.cs
@@ -36,26 +36,18 @@ namespace Nevermore.Advanced.InstanceTypeResolvers
 
         Type FindTypeByValue(Type baseType, object typeColumnValue)
         {
-            foreach (var resolver in resolvers.OrderBy(r => r.Order))
-            {
-                var result = resolver.ResolveTypeFromValue(baseType, typeColumnValue);
-                if (result != null)
-                    return result;
-            }
-
-            return null;
+            return resolvers
+                .OrderBy(r => r.Order)
+                .Select(resolver => resolver.ResolveTypeFromValue(baseType, typeColumnValue))
+                .FirstOrDefault(result => result != null);
         }
 
         object FindValueByType(Type type)
         {
-            foreach (var resolver in resolvers.OrderBy(r => r.Order))
-            {
-                var result = resolver.ResolveValueFromType(type);
-                if (result != null)
-                    return result;
-            }
-
-            return null;
+            return resolvers
+                .OrderBy(r => r.Order)
+                .Select(resolver => resolver.ResolveValueFromType(type))
+                .FirstOrDefault(result => result != null);
         }
     }
 }

--- a/source/Nevermore/Advanced/QueryBuilders/TableSourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilders/TableSourceQueryBuilder.cs
@@ -9,14 +9,10 @@ namespace Nevermore.Advanced.QueryBuilders
         string alias;
         string schemaName;
         string idColumnName;
-        readonly string typeColumnName;
-        readonly object typeColumnValue;
 
         public TableSourceQueryBuilder(string tableOrViewName,
             string schemaName,
             string idColumnName,
-            string typeColumnName,
-            object typeColumnValue,
             IReadTransaction readQueryExecutor,
             ITableAliasGenerator tableAliasGenerator,
             IUniqueParameterNameGenerator uniqueParameterNameGenerator,
@@ -28,20 +24,11 @@ namespace Nevermore.Advanced.QueryBuilders
             this.schemaName = schemaName;
             this.tableOrViewName = tableOrViewName;
             this.idColumnName = idColumnName;
-            this.typeColumnName = typeColumnName;
-            this.typeColumnValue = typeColumnValue;
         }
 
         protected override ISelectBuilder CreateSelectBuilder()
         {
-            var builder = new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
-            if (!string.IsNullOrEmpty(typeColumnName) && typeColumnValue is not null)
-            {
-                var parameter = new UniqueParameter(UniqueParameterNameGenerator, new Parameter("__type"));
-                ParamValues[parameter.ParameterName] = typeColumnValue;
-                builder.AddWhere(new UnaryWhereParameter(typeColumnName, UnarySqlOperand.Equal, parameter));
-            }
-            return builder;
+            return new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
         }
 
         public override IJoinSourceQueryBuilder<TRecord> Join(IAliasedSelectSource source, JoinType joinType, CommandParameterValues parameterValues, Parameters parameters, ParameterDefaults parameterDefaults)

--- a/source/Nevermore/Advanced/QueryBuilders/TableSourceQueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilders/TableSourceQueryBuilder.cs
@@ -9,10 +9,14 @@ namespace Nevermore.Advanced.QueryBuilders
         string alias;
         string schemaName;
         string idColumnName;
+        readonly string typeColumnName;
+        readonly object typeColumnValue;
 
         public TableSourceQueryBuilder(string tableOrViewName,
             string schemaName,
             string idColumnName,
+            string typeColumnName,
+            object typeColumnValue,
             IReadTransaction readQueryExecutor,
             ITableAliasGenerator tableAliasGenerator,
             IUniqueParameterNameGenerator uniqueParameterNameGenerator,
@@ -24,11 +28,20 @@ namespace Nevermore.Advanced.QueryBuilders
             this.schemaName = schemaName;
             this.tableOrViewName = tableOrViewName;
             this.idColumnName = idColumnName;
+            this.typeColumnName = typeColumnName;
+            this.typeColumnValue = typeColumnValue;
         }
 
         protected override ISelectBuilder CreateSelectBuilder()
         {
-            return new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
+            var builder = new TableSelectBuilder(CreateSimpleTableSource(), new Column(idColumnName));
+            if (!string.IsNullOrEmpty(typeColumnName) && typeColumnValue is not null)
+            {
+                var parameter = new UniqueParameter(UniqueParameterNameGenerator, new Parameter("__type"));
+                ParamValues[parameter.ParameterName] = typeColumnValue;
+                builder.AddWhere(new UnaryWhereParameter(typeColumnName, UnarySqlOperand.Equal, parameter));
+            }
+            return builder;
         }
 
         public override IJoinSourceQueryBuilder<TRecord> Join(IAliasedSelectSource source, JoinType joinType, CommandParameterValues parameterValues, Parameters parameters, ParameterDefaults parameterDefaults)

--- a/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
+++ b/source/Nevermore/Advanced/Queryable/SqlExpressionBuilder.cs
@@ -95,6 +95,16 @@ namespace Nevermore.Advanced.Queryable
             DocumentMap = configuration.DocumentMaps.Resolve(documentType);
             var schema = DocumentMap.SchemaName ?? configuration.DefaultSchema;
             from = new SimpleTableSource(DocumentMap.TableName, schema, GetDocumentColumns().ToArray());
+
+            if (DocumentMap.TypeResolutionColumn is not null)
+            {
+                var discriminator = configuration.InstanceTypeResolvers.ResolveValueFromType(documentType);
+                if (discriminator is not null)
+                {
+                    var discriminatorClause = CreateWhere(new WhereFieldReference(DocumentMap.TypeResolutionColumn.ColumnName), UnarySqlOperand.Equal, discriminator);
+                    Where(discriminatorClause);
+                }
+            }
         }
 
         public (IExpression, CommandParameterValues, QueryType) Build()

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -414,8 +414,21 @@ namespace Nevermore.Advanced
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
             var schemaName = configuration.GetSchemaNameOrDefault(map);
+            var typeColumnName = map.TypeResolutionColumn?.ColumnName;
+            var typeColumnValue = configuration.InstanceTypeResolvers.ResolveValueFromType(typeof(TRecord));
 
-            return new TableSourceQueryBuilder<TRecord>(map.TableName, schemaName, map.IdColumn?.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(
+                map.TableName,
+                schemaName,
+                map.IdColumn?.ColumnName,
+                typeColumnName,
+                typeColumnValue,
+                this,
+                tableAliasGenerator,
+                ParameterNameGenerator,
+                new CommandParameterValues(),
+                new Parameters(),
+                new ParameterDefaults());
         }
 
         public IQueryable<TDocument> Queryable<TDocument>()

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -414,21 +414,8 @@ namespace Nevermore.Advanced
         {
             var map = configuration.DocumentMaps.Resolve(typeof(TRecord));
             var schemaName = configuration.GetSchemaNameOrDefault(map);
-            var typeColumnName = map.TypeResolutionColumn?.ColumnName;
-            var typeColumnValue = configuration.InstanceTypeResolvers.ResolveValueFromType(typeof(TRecord));
 
-            return new TableSourceQueryBuilder<TRecord>(
-                map.TableName,
-                schemaName,
-                map.IdColumn?.ColumnName,
-                typeColumnName,
-                typeColumnValue,
-                this,
-                tableAliasGenerator,
-                ParameterNameGenerator,
-                new CommandParameterValues(),
-                new Parameters(),
-                new ParameterDefaults());
+            return new TableSourceQueryBuilder<TRecord>(map.TableName, schemaName, map.IdColumn?.ColumnName, this, tableAliasGenerator, ParameterNameGenerator, new CommandParameterValues(), new Parameters(), new ParameterDefaults());
         }
 
         public IQueryable<TDocument> Queryable<TDocument>()

--- a/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderContext.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderContext.cs
@@ -27,7 +27,7 @@ namespace Nevermore.Advanced.ReaderStrategies.Documents
                 return map.Type;
 
             // But if there IS a value in the Type column, then we expect a type resolver to know how to deal with it. 
-            var resolved = configuration.InstanceTypeResolvers.Resolve(map.Type, typeColumnValue);
+            var resolved = configuration.InstanceTypeResolvers.ResolveTypeFromValue(map.Type, typeColumnValue);
             if (resolved == null)
                 throw new InvalidOperationException($"The 'Type' column has a value of '{typeColumnValue}' ({typeColumnValue.GetType().Name}), but no type resolver was able to map it to a concrete type to deserialize. Either register an instance type resolver that knows how to interpret the value, or consider fixing the data.");
 


### PR DESCRIPTION
# Background

Nevermore is able to store multiple document types in a single table. However, when building queries it is unable to differentiate between the types. This results in the wrong result being generated in certain cases, such as counting documents of a certain type.

For example, a base type `Product` has two derived types, `ProductA` and `ProductB`. These are stored in the `[dbo].[Product]` table, with a `[Type]` column with either the value "ProductA" or "ProductB". When trying to count the number of `ProductB` documents like:

``` CSharp
transaction.Query<ProductB>().Count()
```

will generate the following SQL

``` SQL
SELECT COUNT(*) FROM [dbo].[Product]
```

This will count instances of both `ProductA` and `ProductB`.

Currently the filter must be added manually because type resolvers don't make available the value that should be used to discriminate between each possible type.

# Results

**BREAKING CHANGE:** Change the type resolver interface to both convert the discriminator value to the target type, as well as the reverse. This allows the query builders to generate the WHERE clause necessary to filter by type. This include queries generated both by the `IQueryBuilder` interface as well as the `IQueryable` provider.

In the above example, the following SQL would now be generated:

``` SQL
SELECT COUNT(*) FROM [dbo].[Product] WHERE [Type] = 'ProductB'
```