### PR TITLE
Retry pooled connection timeout

### DIFF
--- a/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
+++ b/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
@@ -201,11 +201,14 @@ namespace Nevermore.Transient
             return ex switch
             {
                 TimeoutException => true,
+                InvalidOperationException invalidOperationException => IsPooledConnectTimeout(invalidOperationException),
                 SqlException sqlException => IsTransientSqlException(sqlException),
                 _ => false
             };
         }
 
+        static bool IsPooledConnectTimeout(InvalidOperationException exception)
+             => exception.Message.Contains("The timeout period elapsed prior to obtaining a connection from the pool.");
 
         static bool IsTransientSqlException(SqlException exception)
         {

--- a/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
+++ b/source/Nevermore/Transient/SqlDatabaseTransientErrorDetectionStrategy.cs
@@ -198,18 +198,24 @@ namespace Nevermore.Transient
 
         public bool IsTransient(Exception ex)
         {
-            if (ex is TimeoutException) return true;
+            return ex switch
+            {
+                TimeoutException => true,
+                SqlException sqlException => IsTransientSqlException(sqlException),
+                _ => false
+            };
+        }
 
-            var sqlException = ex as SqlException;
-            if (sqlException == null) return false;
 
+        static bool IsTransientSqlException(SqlException exception)
+        {
             // If this error was caused by throttling on the server we can augment the exception with more detail
             // I don't feel awesome about mutating the exception directly but it seems the most pragmatic way to add value
-            var sqlErrors = sqlException.Errors.OfType<SqlError>().ToArray();
+            var sqlErrors = exception.Errors.OfType<SqlError>().ToArray();
             var firstThrottlingError = sqlErrors.FirstOrDefault(x => x.Number == ThrottlingCondition.ThrottlingErrorNumber);
             if (firstThrottlingError != null)
             {
-                AugmentSqlExceptionWithThrottlingDetails(firstThrottlingError, sqlException);
+                AugmentSqlExceptionWithThrottlingDetails(firstThrottlingError, exception);
                 return true;
             }
 


### PR DESCRIPTION
## Background

If acquiring a SQL connection from the connection pool times out due to no connections being available, the operation will fail with an error. This class of error is currently not identified as a transient error, though other timeout errors are. This means that encountering this error would fail the operation immediately without retrying.

## Results

Add the exception raised by SqlClient when a pooled connect timeout occurs to the list of transient errors that could be retried. It is no different from other types of timeout errors, except that it is raised as an `InvalidOperationException` instead of a `SqlException`.