### PR TITLE
Ignore non-IQueryable methods

### DIFF
--- a/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
@@ -4,6 +4,18 @@ namespace Nevermore.Analyzers.Tests;
 
 public class NevermoreQueryableAnalyzerFixture : NevermoreFixture
 {
+	[Test]
+	public void ShouldPassOnNonQueryableMethods()
+	{
+		var code = @"
+			transaction.Queryable<Customer>().ToList();
+			transaction.Queryable<Customer>();
+		";
+
+		var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
+		AssertPassed(results);
+	}
+
     [Test]
     public void ShouldPassForWhere()
     {

--- a/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
+++ b/source/Nevermore.Analyzers/NevermoreQueryableAnalyzer.cs
@@ -27,12 +27,21 @@ public class NevermoreQueryableAnalyzer : DiagnosticAnalyzer
         {
             return;
         }
+        
+        // Only target IQueryable methods
+        var symbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax);
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol ||
+            !IsQueryableExtensionMethod(methodSymbol))
+        {
+            return;
+        }
 
         // Only target calls to methods on Nevermore types that return an IQueryable.
-        // E.g: IReadQueryExecutor.Queryable<T>()
-        var symbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax.Expression);
-        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol || 
-            !methodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore"))
+        // E.g: IReadQueryExecutor.Queryable<T>().Select()
+        //  not IQueryable<string> GetNames(IQueryable<T> queryable) => queryable.Select(c => c.Names)
+        var parentSymbolInfo = ModelExtensions.GetSymbolInfo(context.SemanticModel, memberAccessExpressionSyntax.Expression);
+        if (parentSymbolInfo.Symbol is not IMethodSymbol parentMethodSymbol || 
+            !parentMethodSymbol.ContainingType.ContainingNamespace.Name.StartsWith("Nevermore"))
             return;
 
         var result = invocationExpressionSyntax.Accept(new NevermoreQueryableVisitor());
@@ -44,5 +53,21 @@ public class NevermoreQueryableAnalyzer : DiagnosticAnalyzer
                     result.Location ?? invocationExpressionSyntax.GetLocation(),
                     result.Message));
         }
+    }
+
+    bool IsQueryableExtensionMethod(IMethodSymbol methodSymbol)
+    {
+        // If the method is not defined in the Queryable class, then we don't care
+        if (methodSymbol.ContainingType.Name != nameof(Queryable))
+            return false;
+            
+        // If this is an extension method that doesn't take an IQueryable as it's receiver, then we don't care
+        if (methodSymbol is {IsExtensionMethod: true, ReceiverType: not null} &&
+            methodSymbol.ReceiverType.Interfaces.All(i => i.Name != nameof(IQueryable)))
+        {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Updates the `IQueryable` analyser to ignore non `IQueryable` methods, e.g: `.ToList()`.