### PR TITLE
Use full name for types in the cache key

### DIFF
--- a/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/Documents/DocumentReaderStrategy.cs
@@ -84,7 +84,7 @@ namespace Nevermore.Advanced.ReaderStrategies.Documents
                 fieldNames[i] = dbDataReader.GetName(i);
             }
 
-            fieldNames[fieldCount] = mapping.Type.Name;
+            fieldNames[fieldCount] = mapping.Type.FullName;
             var cacheKey = string.Join("|", fieldNames);
             return cache.GetOrAdd(cacheKey, _ => Compile(mapping, dbDataReader));
         }


### PR DESCRIPTION
When two types that look the same, with the same name but belonging to two different namespaces try to access the same data, things go 💥 and the first type wins, second type says it can't see anything.