### PR TITLE
Fix the project file reference on Nuke

### DIFF
--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "./build.schema.json"
+  "$schema": "./build.schema.json",
+  "Solution": "source/Nevermore.sln"
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -42,7 +42,7 @@ class BuildNevermore : NukeBuild
         .Executes(() =>
     {
         DotNetRestore(_ => _
-            .SetProjectFile("source"));
+            .SetProjectFile(SourceDirectory));
     });
 
     Target Build => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,6 @@
 using Nuke.Common;
 using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.OctoVersion;
 using Nuke.Common.Utilities.Collections;
@@ -23,9 +24,11 @@ class BuildNevermore : NukeBuild
     [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch), Framework = "net6.0")]
     public OctoVersionInfo OctoVersionInfo;
 
-    AbsolutePath SourceDirectory => RootDirectory / "source";
+    [Solution(GenerateProjects = true)] public Solution Solution;
+
+    AbsolutePath SourceDirectory => Solution.Directory;
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
-  
+
     public static int Main() => Execute<BuildNevermore>(x => x.Default);
 
     Target Clean => _ => _
@@ -42,7 +45,7 @@ class BuildNevermore : NukeBuild
         .Executes(() =>
     {
         DotNetRestore(_ => _
-            .SetProjectFile(SourceDirectory));
+            .SetProjectFile(Solution));
     });
 
     Target Build => _ => _
@@ -51,7 +54,7 @@ class BuildNevermore : NukeBuild
         .Executes(() =>
         {
             DotNetBuild(_ => _
-                .SetProjectFile(SourceDirectory)
+                .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetAssemblyVersion(OctoVersionInfo.MajorMinorPatch)
                 .SetFileVersion(OctoVersionInfo.MajorMinorPatch)
@@ -103,7 +106,7 @@ class BuildNevermore : NukeBuild
         .Executes(() =>
         {
             DotNetPack(_ => _
-                .SetProject(SourceDirectory)
+                .SetProject(Solution)
                 .SetConfiguration(Configuration)
                 .SetOutputDirectory(ArtifactsDirectory)
                 .EnableNoBuild()


### PR DESCRIPTION
I could not get Nuke to build on my machine without this change.

`SourceDirectory` uses the full path and fixes the problem.

This is the command that was not working: `build.cmd --Target Restore`