### PR TITLE
Update CSharp analyzer base packages and remove legacy compat package

### DIFF
--- a/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
+++ b/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
+++ b/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <!-- At the time of writing anything later than netstandard 2.0 doesn't work in Visual Studio -->
@@ -25,8 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.5.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
@@ -23,10 +23,6 @@
   <ItemGroup>
     <PackageReference Include="dbup-core" Version="5.0.8" />
     <PackageReference Include="dbup-sqlserver" Version="5.0.8" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />


### PR DESCRIPTION
`Nevermore.Analyzers` references older versions of `Microsoft.CodeAnalysis` libraries. The different base analyser versions can cause issues in other projects.

For example, below is a typical warning message from a referencing project. The `3.0.0-beta2.20059.3` version is implicitly included in the older `Microsoft.CodeAnalysis` `v3.5.0` libraries.

```
Warning	CS8032	An instance of analyzer 
Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.CSharpDiagnosticAnalyzerFieldsAnalyzer
 cannot be created from ...\microsoft.codeanalysis.analyzers\3.0.0-beta2.20059.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll
```

This PR:
* Removes redundant `Microsoft.CodeAnalysis` packages
* Updates remaining analyzer packages to their latest versions
* Removes a no-longer-support analyzer compat package from the tests project.