### PR TITLE
Async and cancellation improvements

### DIFF
--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -90,15 +90,15 @@ namespace Nevermore.Advanced
 
             connection = connectionFactory(registry.ConnectionString);
             connection.OpenWithRetry();
-            
+
             TransactionTimer = new TimedSection(ms => configuration.TransactionLogger.Write(ms, name));
         }
 
-        public async Task OpenAsync()
+        public async Task OpenAsync(CancellationToken cancellationToken = default)
         {
             connection = connectionFactory(registry.ConnectionString);
-            await connection.OpenWithRetryAsync().ConfigureAwait(false);
-            
+            await connection.OpenWithRetryAsync(cancellationToken).ConfigureAwait(false);
+
             TransactionTimer = new TimedSection(ms => configuration.TransactionLogger.Write(ms, name));
         }
 
@@ -108,12 +108,12 @@ namespace Nevermore.Advanced
             Transaction = BeginTransactionWithRetry(isolationLevel, SqlServerTransactionName, RetryManager.Instance.GetDefaultSqlTransactionRetryPolicy());
         }
 
-        public async Task OpenAsync(IsolationLevel isolationLevel)
+        public async Task OpenAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
         {
-            await OpenAsync().ConfigureAwait(false);
-            Transaction = await BeginTransactionWithRetryAsync(isolationLevel, SqlServerTransactionName, RetryManager.Instance.GetDefaultSqlTransactionRetryPolicy()).ConfigureAwait(false);
+            await OpenAsync(cancellationToken).ConfigureAwait(false);
+            Transaction = await BeginTransactionWithRetryAsync(isolationLevel, SqlServerTransactionName, RetryManager.Instance.GetDefaultSqlTransactionRetryPolicy(), cancellationToken).ConfigureAwait(false);
         }
-        
+
         [Pure]
         public TDocument? Load<TDocument, TKey>(TKey id) where TDocument : class
         {
@@ -679,18 +679,18 @@ namespace Nevermore.Advanced
             using var command = CreateCommand(preparedCommand);
             return await command.ReadResultsAsync(mapper, cancellationToken).ConfigureAwait(false);
         }
-        
-        async Task<DbTransaction> BeginTransactionWithRetryAsync(IsolationLevel isolationLevel, string sqlServerTransactionName, RetryPolicy retryPolicy)
+
+        async Task<DbTransaction> BeginTransactionWithRetryAsync(IsolationLevel isolationLevel, string sqlServerTransactionName, RetryPolicy retryPolicy, CancellationToken cancellationToken = default)
         {
             if (connection == null) throw new InvalidOperationException("Must create a DbConnection before attempting to begin a transaction");
-            
+
             return await retryPolicy.LoggingRetries("Beginning Database Transaction").ExecuteActionAsync(async () =>
             {
                 // A connection can exist, but be in a broken state.
                 // E.g. a valid connection is returned to the pool, we then acquire it, but on the SQL server end it's been killed perhaps due to Azure SQL resource limits.
-                // We re-open the same connection, following the logic in `DbCommandExtensions.EnsureValidConnection` 
-                if (connection.State != ConnectionState.Open) await connection.OpenAsync().ConfigureAwait(false);
-                
+                // We re-open the same connection, following the logic in `DbCommandExtensions.EnsureValidConnection`
+                if (connection.State != ConnectionState.Open) await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
                 // We use the synchronous overload here even though there is an async one, because BeginTransactionAsync calls
                 // the synchronous version anyway, and the async overload doesn't accept a name parameter.
                 return BeginTransaction(isolationLevel, sqlServerTransactionName);
@@ -700,11 +700,11 @@ namespace Nevermore.Advanced
         DbTransaction BeginTransactionWithRetry(IsolationLevel isolationLevel, string sqlServerTransactionName, RetryPolicy retryPolicy)
         {
             if (connection == null) throw new InvalidOperationException("Must create a DbConnection before attempting to begin a transaction");
-            
+
             return retryPolicy.LoggingRetries("Beginning Database Transaction").ExecuteAction(() =>
             {
                 if (connection.State != ConnectionState.Open) connection.Open();
-                
+
                 return BeginTransaction(isolationLevel, sqlServerTransactionName);
             });
         }

--- a/source/Nevermore/IRelationalStore.cs
+++ b/source/Nevermore/IRelationalStore.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
 
@@ -9,12 +10,12 @@ namespace Nevermore
     {
         IRelationalStoreConfiguration Configuration { get; }
         void WriteCurrentTransactions(StringBuilder output);
-        
+
         IReadTransaction BeginReadTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null);
-        Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null);
+        Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null, CancellationToken cancellationToken = default);
 
         IWriteTransaction BeginWriteTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null);
-        Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null);
+        Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null, CancellationToken cancellationToken = default);
 
         IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null);
     }

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -6,6 +6,7 @@ using System.Data.SqlClient;
 using Microsoft.Data.SqlClient;
 #endif
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
 using Nevermore.Mapping;
@@ -49,12 +50,12 @@ namespace Nevermore
             }
         }
 
-        public async Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
+        public async Task<IReadTransaction> BeginReadTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null, CancellationToken cancellationToken = default)
         {
             var txn = CreateReadTransaction(retriableOperation, name);
             try
             {
-                await txn.OpenAsync(isolationLevel).ConfigureAwait(false);
+                await txn.OpenAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
                 return txn;
             }
             catch
@@ -79,12 +80,12 @@ namespace Nevermore
             }
         }
 
-        public async Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null)
+        public async Task<IWriteTransaction> BeginWriteTransactionAsync(IsolationLevel isolationLevel = NevermoreDefaults.IsolationLevel, RetriableOperation retriableOperation = NevermoreDefaults.RetriableOperations, string name = null, CancellationToken cancellationToken = default)
         {
             var txn = CreateWriteTransaction(retriableOperation, name);
             try
             {
-                await txn.OpenAsync(isolationLevel).ConfigureAwait(false);
+                await txn.OpenAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
                 return txn;
             }
             catch

--- a/source/Nevermore/Transient/DbCommandExtensions.cs
+++ b/source/Nevermore/Transient/DbCommandExtensions.cs
@@ -31,7 +31,7 @@ namespace Nevermore.Transient
         {
             GuardConnectionIsNotNull(command);
             var effectiveCommandRetryPolicy = (commandRetryPolicy ?? RetryPolicy.NoRetry).LoggingRetries(operationName);
-            return effectiveCommandRetryPolicy.ExecuteAction(async () =>
+            return effectiveCommandRetryPolicy.ExecuteActionAsync(async () =>
             {
                 var weOwnTheConnectionLifetime = await EnsureValidConnectionAsync(command, connectionRetryPolicy, cancellationToken).ConfigureAwait(false);
                 try

--- a/source/Nevermore/Transient/DbConnectionExtensions.cs
+++ b/source/Nevermore/Transient/DbConnectionExtensions.cs
@@ -18,7 +18,7 @@ namespace Nevermore.Transient
         {
             (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteAction(connection.Open);
         }
-        
+
         public static Task OpenWithRetryAsync(this DbConnection connection)
         {
             return OpenWithRetryAsync(connection, RetryManager.Instance.GetDefaultSqlConnectionRetryPolicy());
@@ -33,10 +33,10 @@ namespace Nevermore.Transient
         {
             return OpenWithRetryAsync(connection, retryPolicy, CancellationToken.None);
         }
-        
+
         public static Task OpenWithRetryAsync(this DbConnection connection, RetryPolicy retryPolicy, CancellationToken cancellationToken)
         {
-            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteActionAsync(() => connection.OpenAsync(cancellationToken));
+            return (retryPolicy ?? RetryPolicy.NoRetry).LoggingRetries("Open Database Connection").ExecuteActionAsync(connection.OpenAsync, cancellationToken);
         }
     }
 }

--- a/source/Nevermore/Transient/RetryPolicy.cs
+++ b/source/Nevermore/Transient/RetryPolicy.cs
@@ -227,6 +227,17 @@ namespace Nevermore.Transient
             return result;
         }
 
+        public virtual Task ExecuteActionAsync(Func<CancellationToken, Task> func, CancellationToken cancellationToken)
+        {
+            return ExecuteActionAsync<object>(
+                async ct =>
+                {
+                    await func(ct).ConfigureAwait(false);
+                    return null;
+                },
+                cancellationToken);
+        }
+
         public virtual Task ExecuteActionAsync(Func<Task> func)
         {
             return ExecuteActionAsync<object>(async () =>
@@ -237,12 +248,13 @@ namespace Nevermore.Transient
         }
 
         /// <summary>
-        /// Repetitively executes the specified action while it satisfies the current retry policy.
+        /// Repeatedly executes the specified action while it satisfies the current retry policy.
         /// </summary>
         /// <typeparam name="TResult">The type of result expected from the executable action.</typeparam>
         /// <param name="func">A delegate that represents the executable action that returns the result of type <typeparamref name="TResult" />.</param>
+        /// <param name="cancellationToken">A cancellation token that is forwarded to <paramref name="func"/>.</param>
         /// <returns>The result from the action.</returns>
-        public virtual async Task<TResult> ExecuteActionAsync<TResult>(Func<Task<TResult>> func)
+        public virtual async Task<TResult> ExecuteActionAsync<TResult>(Func<CancellationToken, Task<TResult>> func, CancellationToken cancellationToken)
         {
             Guard.ArgumentNotNull(func, "func");
             var num = 0;
@@ -251,10 +263,11 @@ namespace Nevermore.Transient
             TResult result;
             while (true)
             {
-                Exception ex = null;
+                cancellationToken.ThrowIfCancellationRequested();
+                Exception ex;
                 try
                 {
-                    result = await func().ConfigureAwait(false);
+                    result = await func(cancellationToken).ConfigureAwait(false);
                     break;
                 }
 #pragma warning disable 618
@@ -265,7 +278,7 @@ namespace Nevermore.Transient
                     {
                         throw ex2.InnerException;
                     }
-                    result = default(TResult);
+                    result = default;
                     break;
                 }
                 catch (Exception ex3)
@@ -287,6 +300,18 @@ namespace Nevermore.Transient
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Repeatedly executes the specified action while it satisfies the current retry policy.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result expected from the executable action.</typeparam>
+        /// <param name="func">A delegate that represents the executable action that returns the result of type <typeparamref name="TResult" />.</param>
+        /// <returns>The result from the action.</returns>
+        public virtual Task<TResult> ExecuteActionAsync<TResult>(Func<Task<TResult>> func)
+        {
+            Guard.ArgumentNotNull(func, "func");
+            return ExecuteActionAsync(_ => func(), default);
         }
 
         /// <summary>

--- a/source/Nevermore/Transient/RetryPolicy.cs
+++ b/source/Nevermore/Transient/RetryPolicy.cs
@@ -235,7 +235,7 @@ namespace Nevermore.Transient
                 return null;
             });
         }
-        
+
         /// <summary>
         /// Repetitively executes the specified action while it satisfies the current retry policy.
         /// </summary>
@@ -283,7 +283,7 @@ namespace Nevermore.Transient
                 OnRetrying(num, ex, zero);
                 if (num > 1 || !RetryStrategy.FastFirstRetry)
                 {
-                    Thread.Sleep(zero);
+                    await Task.Yield();
                 }
             }
             return result;


### PR DESCRIPTION
Cancellation tokens weren't being passed to `OpenAsync`. This means that failure to acquire a connection (e.g. timing out trying to obtain a connection from the SQL connection pool) cannot be cancelled. This PR resolves that.