### PR TITLE
Add a Roslyn Analyzer for unsupported IQueryable methods

### DIFF
--- a/source/Nevermore.Analyzers.Tests/NevermoreFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreFixture.cs
@@ -14,6 +14,15 @@ namespace Nevermore.Analyzers.Tests
 	        results.Count.Should().Be(1);
 	        results[0].GetMessage().Should().Contain(error);
         }
+	    
+	    protected static void AssertErrors(List<Diagnostic> results, params string[] errors)
+	    {
+		    results.Count.Should().Be(errors.Length);
+		    for (var i = 0; i < errors.Length; i++)
+		    {
+			    results[i].GetMessage().Should().Contain(errors[i]);
+		    }
+	    }
 
         protected static void AssertPassed(List<Diagnostic> results)
         {

--- a/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
@@ -90,7 +90,7 @@ public class NevermoreQueryableAnalyzerFixture : NevermoreFixture
     public void ShouldPassForSkip()
     {
         var code = @"
-			transaction.Queryable<Customer>().Take(1);
+			transaction.Queryable<Customer>().Skip(1);
 		";
 
         var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);

--- a/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
@@ -1,0 +1,152 @@
+using NUnit.Framework;
+
+namespace Nevermore.Analyzers.Tests;
+
+public class NevermoreQueryableAnalyzerFixture : NevermoreFixture
+{
+    [Test]
+    public void ShouldPassForWhere()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Where(c => c.FirstName == '').ToList();
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForOrderBy()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().OrderBy(c => c.FirstName).ToList();
+			transaction.Queryable<Customer>().OrderByDescending(c => c.FirstName).ToList();
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForThenBy()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().OrderBy(c => c.FirstName).ThenBy(c => c.LastName).ToList();
+			transaction.Queryable<Customer>().OrderBy(c => c.FirstName).ThenByDescending(c => c.LastName).ToList();
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForFirst()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().First(c => c.FirstName == ""Foo"");
+			transaction.Queryable<Customer>().FirstOrDefault(c => c.FirstName == ""Foo"");
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForAny()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Any();
+			transaction.Queryable<Customer>().Any(c => c.FirstName == ""Foo"");
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForCount()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Count();
+			transaction.Queryable<Customer>().Count(c => c.FirstName == ""Foo"");
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForTake()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Take(2);
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldPassForSkip()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Take(1);
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertPassed(results);
+    }
+
+    [Test]
+    public void ShouldFailForSingle()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Single(c => c.FirstName == 'Bob');
+			transaction.Queryable<Customer>().SingleOrDefault(c => c.FirstName == 'Bob');
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertErrors(
+            results,
+            "Nevermore Queryable does not support Single",
+            "Nevermore Queryable does not support SingleOrDefault");
+    }
+
+    [Test]
+    public void ShouldFailForDistinct()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Distinct();
+			transaction.Queryable<Customer>().DistinctBy(c => c.FirstName);
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertErrors(
+            results,
+            "Nevermore Queryable does not support Distinct",
+            "Nevermore Queryable does not support DistinctBy");
+    }
+
+    [Test]
+    public void ShouldFailSelect()
+    {
+        var code = @"
+			transaction.Queryable<Customer>().Select(c => c.FirstName);
+		";
+
+        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+        AssertError(results, "Nevermore Queryable does not support Select");
+    }
+
+    [Test]
+    public void ShouldPassOnQueryableFromSomewhereElse()
+    {
+	    var code = @"
+			var list = new List<Customer>();
+			list.AsQueryable().Select(c => c.FirstName);
+		";
+
+	    var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+	    AssertPassed(results);
+    }
+}

--- a/source/Nevermore.Analyzers/Descriptors.cs
+++ b/source/Nevermore.Analyzers/Descriptors.cs
@@ -14,6 +14,16 @@ namespace Nevermore.Analyzers
             isEnabledByDefault: true,
             description: "",
             helpLinkUri: "https://github.com/OctopusDeploy/Nevermore/wiki/Querying");
+        
+        internal static readonly DiagnosticDescriptor NV0002NevermoreQueryableError = Create(
+            "NV0002",
+            "Nevermore Queryable",
+            "Nevermore Queryable does not support {0}",
+            "Nevermore",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: "",
+            helpLinkUri: "https://github.com/OctopusDeploy/Nevermore/wiki/Querying");
 
         internal static readonly DiagnosticDescriptor NV0005NevermoreEmbeddedSqlWarning = Create(
             "NV0005",

--- a/source/Nevermore.Analyzers/Issue.cs
+++ b/source/Nevermore.Analyzers/Issue.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Nevermore.Analyzers
 {
-    internal class Issue
+    public class Issue
     {
         public Issue(string message, Location location)
         {

--- a/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using LanguageNames = Microsoft.CodeAnalysis.LanguageNames;
+
+namespace Nevermore.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NevermoreQueryableAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptors.NV0002NevermoreQueryableError);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(DontUse_UnsupportedQueryableMethods, SyntaxKind.InvocationExpression);
+    }
+
+    void DontUse_UnsupportedQueryableMethods(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax {Expression: MemberAccessExpressionSyntax memberAccessExpressionSyntax} invocationExpressionSyntax)
+        {
+            return;
+        }
+        
+        var symbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax);
+        if (symbolInfo.Symbol is null)
+            return;
+
+        if (symbolInfo.Symbol.ContainingType.AllInterfaces.Any(i => i.Name == nameof(IQueryable)))
+            return;
+
+        var parentSymbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax.Expression);
+        if (parentSymbolInfo.Symbol is not IMethodSymbol methodSymbol || 
+            !methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore"))
+            return;
+
+        var result = invocationExpressionSyntax.Accept(new NevermoreQueryableVisitor());
+        if (result != null)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Descriptors.NV0002NevermoreQueryableError,
+                    result.Location ?? invocationExpressionSyntax.GetLocation(),
+                    result.Message));
+        }
+    }
+}

--- a/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
@@ -27,16 +27,11 @@ public class NevermoreQueryableAnalyzer : DiagnosticAnalyzer
         {
             return;
         }
-        
-        var symbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax);
-        if (symbolInfo.Symbol is null)
-            return;
 
-        if (symbolInfo.Symbol.ContainingType.AllInterfaces.Any(i => i.Name == nameof(IQueryable)))
-            return;
-
-        var parentSymbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax.Expression);
-        if (parentSymbolInfo.Symbol is not IMethodSymbol methodSymbol || 
+        // Only target calls to methods on Nevermore types that return an IQueryable.
+        // E.g: IReadQueryExecutor.Queryable<T>()
+        var symbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax.Expression);
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol || 
             !methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore"))
             return;
 

--- a/source/Nevermore.Analyzers/NevermoreQueryableVisitor.cs
+++ b/source/Nevermore.Analyzers/NevermoreQueryableVisitor.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Nevermore.Analyzers;
+
+public class NevermoreQueryableVisitor : CSharpSyntaxVisitor<Issue>
+{
+    readonly string[] supportedQueryableMethods =
+    {
+        nameof(Queryable.Where),
+        nameof(Queryable.OrderBy),
+        nameof(Queryable.OrderByDescending),
+        nameof(Queryable.ThenBy),
+        nameof(Queryable.ThenByDescending),
+        nameof(Queryable.First),
+        nameof(Queryable.FirstOrDefault),
+        nameof(Queryable.Any),
+        nameof(Queryable.Count),
+        nameof(Queryable.Take),
+        nameof(Queryable.Skip),
+    };
+    
+    public override Issue DefaultVisit(SyntaxNode node)
+    {
+        if (node is not InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccessExpressionSyntax } invocationExpressionSyntax)
+        {
+            return null;
+        }
+
+        if (supportedQueryableMethods.Contains(memberAccessExpressionSyntax.Name.Identifier.Text))
+        {
+            return null;
+        }
+        
+        return new Issue(
+            memberAccessExpressionSyntax.Name.Identifier.Text,
+            invocationExpressionSyntax.GetLocation());
+    }
+}

--- a/source/Nevermore.Analyzers/NevermoreWhereExpressionVisitor.cs
+++ b/source/Nevermore.Analyzers/NevermoreWhereExpressionVisitor.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Nevermore.Analyzers
 {
-    internal class NevermoreWhereExpressionVisitor : CSharpSyntaxVisitor<Issue>
+    public class NevermoreWhereExpressionVisitor : CSharpSyntaxVisitor<Issue>
     {
         readonly ParameterSyntax expressionArgumentParameter;
         readonly SemanticModel model;


### PR DESCRIPTION
Adds a Roslyn Analyzer that raises compiler errors when an unsupported `IQueryable` method is invoked. This analyzer only targets calls to Nevermore types, i.e: `IReadQueryExecutor.Queryable<T>().Single()` and doesn't affect other calls to `IQueryable`, i.e: `myList.AsQueryable().Single()`.

Also makes the visitors public so that they can be accessed in Octopus Server and re-purposed.

[sc-53501]