### PR TITLE
ConfigureAwait(false) wherever we await a task

### DIFF
--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -31,7 +31,7 @@ namespace Nevermore.Advanced
         public new async Task WaitAsync(CancellationToken cancellationToken)
         {
             AssertNoDeadlock();
-            await base.WaitAsync(cancellationToken);
+            await base.WaitAsync(cancellationToken).ConfigureAwait(false);
             RecordLockAcquisition();
         }
 

--- a/source/Nevermore/Advanced/Hooks/HookRegistry.cs
+++ b/source/Nevermore/Advanced/Hooks/HookRegistry.cs
@@ -12,7 +12,7 @@ namespace Nevermore.Advanced.Hooks
         {
             hooks.Add(hook);
         }
-        
+
         public void BeforeInsert<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
             foreach (var hook in hooks) hook.BeforeInsert(document, map, transaction);
@@ -55,42 +55,42 @@ namespace Nevermore.Advanced.Hooks
 
         public async Task BeforeInsertAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.BeforeInsertAsync(document, map, transaction);
+            foreach (var hook in hooks) await hook.BeforeInsertAsync(document, map, transaction).ConfigureAwait(false);
         }
 
         public async Task AfterInsertAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.AfterInsertAsync(document, map, transaction);
+            foreach (var hook in hooks) await hook.AfterInsertAsync(document, map, transaction).ConfigureAwait(false);
         }
 
         public async Task BeforeUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.BeforeUpdateAsync(document, map, transaction);
+            foreach (var hook in hooks) await hook.BeforeUpdateAsync(document, map, transaction).ConfigureAwait(false);
         }
 
         public async Task AfterUpdateAsync<TDocument>(TDocument document, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.AfterUpdateAsync(document, map, transaction);
+            foreach (var hook in hooks) await hook.AfterUpdateAsync(document, map, transaction).ConfigureAwait(false);
         }
 
         public async Task BeforeDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.BeforeDeleteAsync<TDocument>(id, map, transaction);
+            foreach (var hook in hooks) await hook.BeforeDeleteAsync<TDocument>(id, map, transaction).ConfigureAwait(false);
         }
 
         public async Task AfterDeleteAsync<TDocument>(object id, DocumentMap map, IWriteTransaction transaction) where TDocument : class
         {
-            foreach (var hook in hooks) await hook.AfterDeleteAsync<TDocument>(id, map, transaction);
+            foreach (var hook in hooks) await hook.AfterDeleteAsync<TDocument>(id, map, transaction).ConfigureAwait(false);
         }
 
         public async Task BeforeCommitAsync(IWriteTransaction transaction)
         {
-            foreach (var hook in hooks) await hook.BeforeCommitAsync(transaction);
+            foreach (var hook in hooks) await hook.BeforeCommitAsync(transaction).ConfigureAwait(false);
         }
 
         public async Task AfterCommitAsync(IWriteTransaction transaction)
         {
-            foreach (var hook in hooks) await hook.AfterCommitAsync(transaction);
+            foreach (var hook in hooks) await hook.AfterCommitAsync(transaction).ConfigureAwait(false);
         }
     }
 }

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -115,7 +115,7 @@ namespace Nevermore.Advanced
             selectBuilder.AddColumnSelection(new AliasedColumn(new CalculatedColumn(new CustomExpression(expression)), columnAlias));
             return this;
         }
-        
+
         public IQueryBuilder<TNewRecord> AsType<TNewRecord>() where TNewRecord : class
         {
             return new QueryBuilder<TNewRecord, TSelectBuilder>(selectBuilder, readQueryExecutor, tableAliasGenerator, uniqueParameterNameGenerator, ParameterValues, Parameters, ParameterDefaults);
@@ -276,7 +276,7 @@ namespace Nevermore.Advanced
             var clonedSelectBuilder = selectBuilder.Clone();
             clonedSelectBuilder.AddColumnSelection(new SelectCountSource());
             clonedSelectBuilder.AddOptions(optionClauses);
-            var count = await readQueryExecutor.ExecuteScalarAsync<int>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, RetriableOperation.Select, commandTimeout, cancellationToken);
+            var count = await readQueryExecutor.ExecuteScalarAsync<int>(clonedSelectBuilder.GenerateSelect().GenerateSql(), paramValues, RetriableOperation.Select, commandTimeout, cancellationToken).ConfigureAwait(false);
             return count;
         }
 
@@ -317,7 +317,7 @@ namespace Nevermore.Advanced
             var trueParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("true"));
             var falseParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("false"));
 
-            var result = await readQueryExecutor.ExecuteScalarAsync<int>(CreateQuery().GenerateSql(), CreateParameterValues(), RetriableOperation.Select, commandTimeout, cancellationToken);
+            var result = await readQueryExecutor.ExecuteScalarAsync<int>(CreateQuery().GenerateSql(), CreateParameterValues(), RetriableOperation.Select, commandTimeout, cancellationToken).ConfigureAwait(false);
 
             return result != falseValue;
 
@@ -352,7 +352,7 @@ namespace Nevermore.Advanced
 
         public async Task<TRecord> FirstOrDefaultAsync(CancellationToken cancellationToken = default)
         {
-            await foreach (var item in TakeAsync(1, cancellationToken))
+            await foreach (var item in TakeAsync(1, cancellationToken).ConfigureAwait(false))
             {
                 return item;
             }
@@ -409,7 +409,7 @@ namespace Nevermore.Advanced
 
             var results = new List<TRecord>();
             var enumerator = readQueryExecutor.StreamAsync<TRecord>(subqueryBuilder.GenerateSelect().GenerateSql(), parmeterValues, commandTimeout, cancellationToken);
-            await foreach (var item in enumerator.WithCancellation(cancellationToken))
+            await foreach (var item in enumerator.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 results.Add(item);
             }
@@ -499,10 +499,10 @@ namespace Nevermore.Advanced
             var maxRowParameter = new UniqueParameter(uniqueParameterNameGenerator, new Parameter("_maxrow"));
 
             var clonedSelectBuilder = selectBuilder.Clone();
-            
+
             if(!clonedSelectBuilder.HasCustomColumnSelection)
                 clonedSelectBuilder.AddDefaultColumnSelection();
-            
+
             clonedSelectBuilder.AddRowNumberColumn(rowNumberColumnName, new List<Column>());
 
             var subqueryBuilder = CreateSubqueryBuilder(clonedSelectBuilder);
@@ -531,21 +531,21 @@ namespace Nevermore.Advanced
 
         /// <summary>
         /// Query using legacy 2-step operation.
-        /// TODO: Remove this once we can deprecate the legacy approach 
+        /// TODO: Remove this once we can deprecate the legacy approach
         /// </summary>
         async Task<(List<TRecord>, int)> ToListWithCountAsyncLegacy(int skip, int take, CancellationToken cancellationToken = default)
         {
-            var count = await CountAsync(cancellationToken);
-            var list = await ToListAsync(skip, take, cancellationToken);
-            return (list, count);            
+            var count = await CountAsync(cancellationToken).ConfigureAwait(false);
+            var list = await ToListAsync(skip, take, cancellationToken).ConfigureAwait(false);
+            return (list, count);
         }
-        
+
         async Task<(List<TRecord>, int)> ToListWithCountAsyncCte(int skip, int take, CancellationToken cancellationToken = default)
         {
             // Short circuit query if no results will be retrieved
             if (take == 0)
             {
-                return await ReturnJustCount();
+                return await ReturnJustCount().ConfigureAwait(false);
             }
 
             var selectSource = BuildToListCount(skip, take, out var parmeterValues, out var countColumnName);
@@ -558,22 +558,22 @@ namespace Nevermore.Advanced
                 }
                 return map.Map<TRecord>(string.Empty);
             }, commandTimeout, cancellationToken);
-            
+
             var results = new List<TRecord>();
-            await foreach (var item in stream)
+            await foreach (var item in stream.ConfigureAwait(false))
                 results.Add(item);
 
             // If no result came back its possible that the page is greater than whats available
             // Fall back to using just the count
             if (!results.Any())
             {
-                return await ReturnJustCount();
+                return await ReturnJustCount().ConfigureAwait(false);
             }
 
             async Task<(List<TRecord>, int)> ReturnJustCount()
             {
-                var count = await CountAsync(cancellationToken);
-                return (new List<TRecord>(), count); 
+                var count = await CountAsync(cancellationToken).ConfigureAwait(false);
+                return (new List<TRecord>(), count);
             }
 
             return (results, total);
@@ -582,7 +582,9 @@ namespace Nevermore.Advanced
         [Pure]
         public async Task<(List<TRecord>, int)> ToListWithCountAsync(int skip, int take, CancellationToken cancellationToken = default)
         {
-            return FeatureFlags.UseCteBasedListWithCount ? await ToListWithCountAsyncCte(skip, take, cancellationToken) : await ToListWithCountAsyncLegacy(skip, take, cancellationToken);
+            return FeatureFlags.UseCteBasedListWithCount
+                ? await ToListWithCountAsyncCte(skip, take, cancellationToken).ConfigureAwait(false)
+                : await ToListWithCountAsyncLegacy(skip, take, cancellationToken).ConfigureAwait(false);
         }
 
         [Pure]
@@ -595,7 +597,7 @@ namespace Nevermore.Advanced
         {
             var results = new List<TRecord>();
 
-            await foreach (var item in StreamAsync(cancellationToken))
+            await foreach (var item in StreamAsync(cancellationToken).ConfigureAwait(false))
                 results.Add(item);
 
             return results;
@@ -632,7 +634,7 @@ namespace Nevermore.Advanced
 
         public async Task<IDictionary<string, TRecord>> ToDictionaryAsync(Func<TRecord, string> keySelector, CancellationToken cancellationToken = default)
         {
-            return (await ToListAsync(cancellationToken)).ToDictionary(keySelector, StringComparer.OrdinalIgnoreCase);
+            return (await ToListAsync(cancellationToken).ConfigureAwait(false)).ToDictionary(keySelector, StringComparer.OrdinalIgnoreCase);
         }
 
         public Parameters Parameters => new Parameters(@params);

--- a/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/NevermoreQueryableExtensions.cs
@@ -80,7 +80,7 @@ namespace Nevermore.Advanced.Queryable
                     null,
                     CountMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression);
-                return await asyncQueryProvider.ExecuteAsync<int>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<int>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -98,7 +98,7 @@ namespace Nevermore.Advanced.Queryable
                     CountWithPredicateMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression,
                     predicate);
-                return await asyncQueryProvider.ExecuteAsync<int>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<int>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -115,7 +115,7 @@ namespace Nevermore.Advanced.Queryable
                     null,
                     AnyMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression);
-                return await asyncQueryProvider.ExecuteAsync<bool>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<bool>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -133,7 +133,7 @@ namespace Nevermore.Advanced.Queryable
                     AnyWithPredicateMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression,
                     predicate);
-                return await asyncQueryProvider.ExecuteAsync<bool>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<bool>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -150,7 +150,7 @@ namespace Nevermore.Advanced.Queryable
                     null,
                     FirstOrDefaultMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression);
-                return await asyncQueryProvider.ExecuteAsync<TSource>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<TSource>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -168,7 +168,7 @@ namespace Nevermore.Advanced.Queryable
                     FirstOrDefaultWithPredicateMethodInfo.MakeGenericMethod(typeof(TSource)),
                     source.Expression,
                     predicate);
-                return await asyncQueryProvider.ExecuteAsync<TSource>(expression, cancellationToken);
+                return await asyncQueryProvider.ExecuteAsync<TSource>(expression, cancellationToken).ConfigureAwait(false);
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");
@@ -181,7 +181,7 @@ namespace Nevermore.Advanced.Queryable
 
             if (source.Provider is IAsyncQueryProvider asyncQueryProvider)
             {
-                return new List<TSource>(await asyncQueryProvider.ExecuteAsync<IEnumerable<TSource>>(source.Expression, cancellationToken));
+                return new List<TSource>(await asyncQueryProvider.ExecuteAsync<IEnumerable<TSource>>(source.Expression, cancellationToken).ConfigureAwait(false));
             }
 
             throw new InvalidOperationException("The query provider does not support async operations.");

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -78,7 +78,7 @@ namespace Nevermore.Advanced
         public async Task OpenAsync()
         {
             connection = new SqlConnection(registry.ConnectionString);
-            await connection.OpenWithRetryAsync();
+            await connection.OpenWithRetryAsync().ConfigureAwait(false);
         }
 
         public void Open(IsolationLevel isolationLevel)
@@ -89,7 +89,7 @@ namespace Nevermore.Advanced
 
         public async Task OpenAsync(IsolationLevel isolationLevel)
         {
-            await OpenAsync();
+            await OpenAsync().ConfigureAwait(false);
 
             // We use the synchronous overload here even though there is an async one, because the BeginTransactionAsync calls
             // the synchronous version anyway, and the async overload doesn't accept a name parameter.
@@ -118,7 +118,7 @@ namespace Nevermore.Advanced
         public async Task<TDocument?> LoadAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = StreamAsync<TDocument>(PrepareLoad<TDocument, TKey>(id), cancellationToken);
-            await foreach (var row in results.WithCancellation(cancellationToken))
+            await foreach (var row in results.WithCancellation(cancellationToken).ConfigureAwait(false))
                 return row;
             return null;
         }
@@ -183,7 +183,7 @@ namespace Nevermore.Advanced
         public async Task<List<TDocument>> LoadManyAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var results = new List<TDocument>();
-            await foreach (var item in LoadStreamAsync<TDocument, TKey>(ids, cancellationToken))
+            await foreach (var item in LoadStreamAsync<TDocument, TKey>(ids, cancellationToken).ConfigureAwait(false))
             {
                 results.Add(item);
             }
@@ -235,7 +235,7 @@ namespace Nevermore.Advanced
         [Pure]
         public async Task<TDocument> LoadRequiredAsync<TDocument, TKey>(TKey id, CancellationToken cancellationToken = default) where TDocument : class
         {
-            var result = await LoadAsync<TDocument, TKey>(id, cancellationToken);
+            var result = await LoadAsync<TDocument, TKey>(id, cancellationToken).ConfigureAwait(false);
             if (result == null)
                 throw new ResourceNotFoundException(id);
             return result;
@@ -311,7 +311,7 @@ namespace Nevermore.Advanced
         public async Task<List<TDocument>> LoadManyRequiredAsync<TDocument, TKey>(IEnumerable<TKey> ids, CancellationToken cancellationToken = default) where TDocument : class
         {
             var idList = ids.Distinct().ToArray();
-            var results = await LoadManyAsync<TDocument, TKey>(idList, cancellationToken);
+            var results = await LoadManyAsync<TDocument, TKey>(idList, cancellationToken).ConfigureAwait(false);
             if (results.Count != idList.Length)
             {
                 var firstMissing = idList.FirstOrDefault(id => results.All(record => !((TKey)configuration.DocumentMaps.GetId(record)).Equals(id)));
@@ -388,7 +388,7 @@ namespace Nevermore.Advanced
             if (idList.Count == 0)
                 yield break;
 
-            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument, TKey>(idList), cancellationToken))
+            await foreach (var item in StreamAsync<TDocument>(PrepareLoadMany<TDocument, TKey>(idList), cancellationToken).ConfigureAwait(false))
             {
                 yield return item;
             }
@@ -467,9 +467,12 @@ namespace Nevermore.Advanced
         {
             async IAsyncEnumerable<TRecord> Execute()
             {
-                await using var reader = await ExecuteReaderAsync(command, cancellationToken);
-                await foreach (var result in ProcessReaderAsync<TRecord>(reader, command, cancellationToken))
-                    yield return result;
+                var reader = await ExecuteReaderAsync(command, cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
+                {
+                    await foreach (var result in ProcessReaderAsync<TRecord>(reader, command, cancellationToken).ConfigureAwait(false))
+                        yield return result;
+                }
             }
 
             return new ThreadSafeAsyncEnumerable<TRecord>(Execute, DeadlockAwareLock);
@@ -506,7 +509,7 @@ namespace Nevermore.Advanced
             var strategy = configuration.ReaderStrategies.Resolve<TRecord>(command);
             var rowCounter = 0;
 
-            while (await reader.ReadAsync(cancellationToken))
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 rowCounter++;
                 var (instance, success) = strategy(reader);
@@ -537,11 +540,14 @@ namespace Nevermore.Advanced
             async IAsyncEnumerable<TResult> Execute()
             {
                 var command = new PreparedCommand(query, args, RetriableOperation.Select, commandBehavior: CommandBehavior.Default, commandTimeout: commandTimeout);
-                await using var reader = await ExecuteReaderAsync(command, cancellationToken);
-                var mapper = new ProjectionMapper(command, reader, configuration.ReaderStrategies);
-                while (await reader.ReadAsync(cancellationToken))
+                var reader = await ExecuteReaderAsync(command, cancellationToken).ConfigureAwait(false);
+                await using (reader.ConfigureAwait(false))
                 {
-                    yield return projectionMapper(mapper);
+                    var mapper = new ProjectionMapper(command, reader, configuration.ReaderStrategies);
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        yield return projectionMapper(mapper);
+                    }
                 }
             }
 
@@ -579,9 +585,9 @@ namespace Nevermore.Advanced
 
         public async Task<int> ExecuteNonQueryAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default)
         {
-            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken);
+            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken).ConfigureAwait(false);
             using var command = CreateCommand(preparedCommand);
-            return await command.ExecuteNonQueryAsync(cancellationToken);
+            return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public TResult ExecuteScalar<TResult>(string query, CommandParameterValues? args = null, RetriableOperation retriableOperation = RetriableOperation.Select, TimeSpan? commandTimeout = null)
@@ -606,9 +612,9 @@ namespace Nevermore.Advanced
 
         public async Task<TResult> ExecuteScalarAsync<TResult>(PreparedCommand preparedCommand, CancellationToken cancellationToken = default)
         {
-            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken);
+            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken).ConfigureAwait(false);
             using var command = CreateCommand(preparedCommand);
-            var result = await command.ExecuteScalarAsync(cancellationToken);
+            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
             if (result == DBNull.Value)
                 return default!;
             return (TResult)result;
@@ -633,7 +639,7 @@ namespace Nevermore.Advanced
         public async Task<DbDataReader> ExecuteReaderAsync(PreparedCommand preparedCommand, CancellationToken cancellationToken = default)
         {
             using var command = CreateCommand(preparedCommand);
-            return await command.ExecuteReaderAsync(cancellationToken);
+            return await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         }
 
         protected TResult[] ReadResults<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, TResult> mapper)
@@ -646,10 +652,10 @@ namespace Nevermore.Advanced
 
         protected async Task<TResult[]> ReadResultsAsync<TResult>(PreparedCommand preparedCommand, Func<DbDataReader, Task<TResult>> mapper, CancellationToken cancellationToken)
         {
-            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken);
+            using var mutex = await DeadlockAwareLock.LockAsync(cancellationToken).ConfigureAwait(false);
 
             using var command = CreateCommand(preparedCommand);
-            return await command.ReadResultsAsync(mapper, cancellationToken);
+            return await command.ReadResultsAsync(mapper, cancellationToken).ConfigureAwait(false);
         }
 
         PreparedCommand PrepareLoad<TDocument, TKey>(TKey id)

--- a/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
+++ b/source/Nevermore/Advanced/ThreadSafeAsyncEnumerable.cs
@@ -23,9 +23,9 @@ namespace Nevermore.Advanced
 
         public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
         {
-            using var mutex = await deadlockAwareLock.LockAsync(cancellationToken);
+            using var mutex = await deadlockAwareLock.LockAsync(cancellationToken).ConfigureAwait(false);
             var inner = innerFunc();
-            await foreach (var item in inner.WithCancellation(cancellationToken)) yield return item;
+            await foreach (var item in inner.WithCancellation(cancellationToken).ConfigureAwait(false)) yield return item;
         }
     }
 }

--- a/source/Nevermore/CommandExecutor.cs
+++ b/source/Nevermore/CommandExecutor.cs
@@ -66,7 +66,7 @@ namespace Nevermore
         {
             try
             {
-                return await command.ExecuteNonQueryWithRetryAsync(retryPolicy, cancellationToken: cancellationToken);
+                return await command.ExecuteNonQueryWithRetryAsync(retryPolicy, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (SqlException ex)
             {
@@ -103,7 +103,7 @@ namespace Nevermore
         {
             try
             {
-                return await command.ExecuteScalarWithRetryAsync(retryPolicy, cancellationToken: cancellationToken);
+                return await command.ExecuteScalarWithRetryAsync(retryPolicy, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (SqlException ex)
             {
@@ -166,7 +166,7 @@ namespace Nevermore
         {
             try
             {
-                return await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken: cancellationToken);
+                return await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (SqlException ex)
             {
@@ -185,11 +185,11 @@ namespace Nevermore
             try
             {
                 var data = new List<T>();
-                using (var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken))
+                using (var reader = await command.ExecuteReaderWithRetryAsync(retryPolicy, prepared.CommandBehavior, cancellationToken).ConfigureAwait(false))
                 {
-                    while (await reader.ReadAsync(cancellationToken))
+                    while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                     {
-                        data.Add(await mapper(reader));
+                        data.Add(await mapper(reader).ConfigureAwait(false));
                     }
                 }
 

--- a/source/Nevermore/Nevermore.csproj
+++ b/source/Nevermore/Nevermore.csproj
@@ -28,6 +28,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>9</LangVersion>
     <NoWarn>CS1591</NoWarn>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <WarningsAsErrors>CA2007</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -54,7 +54,7 @@ namespace Nevermore
             var txn = CreateReadTransaction(retriableOperation, name);
             try
             {
-                await txn.OpenAsync(isolationLevel);
+                await txn.OpenAsync(isolationLevel).ConfigureAwait(false);
                 return txn;
             }
             catch
@@ -84,7 +84,7 @@ namespace Nevermore
             var txn = CreateWriteTransaction(retriableOperation, name);
             try
             {
-                await txn.OpenAsync(isolationLevel);
+                await txn.OpenAsync(isolationLevel).ConfigureAwait(false);
                 return txn;
             }
             catch

--- a/source/Nevermore/Transient/DbCommandExtensions.cs
+++ b/source/Nevermore/Transient/DbCommandExtensions.cs
@@ -33,15 +33,15 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
             return effectiveCommandRetryPolicy.ExecuteAction(async () =>
             {
-                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken);
+                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    return await command.ExecuteNonQueryAsync(cancellationToken);
+                    return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
                     if (weOwnTheConnectionLifetime && command.Connection?.State == ConnectionState.Open)
-                        await command.Connection.CloseAsync();
+                        await command.Connection.CloseAsync().ConfigureAwait(false);
                 }
             });
         }
@@ -74,19 +74,19 @@ namespace Nevermore.Transient
                 (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
             return await effectiveCommandRetryPolicy.ExecuteActionAsync(async () =>
             {
-                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken);
+                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    return await command.ExecuteReaderAsync(commandBehavior, cancellationToken);
+                    return await command.ExecuteReaderAsync(commandBehavior, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception)
                 {
                     if (weOwnTheConnectionLifetime && command.Connection != null &&
                         command.Connection.State == ConnectionState.Open)
-                        await command.Connection.CloseAsync();
+                        await command.Connection.CloseAsync().ConfigureAwait(false);
                     throw;
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         public static object ExecuteScalarWithRetry(this DbCommand command, RetryPolicy commandRetryPolicy, RetryPolicy connectionRetryPolicy = null, string operationName = "ExecuteScalar")
@@ -114,17 +114,17 @@ namespace Nevermore.Transient
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryManager.Instance.GetDefaultSqlCommandRetryPolicy()).LoggingRetries(operationName);
             return await effectiveCommandRetryPolicy.ExecuteActionAsync(async () =>
             {
-                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken);
+                var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    return await command.ExecuteScalarAsync(cancellationToken);
+                    return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
                     if (weOwnTheConnectionLifetime && command.Connection?.State == ConnectionState.Open)
-                        await command.Connection.CloseAsync();
+                        await command.Connection.CloseAsync().ConfigureAwait(false);
                 }
-            });
+            }).ConfigureAwait(false);
         }
 
         static void GuardConnectionIsNotNull(DbCommand command)
@@ -157,7 +157,7 @@ namespace Nevermore.Transient
 
             if (command.Connection.State == ConnectionState.Open) return false;
 
-            await command.Connection.OpenWithRetryAsync(retryPolicy, cancellationToken);
+            await command.Connection.OpenWithRetryAsync(retryPolicy, cancellationToken).ConfigureAwait(false);
             return true;
         }
     }

--- a/source/Nevermore/Transient/RetryPolicy.cs
+++ b/source/Nevermore/Transient/RetryPolicy.cs
@@ -231,7 +231,7 @@ namespace Nevermore.Transient
         {
             return ExecuteActionAsync<object>(async () =>
             {
-                await func();
+                await func().ConfigureAwait(false);
                 return null;
             });
         }
@@ -254,7 +254,7 @@ namespace Nevermore.Transient
                 Exception ex = null;
                 try
                 {
-                    result = await func();
+                    result = await func().ConfigureAwait(false);
                     break;
                 }
 #pragma warning disable 618


### PR DESCRIPTION
The boolean passed to `ConfigureAwait` allows you to specify whether or not the callback after the `await` is forced to be invoked on the original `SynchronizationContext`. If unspecified, the default value is `true`. Under most circumstances this is not an issue, but for library code it's a good idea to specify `false` so the caller can decide.

This PR enables the [CA2007](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007) warning as an error to help guide us toward using `ConfigureAwait(false)`, and fixes all violations.