### PR TITLE
Downgrade Microsoft.CodeAnalysis.* packages to 4.3 for .NET 6 compiler support

### DIFF
--- a/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
+++ b/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
+++ b/source/Nevermore.Analyzers/Nevermore.Analyzers.csproj
@@ -25,7 +25,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR downgrades `Microsoft.CodeAnalysis.*` pacakges to `4.3.1` to properly support the .NET 6 compiler.

As part of the `Microsoft.CodeAnalysis.*` cleanup in #249, the packages were updated to `4.5.0`. While this version works with a .NET 7 compiler (regardless of the project's target .NET version), it will not work with pinned .NET 6 compiler (e.g. via `global.json`).

`Microsoft.CodeAnalysis.*` vesion numbers track Roslyn version numbers. .NET 6 includes Rolsyn `4.3.x` only. C# analyzers (such as `Microsoft.CodeAnalysis.*`) are built to require specific compiler features, based on their versions.