### PR TITLE
Updates list of SQL Server transient error codes to match those defined in EF Core

### DIFF
--- a/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
+++ b/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
@@ -18,6 +18,7 @@ namespace Nevermore.Transient
         static readonly int[] SimpleTransientErrorCodes = {
             // Details https://docs.microsoft.com/en-us/azure/sql-database/sql-database-develop-error-messages#database-connection-errors-transient-errors-and-other-temporary-errors
             // Copied from https://github.com/aspnet/EntityFrameworkCore/blob/10e553acc2/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
+
             // SQL Error Code: 49920
             // Cannot process request. Too many operations in progress for subscription "%ld".
             // The service is busy processing multiple requests for this subscription.
@@ -60,6 +61,20 @@ namespace Nevermore.Transient
             // SQL Error Code: 40197
             // The service has encountered an error processing your request. Please try again.
             40197,
+            // SQL Error Code: 20041
+            // Transaction rolled back. Could not execute trigger. Retry your transaction.
+            20041,
+            // SQL Error Code: 17197
+            // Login failed due to timeout; the connection has been closed. This error may indicate heavy server load.
+            // Reduce the load on the server and retry login.
+            17197,
+            // SQL Error Code: 14355
+            // The MSSQLServerADHelper service is busy. Retry this operation later.
+            14355,
+            // SQL Error Code: 10936
+            // Resource ID : %d. The request limit for the elastic pool is %d and has been reached.
+            // See 'http://go.microsoft.com/fwlink/?LinkId=267637' for assistance.
+            10936,
             // SQL Error Code: 10929
             // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d.
             // However, the server is currently too busy to support requests greater than %d for this database.
@@ -69,6 +84,9 @@ namespace Nevermore.Transient
             // Resource ID: %d. The %s limit for the database is %d and has been reached. For more information,
             // see http://go.microsoft.com/fwlink/?LinkId=267637.
             10928,
+            // SQL Error Code: 10922
+            // %ls failed. Rerun the statement.
+            10922,
             // SQL Error Code: 10060
             // A network-related or instance-specific error occurred while establishing a connection to SQL Server.
             // The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server
@@ -84,9 +102,77 @@ namespace Nevermore.Transient
             // A transport-level error has occurred when receiving results from the server.
             // An established connection was aborted by the software in your host machine.
             10053,
+            // SQL Error Code: 9515
+            // An XML schema has been altered or dropped, and the query plan is no longer valid. Please rerun the query batch.
+            9515,
+            // SQL Error Code: 8651
+            // Could not perform the operation because the requested memory grant was not available in resource pool '%ls' (%ld).
+            // Rerun the query, reduce the query load, or check resource governor configuration setting.
+            8651,
+            // SQL Error Code: 8645
+            // A timeout occurred while waiting for memory resources to execute the query in resource pool '%ls' (%ld). Rerun the query.
+            8645,
+            // SQL Error Code: 8628
+            // A time out occurred while waiting to optimize the query. Rerun the query.
+            8628,
+            // SQL Error Code: 4221
+            // Login to read-secondary failed due to long wait on 'HADR_DATABASE_WAIT_FOR_TRANSITION_TO_VERSIONING'.
+            // The replica is not available for login because row versions are missing for transactions that were in-flight
+            // when the replica was recycled. The issue can be resolved by rolling back or committing the active transactions
+            // on the primary replica. Occurrences of this condition can be minimized by avoiding long write transactions on the primary.
+            4221,
+            // SQL Error Code: 4060
+            // Cannot open database "%.*ls" requested by the login. The login failed.
+            4060,
+            // SQL Error Code: 3966
+            // Transaction is rolled back when accessing version store. It was earlier marked as victim when the version store
+            // was shrunk due to insufficient space in tempdb. This transaction was marked as a victim earlier because it may need
+            // the row version(s) that have already been removed to make space in tempdb. Retry the transaction
+            3966,
+            // SQL Error Code: 3960
+            // Snapshot isolation transaction aborted due to update conflict. You cannot use snapshot isolation to access table '%.*ls'
+            // directly or indirectly in database '%.*ls' to update, delete, or insert the row that has been modified or deleted
+            // by another transaction. Retry the transaction or change the isolation level for the update/delete statement.
+            3960,
+            // SQL Error Code: 3935
+            // A FILESTREAM transaction context could not be initialized. This might be caused by a resource shortage. Retry the operation.
+            3935,
+            // SQL Error Code: 1807
+            // Could not obtain exclusive lock on database 'model'. Retry the operation later.
+            1807,
+            // SQL Error Code: 1221
+            // The Database Engine is attempting to release a group of locks that are not currently held by the transaction.
+            // Retry the transaction. If the problem persists, contact your support provider.
+            1221,
             // SQL Error Code: 1205
             // Deadlock
             1205,
+            // SQL Error Code: 1204
+            // The instance of the SQL Server Database Engine cannot obtain a LOCK resource at this time. Rerun your statement
+            // when there are fewer active users. Ask the database administrator to check the lock and memory configuration for
+            // this instance, or to check for long-running transactions.
+            1204,
+            // SQL Error Code: 1203
+            // Process ID %d attempted to unlock a resource it does not own: %.*ls. Retry the transaction, because this error
+            // may be caused by a timing condition. If the problem persists, contact the database administrator.
+            1203,
+            // SQL Error Code: 997
+            // A connection was successfully established with the server, but then an error occurred during the login process.
+            // (provider: Named Pipes Provider, error: 0 - Overlapped I/O operation is in progress)
+            997,
+            // SQL Error Code: 921
+            // Database '%.*ls' has not been recovered yet. Wait and try again.
+            921,
+            // SQL Error Code: 669
+            // The row object is inconsistent. Please rerun the query.
+            669,
+            // SQL Error Code: 617
+            // Descriptor for object ID %ld in database ID %d not found in the hash table during attempt to un-hash it.
+            // A work table is missing an entry. Rerun the query. If a cursor is involved, close and reopen the cursor.
+            617,
+            // SQL Error Code: 601
+            // Could not continue scan with NOLOCK due to data movement.
+            601,
             // SQL Error Code: 233
             // The client was unable to establish a connection because of an error during connection initialization process before login.
             // Possible causes include the following: the client tried to connect to an unsupported version of SQL Server;
@@ -103,7 +189,11 @@ namespace Nevermore.Transient
             64,
             // DBNETLIB Error Code: 20
             // The instance of SQL Server you attempted to connect to does not support encryption.
-            20
+            20,
+            // This exception can be thrown even if the operation completed successfully, so it's safer to let the application fail.
+            // DBNETLIB Error Code: -2
+            // Timeout expired. The timeout period elapsed prior to completion of the operation or the server is not responding. The statement has been terminated.
+            //-2,
         };
 
         public bool IsTransient(Exception ex)


### PR DESCRIPTION
This is an alternative PR to #217.

We (Cloud Platform) are frequently hitting the following error/exception when executing our E2E tests which utilise a SQL Azure Elastic Pool.

`SQL Error 10936 - Resource ID : %d. The request limit for the elastic pool is %d and has been reached.`

While adding this error code to the list of transient codes in Nevermore, I noticed that the list is considerably different/outdated(?) when compared to that of EF Core - where this list was originally sourced.

This PR updates the list of transient error codes to match those [now defined in EF Core](https://github.com/dotnet/efcore/blob/3a428827470ed6806739715b7607b8e7752084d8/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs)