### PR TITLE
Fix incorrectly configured recyclable memory stream pool sizes

### DIFF
--- a/source/Nevermore/Advanced/Serialization/NewtonsoftDocumentSerializer.cs
+++ b/source/Nevermore/Advanced/Serialization/NewtonsoftDocumentSerializer.cs
@@ -11,8 +11,8 @@ namespace Nevermore.Advanced.Serialization
 {
     public class NewtonsoftDocumentSerializer : IDocumentSerializer
     {
-        static readonly RecyclableMemoryStreamManager MemoryStreamManager = new RecyclableMemoryStreamManager(1024 * 32, 4, 1024 * 1024 * 1);
-        readonly ArrayPoolAdapter arrayPoolAdapter = new ArrayPoolAdapter();
+        static readonly RecyclableMemoryStreamManager MemoryStreamManager = new(1024 * 32, 1024 * 256, 1024 * 1024 * 2);
+        readonly ArrayPoolAdapter arrayPoolAdapter = new();
 
         public NewtonsoftDocumentSerializer(IRelationalStoreConfiguration configuration)
         {


### PR DESCRIPTION
## Background

The `NewtonsoftDocumentSerializer` makes use of a [`RecycableMemoryStreamManager`](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream) to efficiently use and re-use memory streams. However, the manager is configured in such a way as to be quite inefficient with memory.

On construction, the `RecyclableMemoryStreamManager` takes three arguments:
- Block Size
- Large Buffer Multiple
- Maximum Large Buffer Size

The last two are of interest. For pooling large buffers of memory, a series of pools is created with varying sizes. These sizes are (1 * Large Buffer Multiple), (2 * Large Buffer Multiple), etc. up to the Maximum Large Buffer Size. The idea being to have a fairly small variety of sizes to choose from, with the smaller pools being more densely populated than the larger pools.

Currently, the `NewtonsoftDocumentSerializer` uses 1MB for the Maximum Large Buffer Size and 4 _bytes_ for the Large Buffer Multiple. This means that there are 262,144 pools created, each one 4 bytes larger than the previous. Having this amount of variance in pool sizes is not helpful, and is in fact quite costly. Around 12MB of memory is used just to track the pools.

## Results

Change the Large Buffer Multiple to 256kB and increase the Maximum Large Buffer Size to 2MB. This will result in the following 8 large buffer pools:
- 256kB
- 512kB
- 768kB
- 1,024kB (1MB)
- 1,280kB (~1.25MB)
- 1,536kB (~1.5MB)
- 1,792kB (~1.75MB)
- 2,048kB (2MB)