### PR TITLE
Escape `LIKE` comparison so that `[` and `%` can be used in queries

### DIFF
--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -669,6 +669,32 @@ namespace Nevermore.IntegrationTests
 
             customers.Select(c => c.FirstName).Should().BeEquivalentTo("Alice", "Bob", "Charlie");
         }
+        
+        [Test]
+        public void WhereStringContains()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", Nickname = "Bear" },
+                new Customer { FirstName = "Bob", LastName = "Banana", Nickname = "Beets" },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", Nickname = "Chicken" }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            t.Commit();
+
+            var customers = t.Queryable<Customer>()
+                .Where(c => c.Nickname.Contains("hi"))
+                .ToList();
+
+            customers.Select(c => c.FirstName).Should().BeEquivalentTo("Charlie");
+        }
 
         [Test]
         public void WhereNotStringContains()
@@ -694,6 +720,32 @@ namespace Nevermore.IntegrationTests
                 .ToList();
 
             customers.Select(c => c.FirstName).Should().BeEquivalentTo("Alice", "Bob");
+        }
+
+        [Test]
+        public void WhereStringContainsSpecialCharacters()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", Nickname = "[Bear]" },
+                new Customer { FirstName = "Bob", LastName = "Banana", Nickname = "[100%]" }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            t.Commit();
+
+            var customers = t.Queryable<Customer>()
+                .Where(c => c.Nickname.Contains("["))
+                .Where(c => !c.Nickname.Contains("%"))
+                .ToList();
+
+            customers.Select(c => c.FirstName).Should().BeEquivalentTo("Alice");
         }
 
         [Test]

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -730,7 +730,8 @@ namespace Nevermore.IntegrationTests
             var testCustomers = new[]
             {
                 new Customer { FirstName = "Alice", LastName = "Apple", Nickname = "[Bear]" },
-                new Customer { FirstName = "Bob", LastName = "Banana", Nickname = "[100%]" }
+                new Customer { FirstName = "Bob", LastName = "Banana", Nickname = "[100%]" },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", Nickname = "[Fried_Chicken]" }
             };
 
             foreach (var c in testCustomers)
@@ -743,6 +744,7 @@ namespace Nevermore.IntegrationTests
             var customers = t.Queryable<Customer>()
                 .Where(c => c.Nickname.Contains("["))
                 .Where(c => !c.Nickname.Contains("%"))
+                .Where(c => !c.Nickname.Contains("_"))
                 .ToList();
 
             customers.Select(c => c.FirstName).Should().BeEquivalentTo("Alice");

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -269,7 +269,7 @@ namespace Nevermore.Advanced.Queryable
         IWhereClause CreateStringMethodWhere(MethodCallExpression expression, bool invert = false)
         {
             var (fieldReference, _) = GetFieldReferenceAndType(expression.Object);
-            var value = (string)GetValueFromExpression(expression.Arguments[0], typeof(string));
+            var value = ((string)GetValueFromExpression(expression.Arguments[0], typeof(string))).EscapeForLikeComparison();
 
             if (expression.Method.Name == nameof(string.Contains))
             {

--- a/source/Nevermore/LikeComparisonExtensions.cs
+++ b/source/Nevermore/LikeComparisonExtensions.cs
@@ -1,9 +1,10 @@
 ﻿namespace Nevermore
 {
-    public static class LikeComparisonExtensions {
+    public static class LikeComparisonExtensions
+    {
         public static string EscapeForLikeComparison(this string value)
         {
-            return value.Replace("[", "[[]").Replace("%", "[%]");
+            return value.Replace("[", "[[]").Replace("%", "[%]").Replace("_", "[_]");
         }
     }
 }

--- a/source/Nevermore/LikeComparisonExtensions.cs
+++ b/source/Nevermore/LikeComparisonExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace Nevermore
+{
+    public static class LikeComparisonExtensions {
+        public static string EscapeForLikeComparison(this string value)
+        {
+            return value.Replace("[", "[[]").Replace("%", "[%]");
+        }
+    }
+}

--- a/source/Nevermore/QueryBuilderWhereExtensions.cs
+++ b/source/Nevermore/QueryBuilderWhereExtensions.cs
@@ -286,8 +286,9 @@ namespace Nevermore
         [Pure] public static IQueryBuilder<TRecord> LikeParameter<TRecord>(this IQueryBuilder<TRecord> queryBuilder,
             string name, object value) where TRecord : class
         {
+            var likeValue = (value ?? string.Empty).ToString().EscapeForLikeComparison();
             return queryBuilder.Parameter(name,
-                "%" + (value ?? string.Empty).ToString().Replace("[", "[[]").Replace("%", "[%]") + "%");
+                "%" + likeValue + "%");
         }
 
         /// <summary>
@@ -303,7 +304,7 @@ namespace Nevermore
             string name, object value) where TRecord : class
         {
             return queryBuilder.Parameter(name,
-                "%|" + (value ?? string.Empty).ToString().Replace("[", "[[]").Replace("%", "[%]") + "|%");
+                "%|" + (value ?? string.Empty).ToString().EscapeForLikeComparison() + "|%");
         }
     }
 }


### PR DESCRIPTION
When querying a value with `.Contains`, the resulting SQL is a `WHERE foo LIKE %{value}%` clause. When `value` contains special characters (`[` or `%`) the results can be unpredictable.