### PR TITLE
Add async enumeration support to INevermoreQueryable

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1367,7 +1367,7 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
-        public async Task AsyncForeach()
+        public async Task AsyncEnumeration()
         {
             using var t = Store.BeginTransaction();
 
@@ -1385,9 +1385,11 @@ namespace Nevermore.IntegrationTests
 
             var customers = new List<Customer>();
             var queryable = (INevermoreQueryable<Customer>)t.Queryable<Customer>().Where(c => c.FirstName.EndsWith("e"));
-            await foreach (var customer in queryable)
+
+            var enumerator = queryable.GetAsyncEnumerator(CancellationToken.None);
+            while (await enumerator.MoveNextAsync())
             {
-                customers.Add(customer);
+                customers.Add(enumerator.Current);
             }
 
             customers.Select(c => c.LastName).Should().BeEquivalentTo("Apple", "Cherry");

--- a/source/Nevermore/Advanced/Queryable/IAsyncQueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/IAsyncQueryProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,5 +9,7 @@ namespace Nevermore.Advanced.Queryable
     public interface IAsyncQueryProvider : IQueryProvider
     {
         public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken);
+
+        public IAsyncEnumerable<TResult> StreamAsync<TResult>(Expression expression, CancellationToken cancellationToken);
     }
 }

--- a/source/Nevermore/Advanced/Queryable/INevermoreQueryable.cs
+++ b/source/Nevermore/Advanced/Queryable/INevermoreQueryable.cs
@@ -11,6 +11,6 @@ namespace Nevermore.Advanced.Queryable
     /// <typeparam name="T">The queryable element type</typeparam>
     public interface INevermoreQueryable<out T> : IOrderedQueryable<T>
     {
-        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken);
     }
 }

--- a/source/Nevermore/Advanced/Queryable/INevermoreQueryable.cs
+++ b/source/Nevermore/Advanced/Queryable/INevermoreQueryable.cs
@@ -1,13 +1,16 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 namespace Nevermore.Advanced.Queryable
 {
     /// <summary>
-    /// This is a marker interface for determining whether an IQueryable is underpinned
+    /// This interface can be used to determine whether an IQueryable is underpinned
     /// by Nevermore.
     /// </summary>
     /// <typeparam name="T">The queryable element type</typeparam>
-    public interface INevermoreQueryable<T> : IOrderedQueryable<T>
+    public interface INevermoreQueryable<out T> : IOrderedQueryable<T>
     {
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
     }
 }

--- a/source/Nevermore/Advanced/Queryable/Query.cs
+++ b/source/Nevermore/Advanced/Queryable/Query.cs
@@ -27,7 +27,7 @@ namespace Nevermore.Advanced.Queryable
 
         IEnumerator IEnumerable.GetEnumerator() => queryProvider.Execute<IEnumerable>(Expression).GetEnumerator();
 
-        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken) =>
             queryProvider.StreamAsync<T>(Expression, cancellationToken).GetAsyncEnumerator(cancellationToken);
 
         public Type ElementType => typeof(T);

--- a/source/Nevermore/Advanced/Queryable/Query.cs
+++ b/source/Nevermore/Advanced/Queryable/Query.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 
 namespace Nevermore.Advanced.Queryable
 {
@@ -25,6 +26,9 @@ namespace Nevermore.Advanced.Queryable
         public IEnumerator<T> GetEnumerator() => queryProvider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => queryProvider.Execute<IEnumerable>(Expression).GetEnumerator();
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+            queryProvider.StreamAsync<T>(Expression, cancellationToken).GetAsyncEnumerator(cancellationToken);
 
         public Type ElementType => typeof(T);
         public Expression Expression { get; }


### PR DESCRIPTION
# Background

This PR adds the minimum requirements to properly support async enumeration over the results of a query via Nevermore's `IQueryable` implementation. It's backed by `StreamAsync` which already existed and works well, so not much had to be done.

It's possible to go further with this and add an `IAsyncEnumerable` layer on top which can provide `async foreach` support and nicer cancellation token ergonomics among other things, but that's left up to consumers.


# Notes

To confirm this works as intended (minimising the amount of information kept in memory while iterating) I ran the following code locally and used the debugger to verify the number of `Customer` instances on the heap did not grow.

```csharp
[Test]
public async Task TestingMemoryUsage()
{
    using var t = Store.BeginTransaction();

    foreach (var i in Enumerable.Range(0, 100))
    {
        t.Insert(new Customer { FirstName = $"Alice{i}", LastName = "Apple", Roles = { "Admin" } });
    }

    GC.Collect();

    var queryable = (INevermoreQueryable<Customer>)t.Queryable<Customer>();
    var enumerator = queryable.GetAsyncEnumerator(CancellationToken.None);
    while (await enumerator.MoveNextAsync())
    {
        var customer = enumerator.Current;

        // The number of Customer instances in memory should not grow here
        GC.Collect();
    }
}
```

Placing a breakpoint in the loop, I observed the number of `Customer` instances in memory never grew above 3 (looks like there's a bit of internal buffering going on but not much). For example, see the screenshot below in which there's only 3 in memory after iterating over 80+:

![image](https://user-images.githubusercontent.com/6970423/231948781-b0ec007a-a886-4e3f-b718-6b3bf5ba52b2.png)
