### PR TITLE
Enable `SequentialAccess` for queries translated by the `QueryTranslator`

### DIFF
--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -23,7 +24,7 @@ namespace Nevermore.Advanced.Queryable
             Visit(expression);
 
             var (sqlExpression, parameterValues, queryType) = sqlBuilder.Build();
-            return (new PreparedCommand(sqlExpression.GenerateSql(), parameterValues, RetriableOperation.Select), queryType);
+            return (new PreparedCommand(sqlExpression.GenerateSql(), parameterValues, RetriableOperation.Select, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess), queryType);
         }
 
         protected override Expression VisitConstant(ConstantExpression node)


### PR DESCRIPTION
# Summary

When reading documents where the JSON is large, 4MB takes about 22 seconds. The time increases quickly from there to hours for 40MB.

It does seem that lots of node CPU is used as well.

This is due to https://github.com/dotnet/SqlClient/issues/593#issuecomment-642831448.

See OctopusDeploy/Issues#8076

[sc-48263]

# Results

When translating a Linq expression to a `PreparedCommand`, the resulting command will now have the `SequentialAccess` and `SingleResult` behaviour flags enabled.

This is also consistent with other usages of the `PreparedCommand` constructor, as well as [Microsoft's own advice for streaming large BLOBs](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sqlclient-streaming-support).

While I'm in the area, I figured I'd add the `SingleRow` flag to some `ExecuteScalar` methods. 
<!--I considered adding `SequentialAccess` to the `Stream` methods with the `Func<IProjectionMapper, TResult> projectionMapper` argument, but this isn't compatible with the `ToListWithCountAsyncCte(...)` method, as it intentionally reads columns out of order.-->

See OctopusDeploy/OctopusDeploy#17993 for performance results.