### PR TITLE
Allow inherited types in type check in DataModificationQueryBuilder

### DIFF
--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByIdWithInheritedTypedKey.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByIdWithInheritedTypedKey.approved.txt
@@ -1,0 +1,3 @@
+DELETE FROM [dbo].[TestDocumentWithTypedKey] WITH (ROWLOCK) WHERE [Id] = @Id
+
+@Id=Nevermore.Tests.Util.DataModificationQueryBuilderFixture+InheritedTypedKey

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByIdWithTypedKey.approved.txt
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.DeleteByIdWithTypedKey.approved.txt
@@ -1,0 +1,3 @@
+DELETE FROM [dbo].[TestDocumentWithTypedKey] WITH (ROWLOCK) WHERE [Id] = @Id
+
+@Id=Nevermore.Tests.Util.DataModificationQueryBuilderFixture+TypedKey

--- a/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/Util/DataModificationQueryBuilderFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Assent;
+using Microsoft.Data.SqlClient.Server;
 using Nevermore.Advanced;
 using Nevermore.Advanced.Serialization;
 using Nevermore.Mapping;
@@ -24,6 +25,9 @@ namespace Nevermore.Tests.Util
         {
             configuration = new RelationalStoreConfiguration("");
             configuration.DocumentSerializer = new NewtonsoftDocumentSerializer(configuration);
+            configuration.PrimaryKeyHandlers.Register(
+                new TypedKeyHandler()
+            );
             configuration.DocumentMaps.Register(
                 new TestDocumentMap(),
                 new TestDocumentWithRelatedDocumentsMap(),
@@ -31,7 +35,8 @@ namespace Nevermore.Tests.Util
                 new OtherMap(),
                 new TestDocumentWithIdentityIdMap(),
                 new TestDocumentWithIdentityIdAndRowVersionMap(),
-                new TestDocumentWithColumnsFromBaseMap());
+                new TestDocumentWithColumnsFromBaseMap(),
+                new TestDocumentWithTypedKeyMap());
             builder = new DataModificationQueryBuilder(
                 configuration,
                 m => idAllocator()
@@ -590,6 +595,40 @@ namespace Nevermore.Tests.Util
                 Column(t => t.BaseColumn);
                 Column(t => t.DerivedColumn);
                 RowVersion(t => t.RowVersion);
+            }
+        }
+
+        class TestDocumentWithTypedKeyMap : DocumentMap<TestDocumentWithTypedKey>
+        {
+            public TestDocumentWithTypedKeyMap()
+            {
+                Id(t => t.Id);
+            }
+        }
+
+        class TestDocumentWithTypedKey
+        {
+            public TypedKey Id { get; set; }
+        }
+
+        class TypedKey
+        {
+        }
+        
+        class InheritedTypedKey : TypedKey
+        {
+        }
+
+        class TypedKeyHandler : PrimaryKeyHandler<TypedKey>
+        {
+            public override SqlMetaData GetSqlMetaData(string name)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object GetNextKey(IKeyAllocator keyAllocator, string tableName)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -125,7 +125,7 @@ namespace Nevermore.Util
             var mapping = mappings.Resolve(typeof(TDocument));
 
             var idType = id.GetType();
-            if (mapping.IdColumn.Type != idType)
+            if (!mapping.IdColumn.Type.IsAssignableFrom(idType))
                 throw new ArgumentException($"Provided Id of type '{idType.FullName}' does not match configured type of '{mapping.IdColumn.Type.FullName}'.");
 
             return PrepareDelete(mapping, id, options);
@@ -315,7 +315,7 @@ namespace Nevermore.Util
 
             var id = mapping.IdColumn.PropertyHandler.Read(document);
 
-            if (customAssignedId != null && customAssignedId.GetType() != mapping.IdColumn.Type)
+            if (customAssignedId != null && !mapping.IdColumn.Type.IsAssignableFrom(customAssignedId.GetType()))
                 throw new ArgumentException($"The given custom Id '{customAssignedId}' must be of type ({mapping.IdColumn.Type.Name}), to match the model's Id property");
 
             if (customIdAssignmentBehavior == CustomIdAssignmentBehavior.ThrowIfIdAlreadySetToDifferentValue &&


### PR DESCRIPTION
Relaxes the type check in `PrepareDelete` and `GetDocumentParameters` to allow inherited types of the DocumentMap id column key type.

## Details
The key type check on the [`PrepareLoad` in `ReadTransaction`](https://github.com/OctopusDeploy/Nevermore/blob/b22d050365396e975c45f024dbb28de18bbb95b9/source/Nevermore/Advanced/ReadTransaction.cs#L676-L677) allows for inherited types to be passed in because we check that the mapping id column type matches `TKey` rather than the specific runtime type.

In [`PrepareDelete` in `DataModificationQueryBuilder`](https://github.com/OctopusDeploy/Nevermore/blob/master/source/Nevermore/Util/DataModificationQueryBuilder.cs#L127-L129) called by `WriteTransaction`, we do an exact comparison against the runtime type of the identifier. If it is not an exact type match, this will throw. So while we can support inherited id types for reads, they'll break on delete. 

This change modifies the type check from a exact comparison to an `IsAssignableFrom` comparison. We're still checking the runtime type, but the behaviour is more like what we get with `PrepareLoad`. I've gone for this approach as changing the interface to align with `ReadTransaction` and pass through `TKey` would require an API change. This seems like the least disruptive option as it just makes the type check more permissive and aligns with other behaviour in Nevermore.