### PR TITLE
Allow us to use string.Contains with a string comparison enum, which will be ignored

### DIFF
--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -260,6 +260,11 @@ namespace Nevermore.Advanced.Queryable
                     var (fieldReference, _) = GetFieldReferenceAndType(right);
                     return sqlBuilder.CreateWhere(fieldReference, invert ? ArraySqlOperand.NotIn : ArraySqlOperand.In, values);
                 }
+                else if (left!.Type == typeof(string) &&  right.Type == typeof(StringComparison))
+                {
+                    return CreateStringMethodWhere(expression, invert);
+                }
+
             }
 
             throw new NotSupportedException();


### PR DESCRIPTION
At present nevermore will throw a  NotSupportedException if a query makes use of string.Contains with a StringComparison enum value set. 

It is believe this argument should be ignored but not cause Nevermore to throw an exception. This would be consistent with how it handles StartsWith and EndsWith