### PR TITLE
Prevent isolation mode from being reused

### DIFF
--- a/source/Nevermore.Benchmarks/NevermoreBenchmark.cs
+++ b/source/Nevermore.Benchmarks/NevermoreBenchmark.cs
@@ -92,15 +92,6 @@ namespace Nevermore.Benchmarks
         }
         
         [Benchmark]
-        public List<Customer> SelectWithoutTransaction()
-        {
-            using var reader = store.BeginReadTransaction();
-            return EnsureResults(
-                reader.Query<Customer>().Where("FirstName = @name").Parameter("name", "Robert").Take(100).ToList()
-            );
-        }
-        
-        [Benchmark]
         public List<Customer> SelectWithTransaction()
         {
             using var reader = store.BeginReadTransaction(IsolationLevel.ReadCommitted);

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -39,7 +39,7 @@ namespace Nevermore
             try
 
             {
-                txn.Open();
+                txn.Open(NevermoreDefaults.IsolationLevel);
                 return txn;
             }
             catch
@@ -55,7 +55,7 @@ namespace Nevermore
 
             try
             {
-                await txn.OpenAsync();
+                await txn.OpenAsync(NevermoreDefaults.IsolationLevel);
                 return txn;
             }
             catch


### PR DESCRIPTION
We saw evidence that queries being executed as part of `KeyAllocator` were inheriting the KeyAllocator isolation mode of Serializable instead of ReadCommitted.

Nevermore KeyAllocator is putting the connection into Serializable here: https://github.com/OctopusDeploy/Nevermore/blob/a22029b02aaae5095fd45ee8138e6cc8610802aa/source/Nevermore/Mapping/KeyAllocator.cs#L85
Then the connection gets put back on the connection pool, grabbed up again when we do a BeginReadTransactionAsync, and because nothing has reset the isolation level the query ends up running in Serializable instead of Read Committed. 

