### PR TITLE
Allow using a custom key allocator by setting the `KeyAllocatorFactory` configuration

### DIFF
--- a/source/Nevermore.IntegrationTests/Advanced/CustomKeyAllocatorFixture.cs
+++ b/source/Nevermore.IntegrationTests/Advanced/CustomKeyAllocatorFixture.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nevermore.IntegrationTests.SetUp;
+using Nevermore.Mapping;
+using NUnit.Framework;
+
+namespace Nevermore.IntegrationTests.Advanced;
+
+public class CustomKeyAllocatorFixture : FixtureWithDatabase
+{
+    readonly RelationalStore store;
+
+    class SimpleDocument
+    {
+        public string Id { get; private set; }
+        public string Name { get; set; }
+    }
+
+    class SimpleDocumentMap : DocumentMap<SimpleDocument>
+    {
+        public SimpleDocumentMap()
+        {
+            Id().KeyHandler(new StringPrimaryKeyHandler("Simples"));
+            Column(m => m.Name).MaxLength(20);
+        }
+    }
+
+    public CustomKeyAllocatorFixture()
+    {
+        var config = new RelationalStoreConfiguration(ConnectionString)
+        {
+            KeyAllocatorFactory = () => new CustomKeyAllocator(),
+        };
+        config.DocumentMaps.Register(new SimpleDocumentMap());
+
+        store = new RelationalStore(config);
+
+        ExecuteSql(@"
+                CREATE TABLE [SimpleDocument] (
+                  [Id] NVARCHAR(50) NOT NULL CONSTRAINT [PK__Id] PRIMARY KEY CLUSTERED,
+                  [Name] NVARCHAR(20) NOT NULL,
+                  [JSON] NVARCHAR(MAX) NOT NULL
+                )
+                ");
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Reset the allocated Ids so we get a predictable result
+        store.Reset();
+    }
+
+    [Test, Order(1)]
+    public void ShouldAllocateCustomKeys()
+    {
+        using var transaction = store.BeginTransaction();
+
+        var allocated1 = transaction.AllocateId("Foo", "Bars");
+        var allocated2 = transaction.AllocateId("Foo", "Bars");
+        var allocated3 = transaction.AllocateId("Foo", "Bars");
+
+        allocated1.Should().Be("Bars-100");
+        allocated2.Should().Be("Bars-200");
+        allocated3.Should().Be("Bars-300");
+    }
+
+    [Test, Order(2)]
+    public void ShouldAllocateCustomKeysByMapping()
+    {
+        using var transaction = store.BeginTransaction();
+
+        var allocated1 = transaction.AllocateId<string>(typeof(SimpleDocument));
+        var allocated2 = transaction.AllocateId<string>(typeof(SimpleDocument));
+        var allocated3 = transaction.AllocateId<string>(typeof(SimpleDocument));
+
+        allocated1.Should().Be("Simples-100");
+        allocated2.Should().Be("Simples-200");
+        allocated3.Should().Be("Simples-300");
+    }
+
+    [Test, Order(3)]
+    public void ShouldAllocateCustomKeyToInsertedDocuments()
+    {
+        var document = new SimpleDocument() { Name = "Donald" };
+
+        using var transaction = store.BeginTransaction();
+
+        transaction.Insert(document);
+        transaction.Commit();
+
+        document.Id.Should().Be("Simples-100");
+    }
+
+    // This is a simple in-memory custom key allocator that allocates keys in intervals of 100 without relying on the database.
+    class CustomKeyAllocator : IKeyAllocator
+    {
+        readonly ConcurrentDictionary<string, int> allocations = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Reset()
+        {
+            allocations.Clear();
+        }
+
+        public int NextId(string tableName)
+        {
+            return allocations.AddOrUpdate(tableName, (_) => 100, (_, prev) => prev + 100);
+        }
+
+        public ValueTask<int> NextIdAsync(string tableName, CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(NextId(tableName));
+        }
+    }
+}

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -52,6 +52,12 @@ namespace Nevermore
         ISqlCommandFactory CommandFactory { get; set; }
 
         /// <summary>
+        /// Sets a factory for creating a Key Allocator. Set this if you want to have control over how the numeric suffix
+        /// for keys are allocated.
+        /// </summary>
+        Func<IKeyAllocator> KeyAllocatorFactory { get; set; }
+
+        /// <summary>
         /// Gets or sets the key block size that will be used for the key allocator. A higher number enables less
         /// SQL queries to get new blocks, but increases fragmentation.
         /// </summary>

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -16,13 +16,13 @@ namespace Nevermore
     public class RelationalStore : IRelationalStore
     {
         readonly Lazy<RelationalTransactionRegistry> registry;
-        readonly Lazy<KeyAllocator> keyAllocator;
+        readonly Lazy<IKeyAllocator> keyAllocator;
 
         public RelationalStore(IRelationalStoreConfiguration configuration)
         {
             Configuration = configuration;
             registry = new Lazy<RelationalTransactionRegistry>(() => new RelationalTransactionRegistry(new SqlConnectionStringBuilder(configuration.ConnectionString)));
-            keyAllocator = new Lazy<KeyAllocator>(() => new KeyAllocator(this, configuration.KeyBlockSize));
+            keyAllocator = new Lazy<IKeyAllocator>(configuration.KeyAllocatorFactory is not null ? () => configuration.KeyAllocatorFactory() : () => new KeyAllocator(this, configuration.KeyBlockSize));
         }
 
         public void WriteCurrentTransactions(StringBuilder output) => registry.Value.WriteCurrentTransactions(output);

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -108,6 +108,8 @@ namespace Nevermore
 
         public ISqlCommandFactory CommandFactory { get; set; }
 
+        public Func<IKeyAllocator> KeyAllocatorFactory { get; set; }
+
         string InitializeConnectionString(string sqlConnectionString)
         {
             var builder = new SqlConnectionStringBuilder(sqlConnectionString);


### PR DESCRIPTION
This allows the configuration of a custom `IKeyAllocator` implementation which will be used to provide the numerical suffix when generating Ids. We intend to use this to synchronise key allocation with documents that are outside of the control of Nevermore.