### PR TITLE
Correctly identify DateTimeOffset JSON properties as scalar

### DIFF
--- a/source/Nevermore.IntegrationTests/Model/Machine.cs
+++ b/source/Nevermore.IntegrationTests/Model/Machine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nevermore.IntegrationTests.Model
+﻿using System;
+
+namespace Nevermore.IntegrationTests.Model
 {
     public class Machine
     {
@@ -7,5 +9,6 @@
 
         public string Description { get; set; }
         public Endpoint Endpoint { get; set; }
+        public DateTimeOffset LastModified { get; set; }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -173,6 +173,33 @@ namespace Nevermore.IntegrationTests
         }
 
         [Test]
+        public void WhereEqualJsonDateTimeOffset()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testLastModified = new DateTimeOffset(2023, 07, 27, 16, 04, 00, TimeSpan.Zero);
+            var testMachines = new[]
+            {
+                new Machine { Name = "Machine A", LastModified = DateTimeOffset.Now },
+                new Machine { Name = "Machine B", LastModified = testLastModified},
+                new Machine { Name = "Machine C", LastModified = DateTimeOffset.Now},
+            };
+
+            foreach (var c in testMachines)
+            {
+                t.Insert(c);
+            }
+
+            t.Commit();
+
+            var customers = t.Queryable<Machine>()
+                .Where(m => m.LastModified == testLastModified)
+                .ToList();
+
+            customers.Select(m => m.Name).Should().BeEquivalentTo("Machine B");
+        }
+
+        [Test]
         public void WhereIsNullJsonValue()
         {
             using var t = Store.BeginTransaction();

--- a/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Nevermore.Advanced.Queryable
 {
     internal static class PropertyInfoExtensions
     {
+        static readonly HashSet<Type> KnownScalarTypes = new()
+        {
+            typeof(DateTimeOffset)
+        };
+
         public static bool Matches(this PropertyInfo propertyInfo, PropertyInfo other)
         {
             return propertyInfo.Name.Equals(other.Name) &&
@@ -13,6 +19,12 @@ namespace Nevermore.Advanced.Queryable
 
         public static bool IsScalar(this PropertyInfo propertyInfo)
         {
+            // there are some types that can be consider scalars but have a TypeCode of Object
+            if (KnownScalarTypes.Contains(propertyInfo.PropertyType))
+            {
+                return true;
+            }
+
             return Type.GetTypeCode(propertyInfo.PropertyType) switch
             {
                 TypeCode.Object => false,


### PR DESCRIPTION
When performing a `.Where` query against a property of type `DateTimeOffset`, it was incorrectly being identified as a non-scalar type, meaning nevermore tried to use `JSON_QUERY`, as opposed to `JSON_VALUE`.

This is because the TypeCode returned is `Object`.

This PR just updates the `IsScalar` to check certain predefined scalar types before falling back on the `GetTypeCode` check