### PR TITLE
Log transaction duration

### DIFF
--- a/source/Nevermore.IntegrationTests/RelationalTransaction/TransactionTimerFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/TransactionTimerFixture.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nevermore.Advanced;
+using Nevermore.Diagnostics;
+using Nevermore.IntegrationTests.SetUp;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.RelationalTransaction;
+
+public class TransactionTimerFixture : FixtureWithRelationalStore
+{
+    class MockTransactionLogger : ITransactionLogger
+    {
+        public List<(long duration, string transactionName)> Entries { get; } = new();
+        
+        public void Write(long duration, string transactionName)
+        {
+            Entries.Add((duration, transactionName));
+        }
+    }
+    
+    [Test]
+    public void Duration()
+    {
+        var mockTransactionLogger = new MockTransactionLogger();
+        Store.Configuration.TransactionLogger = mockTransactionLogger;
+
+        using (var t = Store.BeginTransaction(name: "timed transaction") as ReadTransaction)
+        {
+            if (t is null)
+            {
+                Assert.Fail($"Transaction is not {nameof(ReadTransaction)}");
+            }
+        
+            t.ExecuteScalar<object>("WAITFOR DELAY '00:00:10'");
+        }
+
+        mockTransactionLogger.Entries.Should().ContainSingle();
+        mockTransactionLogger.Entries.Single().duration.Should().BeGreaterThan(10_000);
+        mockTransactionLogger.Entries.Single().transactionName.Should().Be("timed transaction");
+    }
+}

--- a/source/Nevermore.IntegrationTests/RelationalTransaction/TransactionTimerFixture.cs
+++ b/source/Nevermore.IntegrationTests/RelationalTransaction/TransactionTimerFixture.cs
@@ -26,18 +26,13 @@ public class TransactionTimerFixture : FixtureWithRelationalStore
         var mockTransactionLogger = new MockTransactionLogger();
         Store.Configuration.TransactionLogger = mockTransactionLogger;
 
-        using (var t = Store.BeginTransaction(name: "timed transaction") as ReadTransaction)
+        using (var t = Store.BeginTransaction(name: "timed transaction"))
         {
-            if (t is null)
-            {
-                Assert.Fail($"Transaction is not {nameof(ReadTransaction)}");
-            }
-        
             t.ExecuteScalar<object>("WAITFOR DELAY '00:00:10'");
         }
 
         mockTransactionLogger.Entries.Should().ContainSingle();
-        mockTransactionLogger.Entries.Single().duration.Should().BeGreaterThan(10_000);
+        mockTransactionLogger.Entries.Single().duration.Should().BeGreaterThanOrEqualTo(10_000);
         mockTransactionLogger.Entries.Single().transactionName.Should().Be("timed transaction");
     }
 }

--- a/source/Nevermore/Diagnostics/DefaultTransactionLogger.cs
+++ b/source/Nevermore/Diagnostics/DefaultTransactionLogger.cs
@@ -1,22 +1,9 @@
-﻿using Nevermore.Diagnositcs;
-
-namespace Nevermore.Diagnostics
+﻿namespace Nevermore.Diagnostics
 {
     public class DefaultTransactionLogger : ITransactionLogger
     {
-        static readonly ILog Log = LogProvider.For<DefaultTransactionLogger>();
-
-        readonly long infoThreshold;
-
-        public DefaultTransactionLogger(long infoThreshold = 10_000)
-        {
-            this.infoThreshold = infoThreshold;
-        }
-        
         public void Write(long duration, string transactionName)
         {
-            var level = duration >= infoThreshold ? LogLevel.Info : LogLevel.Debug;
-            Log.Log(level, () => $"Transaction '{transactionName}' was open for {duration}ms");
         }
     }
 }

--- a/source/Nevermore/Diagnostics/DefaultTransactionLogger.cs
+++ b/source/Nevermore/Diagnostics/DefaultTransactionLogger.cs
@@ -1,0 +1,22 @@
+﻿using Nevermore.Diagnositcs;
+
+namespace Nevermore.Diagnostics
+{
+    public class DefaultTransactionLogger : ITransactionLogger
+    {
+        static readonly ILog Log = LogProvider.For<DefaultTransactionLogger>();
+
+        readonly long infoThreshold;
+
+        public DefaultTransactionLogger(long infoThreshold = 10_000)
+        {
+            this.infoThreshold = infoThreshold;
+        }
+        
+        public void Write(long duration, string transactionName)
+        {
+            var level = duration >= infoThreshold ? LogLevel.Info : LogLevel.Debug;
+            Log.Log(level, () => $"Transaction '{transactionName}' was open for {duration}ms");
+        }
+    }
+}

--- a/source/Nevermore/Diagnostics/ITransactionLogger.cs
+++ b/source/Nevermore/Diagnostics/ITransactionLogger.cs
@@ -1,0 +1,7 @@
+﻿namespace Nevermore.Diagnostics
+{
+    public interface ITransactionLogger
+    {
+        void Write(long duration, string transactionName);
+    }
+}

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -38,6 +38,7 @@ namespace Nevermore
         IPrimaryKeyHandlerRegistry PrimaryKeyHandlers { get; }
         IRelatedDocumentStore RelatedDocumentStore { get; set; }
         IQueryLogger QueryLogger { get; set; }
+        ITransactionLogger TransactionLogger { get; set; }
 
         /// <summary>
         /// Hooks can be used to apply general logic when documents are inserted, updated or deleted.

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -55,6 +55,7 @@ namespace Nevermore
             AllowSynchronousOperations = true;
 
             QueryLogger = new DefaultQueryLogger();
+            TransactionLogger = new DefaultTransactionLogger();
 
             connectionString = new Lazy<string>(() =>
             {
@@ -80,6 +81,8 @@ namespace Nevermore
         public IRelatedDocumentStore RelatedDocumentStore { get; set; }
 
         public IQueryLogger QueryLogger { get; set; }
+
+        public ITransactionLogger TransactionLogger { get; set; }
 
         public IHookRegistry Hooks { get; }
         public int KeyBlockSize { get; set; }


### PR DESCRIPTION
Log how long each transaction was open for. This follows the same pattern for logging the query duration. The server can then hook into the `ITransactionLogger` to provide telemetry data.

1 of 2 PRs for [sc-47869]. The server PR to be merged after this is https://github.com/OctopusDeploy/OctopusDeploy/pull/17998.