### PR TITLE
Support IQueryable Projection

### DIFF
--- a/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
+++ b/source/Nevermore.Analyzers.Tests/NevermoreQueryableAnalyzerFixture.cs
@@ -140,17 +140,6 @@ public class NevermoreQueryableAnalyzerFixture : NevermoreFixture
     }
 
     [Test]
-    public void ShouldFailSelect()
-    {
-        var code = @"
-			transaction.Queryable<Customer>().Select(c => c.FirstName);
-		";
-
-        var results = CodeCompiler.Compile<NevermoreQueryableAnalyzer>(code);
-        AssertError(results, "Nevermore Queryable does not support Select");
-    }
-
-    [Test]
     public void ShouldPassOnQueryableFromSomewhereElse()
     {
 	    var code = @"

--- a/source/Nevermore.Analyzers/NevermoreQueryableVisitor.cs
+++ b/source/Nevermore.Analyzers/NevermoreQueryableVisitor.cs
@@ -20,6 +20,7 @@ public class NevermoreQueryableVisitor : CSharpSyntaxVisitor<Issue>
         nameof(Queryable.Count),
         nameof(Queryable.Take),
         nameof(Queryable.Skip),
+        nameof(Queryable.Select)
     };
     
     public override Issue DefaultVisit(SyntaxNode node)

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1527,5 +1527,29 @@ namespace Nevermore.IntegrationTests
                 new { FirstName = "Charlie", IsEmployee = true }
             });
         }
+
+        [Test]
+        public async Task ProjectValueType()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", IsEmployee = true },
+                new Customer { FirstName = "Bob", LastName = "Banana", IsEmployee = false },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", IsEmployee = true }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = await t.Queryable<Customer>().Select(c => c.IsEmployee).ToListAsync();
+
+            customers.Should().BeEquivalentTo(new[] { true, false, true });
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1551,5 +1551,42 @@ namespace Nevermore.IntegrationTests
 
             customers.Should().BeEquivalentTo(new[] { true, false, true });
         }
+
+        [Test]
+        public async Task ProjectTypeWithParameterizedConstructor()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", IsEmployee = true },
+                new Customer { FirstName = "Bob", LastName = "Banana", IsEmployee = false },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", IsEmployee = true }
+            };
+
+            await t.InsertManyAsync(testCustomers);
+            await t.CommitAsync();
+
+            var customers = await t.Queryable<Customer>().Select(c => new CustomerProjection(c.FirstName, c.IsEmployee)).ToListAsync();
+
+            customers.Should().BeEquivalentTo(new[]
+            {
+                new CustomerProjection("Alice", true),
+                new CustomerProjection("Bob", false),
+                new CustomerProjection("Charlie", true)
+            });
+        }
+
+        class CustomerProjection
+        {
+            public CustomerProjection(string firstName, bool isEmployee)
+            {
+                FirstName = firstName;
+                IsEmployee = isEmployee;
+            }
+
+            public string FirstName { get; }
+            public bool IsEmployee { get; }
+        }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1521,10 +1521,11 @@ namespace Nevermore.IntegrationTests
 
             var customers = t.Queryable<Customer>().Select(c => new { c.FirstName, c.IsEmployee });
 
-            customers.Should().BeEquivalentTo(
+            customers.Should().BeEquivalentTo(new[] {
                 new { FirstName = "Alice", IsEmployee = true },
                 new { FirstName = "Bob", IsEmployee = false },
-                new { FirstName = "Charlie", IsEmployee = true });
+                new { FirstName = "Charlie", IsEmployee = true }
+            });
         }
     }
 }

--- a/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
+++ b/source/Nevermore.IntegrationTests/QueryableIntegrationFixture.cs
@@ -1475,5 +1475,56 @@ namespace Nevermore.IntegrationTests
 
             customers.Select(c => c.LastName).Should().BeEquivalentTo("Apple", "Cherry");
         }
+
+        [Test]
+        public async Task ProjectColumnField()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", Roles = { "Admin" }},
+                new Customer { FirstName = "Bob", LastName = "Banana", Roles = { "Boss" } },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", Roles = { "Editor", "Bum" } }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = t.Queryable<Customer>().Select(c => c.FirstName);
+
+            customers.Should().BeEquivalentTo("Alice", "Bob", "Charlie");
+        }
+
+        [Test]
+        public async Task ProjectJsonField()
+        {
+            using var t = Store.BeginTransaction();
+
+            var testCustomers = new[]
+            {
+                new Customer { FirstName = "Alice", LastName = "Apple", IsEmployee = true },
+                new Customer { FirstName = "Bob", LastName = "Banana", IsEmployee = false },
+                new Customer { FirstName = "Charlie", LastName = "Cherry", IsEmployee = true }
+            };
+
+            foreach (var c in testCustomers)
+            {
+                t.Insert(c);
+            }
+
+            await t.CommitAsync();
+
+            var customers = t.Queryable<Customer>().Select(c => new { c.FirstName, c.IsEmployee });
+
+            customers.Should().BeEquivalentTo(
+                new { FirstName = "Alice", IsEmployee = true },
+                new { FirstName = "Bob", IsEmployee = false },
+                new { FirstName = "Charlie", IsEmployee = true });
+        }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
+++ b/source/Nevermore/Advanced/Queryable/AsyncEnumerableAdapter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nevermore.Advanced.Queryable
+{
+    internal static class AsyncEnumerableAdapter
+    {
+        public static async Task<IEnumerable> ConvertToEnumerable(object asyncEnumerable, Type sequenceType, CancellationToken cancellationToken)
+        {
+            var asyncEnumerableType = typeof(IAsyncEnumerable<>).MakeGenericType(sequenceType);
+            var asyncEnumeratorType = typeof(IAsyncEnumerator<>).MakeGenericType(sequenceType);
+
+            var getAsyncEnumeratorMethod = asyncEnumerableType.GetRuntimeMethod("GetAsyncEnumerator", new[] { typeof(CancellationToken) });
+            var moveNextAsyncMethod = asyncEnumeratorType.GetRuntimeMethod("MoveNextAsync", Array.Empty<Type>());
+            var currentProperty = asyncEnumeratorType.GetRuntimeProperty("Current");
+
+            var asyncEnumerator = getAsyncEnumeratorMethod.Invoke(asyncEnumerable, new object[] { cancellationToken });
+
+            var list = CreateList(sequenceType);
+            while (await ((ValueTask<bool>)moveNextAsyncMethod.Invoke(asyncEnumerator, Array.Empty<object>())).ConfigureAwait(false))
+            {
+                var item = currentProperty.GetValue(asyncEnumerator);
+                list.Add(item);
+            }
+
+            return list;
+        }
+
+        static IList CreateList(Type elementType)
+        {
+            var listType = typeof(List<>).MakeGenericType(elementType);
+            var list = (IList)Activator.CreateInstance(listType);
+            return list;
+        }
+    }
+}

--- a/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/PropertyInfoExtensions.cs
@@ -1,35 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Nevermore.Advanced.Queryable
 {
     internal static class PropertyInfoExtensions
     {
-        static readonly HashSet<Type> KnownScalarTypes = new()
-        {
-            typeof(DateTimeOffset)
-        };
-
         public static bool Matches(this PropertyInfo propertyInfo, PropertyInfo other)
         {
             return propertyInfo.Name.Equals(other.Name) &&
                    propertyInfo.PropertyType.IsAssignableFrom(other.PropertyType);
-        }
-
-        public static bool IsScalar(this PropertyInfo propertyInfo)
-        {
-            // there are some types that can be consider scalars but have a TypeCode of Object
-            if (KnownScalarTypes.Contains(propertyInfo.PropertyType))
-            {
-                return true;
-            }
-
-            return Type.GetTypeCode(propertyInfo.PropertyType) switch
-            {
-                TypeCode.Object => false,
-                _ => true
-            };
         }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/QueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryProvider.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Nevermore.Advanced.ReaderStrategies;
 using Nevermore.Util;
 
 namespace Nevermore.Advanced.Queryable
@@ -16,10 +18,6 @@ namespace Nevermore.Advanced.Queryable
             .GetRuntimeMethods().Single(m => m.Name == nameof(CreateQuery) && m.IsGenericMethod);
         static readonly MethodInfo GenericExecuteMethod = typeof(QueryProvider)
             .GetRuntimeMethods().Single(m => m.Name == nameof(Execute) && m.IsGenericMethod);
-        static readonly MethodInfo GenericStreamMethod = typeof(IReadQueryExecutor)
-            .GetRuntimeMethod(nameof(IReadQueryExecutor.Stream), new[] { typeof(PreparedCommand) });
-        static readonly MethodInfo GenericStreamAsyncMethod = typeof(IReadQueryExecutor)
-            .GetRuntimeMethod(nameof(IReadQueryExecutor.StreamAsync), new[] { typeof(PreparedCommand), typeof(CancellationToken) });
         static readonly MethodInfo GenericExecuteScalarMethod = typeof(IReadQueryExecutor)
             .GetRuntimeMethod(nameof(IReadQueryExecutor.ExecuteScalar), new[] { typeof(PreparedCommand) });
         static readonly MethodInfo GenericExecuteScalarAsyncMethod = typeof(IReadQueryExecutor)
@@ -55,15 +53,12 @@ namespace Nevermore.Advanced.Queryable
             if (queryType == QueryType.SelectMany)
             {
                 var sequenceType = expression.Type.GetSequenceType();
-                return (TResult)GenericStreamMethod.MakeGenericMethod(sequenceType)
-                    .Invoke(queryExecutor, new object[] { command });
+                return (TResult)ReadList(command, sequenceType);
             }
 
             if (queryType == QueryType.SelectSingle)
             {
-                var stream = (IEnumerable)GenericStreamMethod.MakeGenericMethod(expression.Type)
-                    .Invoke(queryExecutor, new object[] { command });
-                return (TResult)stream.Cast<object>().FirstOrDefault();
+                return (TResult)ReadSingle(command, expression.Type);
             }
 
             return (TResult)GenericExecuteScalarMethod.MakeGenericMethod(expression.Type)
@@ -77,25 +72,12 @@ namespace Nevermore.Advanced.Queryable
             if (queryType == QueryType.SelectMany)
             {
                 var sequenceType = expression.Type.GetSequenceType();
-                var asyncStream = (IAsyncEnumerable<object>)GenericStreamAsyncMethod.MakeGenericMethod(sequenceType)
-                    .Invoke(queryExecutor, new object[] { command, cancellationToken });
-
-                return (TResult)await CreateList(asyncStream, sequenceType).ConfigureAwait(false);
+                return (TResult)await ReadList(command, sequenceType, cancellationToken).ConfigureAwait(false);
             }
 
             if (queryType == QueryType.SelectSingle)
             {
-                var asyncStream = (IAsyncEnumerable<object>)GenericStreamAsyncMethod.MakeGenericMethod(expression.Type)
-                    .Invoke(queryExecutor, new object[] { command, cancellationToken });
-                var firstOrDefaultAsync = await FirstOrDefaultAsync(asyncStream, cancellationToken).ConfigureAwait(false);
-
-                if (firstOrDefaultAsync is not null) return (TResult) firstOrDefaultAsync;
-
-                // TODO: This NEEDS to go away when we turn nullable on in Nevermore
-                // This method needs to be able to return null for instances like `FirstOrDefaultAsync`
-                object GetNull() => null;
-                return (TResult) GetNull();
-
+                return (TResult)await ReadSingle(command, expression.Type, cancellationToken).ConfigureAwait(false);
             }
 
             return await ((Task<TResult>)GenericExecuteScalarAsyncMethod.MakeGenericMethod(expression.Type)
@@ -121,31 +103,100 @@ namespace Nevermore.Advanced.Queryable
             return new QueryTranslator(configuration).Translate(expression);
         }
 
-        static async Task<IList> CreateList(IAsyncEnumerable<object> items, Type elementType)
+        IList ReadList(PreparedCommand command, Type elementType)
         {
-            var listType = typeof(List<>).MakeGenericType(elementType);
-            IList list = (IList)Activator.CreateInstance(listType);
-            await foreach (var item in items.ConfigureAwait(false))
+            var list = CreateList(elementType);
+            var readerStrategy = GetReaderStrategy(elementType, command);
+            using var reader = queryExecutor.ExecuteReader(command);
+            while (reader.Read())
             {
-                list.Add(item);
+                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
+                if (success)
+                {
+                    list.Add(item);
+                }
+            }
+
+            return list;
+        }
+        
+        async Task<IList> ReadList(PreparedCommand command, Type elementType, CancellationToken cancellationToken)
+        {
+            var list = CreateList(elementType);
+            var readerStrategy = GetReaderStrategy(elementType, command);
+            using var reader = await queryExecutor.ExecuteReaderAsync(command, cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
+                if (success)
+                {
+                    list.Add(item);
+                }
             }
 
             return list;
         }
 
-        static async ValueTask<T> FirstOrDefaultAsync<T>(IAsyncEnumerable<T> enumerable, CancellationToken cancellationToken)
+        object ReadSingle(PreparedCommand command, Type elementType)
         {
-#pragma warning disable CA2007
-            // CA2007 doesn't understand ConfiguredCancelableAsyncEnumerable and incorrectly thinks we need another ConfigureAwait(false) here
-            await using var enumerator = enumerable.ConfigureAwait(false).WithCancellation(cancellationToken).GetAsyncEnumerator();
-#pragma warning restore CA2007
-
-            if (await enumerator.MoveNextAsync())
+            var readerStrategy = GetReaderStrategy(elementType, command);
+            using var reader = queryExecutor.ExecuteReader(command);
+            if (reader.Read())
             {
-                return enumerator.Current;
+                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
+                if (success)
+                {
+                    return item;
+                }
             }
 
-            return default;
+            return elementType.GetDefaultValue();
+        }
+
+        async Task<object> ReadSingle(PreparedCommand command, Type elementType, CancellationToken cancellationToken)
+        {
+            var readerStrategy = GetReaderStrategy(elementType, command);
+            await using var reader = await queryExecutor.ExecuteReaderAsync(command, cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
+                if (success)
+                {
+                    return item;
+                }
+            }
+
+            return elementType.GetDefaultValue();
+        }
+
+        static bool TryProcessRow(Delegate readerStrategy, Type elementType, DbDataReader reader, out object item)
+        {
+            var readResult = readerStrategy.DynamicInvoke(reader);
+            var tupleType = typeof(ValueTuple<,>).MakeGenericType(elementType, typeof(bool));
+            // ReSharper disable once PossibleNullReferenceException
+            var success = (bool)tupleType.GetField("Item2").GetValue(readResult);
+            // ReSharper disable once PossibleNullReferenceException
+            item = success
+                ? tupleType.GetField("Item1").GetValue(readResult)
+                : null;
+
+            return success;
+        }
+
+        Delegate GetReaderStrategy(Type elementType, PreparedCommand command)
+        {
+            // ReSharper disable once PossibleNullReferenceException
+            return (Delegate)typeof(IReaderStrategyRegistry)
+                .GetMethod(nameof(IReaderStrategyRegistry.Resolve), 1, new[] { typeof(PreparedCommand) })
+                .MakeGenericMethod(elementType)
+                .Invoke(configuration.ReaderStrategies, new object[] { command });
+        }
+
+        static IList CreateList(Type elementType)
+        {
+            var listType = typeof(List<>).MakeGenericType(elementType);
+            var list = (IList)Activator.CreateInstance(listType);
+            return list;
         }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/QueryProvider.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryProvider.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Nevermore.Advanced.ReaderStrategies;
 using Nevermore.Util;
 
 namespace Nevermore.Advanced.Queryable
@@ -18,12 +16,14 @@ namespace Nevermore.Advanced.Queryable
             .GetRuntimeMethods().Single(m => m.Name == nameof(CreateQuery) && m.IsGenericMethod);
         static readonly MethodInfo GenericExecuteMethod = typeof(QueryProvider)
             .GetRuntimeMethods().Single(m => m.Name == nameof(Execute) && m.IsGenericMethod);
+        static readonly MethodInfo GenericStreamMethod = typeof(IReadQueryExecutor)
+            .GetRuntimeMethod(nameof(IReadQueryExecutor.Stream), new[] { typeof(PreparedCommand) } );
+        static readonly MethodInfo GenericStreamAsyncMethod = typeof(IReadQueryExecutor)
+            .GetRuntimeMethod(nameof(IReadQueryExecutor.StreamAsync), new[] { typeof(PreparedCommand), typeof(CancellationToken) });
         static readonly MethodInfo GenericExecuteScalarMethod = typeof(IReadQueryExecutor)
             .GetRuntimeMethod(nameof(IReadQueryExecutor.ExecuteScalar), new[] { typeof(PreparedCommand) });
         static readonly MethodInfo GenericExecuteScalarAsyncMethod = typeof(IReadQueryExecutor)
             .GetRuntimeMethod(nameof(IReadQueryExecutor.ExecuteScalarAsync), new[] { typeof(PreparedCommand), typeof(CancellationToken) });
-        static readonly MethodInfo GenericStreamAsyncMethod = typeof(IReadQueryExecutor)
-            .GetRuntimeMethod(nameof(IReadQueryExecutor.StreamAsync), new[] { typeof(PreparedCommand), typeof(CancellationToken) });
 
         readonly IReadQueryExecutor queryExecutor;
         readonly IRelationalStoreConfiguration configuration;
@@ -55,18 +55,16 @@ namespace Nevermore.Advanced.Queryable
             if (queryType == QueryType.SelectMany)
             {
                 var sequenceType = expression.Type.GetSequenceType();
-                return (TResult)ReadList(command, sequenceType);
+                return (TResult)ExecuteStream(command, sequenceType);
             }
 
             if (queryType == QueryType.SelectSingle)
             {
-                return (TResult)ReadSingle(command, expression.Type);
+                return (TResult)FirstOrDefault(ExecuteStream(command, expression.Type));
             }
 
-            return (TResult)GenericExecuteScalarMethod.MakeGenericMethod(expression.Type)
-                .Invoke(queryExecutor, new object[] { command });
+            return (TResult)ExecuteScalar(command, expression.Type);
         }
-
 
         public async Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
         {
@@ -74,12 +72,12 @@ namespace Nevermore.Advanced.Queryable
             if (queryType == QueryType.SelectMany)
             {
                 var sequenceType = expression.Type.GetSequenceType();
-                return (TResult)await ReadList(command, sequenceType, cancellationToken).ConfigureAwait(false);
+                return (TResult)await ExecuteStreamAsync(command, sequenceType, cancellationToken).ConfigureAwait(false);
             }
 
             if (queryType == QueryType.SelectSingle)
             {
-                return (TResult)await ReadSingle(command, expression.Type, cancellationToken).ConfigureAwait(false);
+                return (TResult)FirstOrDefault(await ExecuteStreamAsync(command, expression.Type, cancellationToken).ConfigureAwait(false));
             }
 
             return await ((Task<TResult>)GenericExecuteScalarAsyncMethod.MakeGenericMethod(expression.Type)
@@ -105,102 +103,37 @@ namespace Nevermore.Advanced.Queryable
             return new QueryTranslator(configuration).Translate(expression);
         }
 
-        IList ReadList(PreparedCommand command, Type elementType)
+        IEnumerable ExecuteStream(PreparedCommand command, Type elementType)
         {
-            var list = CreateList(elementType);
-            var readerStrategy = GetReaderStrategy(elementType, command);
-            using var reader = queryExecutor.ExecuteReader(command);
-            while (reader.Read())
+            return (IEnumerable)GenericStreamMethod.MakeGenericMethod(elementType)
+                .Invoke(queryExecutor, new object[] { command });
+        }
+
+        async Task<IEnumerable> ExecuteStreamAsync(PreparedCommand command, Type elementType, CancellationToken cancellationToken)
+        {
+            var stream = GenericStreamAsyncMethod.MakeGenericMethod(elementType)
+                .Invoke(queryExecutor, new object[] { command, cancellationToken });
+
+            return await AsyncEnumerableAdapter.ConvertToEnumerable(stream, elementType, cancellationToken).ConfigureAwait(false);
+        }
+
+        object ExecuteScalar(PreparedCommand command, Type resultType)
+        {
+            return GenericExecuteScalarMethod.MakeGenericMethod(resultType)
+                .Invoke(queryExecutor, new object[] { command });
+        }
+
+        static object FirstOrDefault(IEnumerable stream)
+        {
+            var enumerator = stream.GetEnumerator();
+            try
             {
-                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
-                if (success)
-                {
-                    list.Add(item);
-                }
+                return enumerator.MoveNext() ? enumerator.Current : default;
             }
-
-            return list;
-        }
-        
-        async Task<IList> ReadList(PreparedCommand command, Type elementType, CancellationToken cancellationToken)
-        {
-            var list = CreateList(elementType);
-            var readerStrategy = GetReaderStrategy(elementType, command);
-            using var reader = await queryExecutor.ExecuteReaderAsync(command, cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            finally
             {
-                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
-                if (success)
-                {
-                    list.Add(item);
-                }
+                (enumerator as IDisposable)?.Dispose();
             }
-
-            return list;
-        }
-
-        object ReadSingle(PreparedCommand command, Type elementType)
-        {
-            var readerStrategy = GetReaderStrategy(elementType, command);
-            using var reader = queryExecutor.ExecuteReader(command);
-            if (reader.Read())
-            {
-                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
-                if (success)
-                {
-                    return item;
-                }
-            }
-
-            return elementType.GetDefaultValue();
-        }
-
-        async Task<object> ReadSingle(PreparedCommand command, Type elementType, CancellationToken cancellationToken)
-        {
-            var readerStrategy = GetReaderStrategy(elementType, command);
-#pragma warning disable CA2007
-            await using var reader = await queryExecutor.ExecuteReaderAsync(command, cancellationToken).ConfigureAwait(false);
-#pragma warning restore CA2007
-            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                var success = TryProcessRow(readerStrategy, elementType, reader, out var item);
-                if (success)
-                {
-                    return item;
-                }
-            }
-
-            return elementType.GetDefaultValue();
-        }
-
-        static bool TryProcessRow(Delegate readerStrategy, Type elementType, DbDataReader reader, out object item)
-        {
-            var readResult = readerStrategy.DynamicInvoke(reader);
-            var tupleType = typeof(ValueTuple<,>).MakeGenericType(elementType, typeof(bool));
-            // ReSharper disable once PossibleNullReferenceException
-            var success = (bool)tupleType.GetField("Item2").GetValue(readResult);
-            // ReSharper disable once PossibleNullReferenceException
-            item = success
-                ? tupleType.GetField("Item1").GetValue(readResult)
-                : null;
-
-            return success;
-        }
-
-        Delegate GetReaderStrategy(Type elementType, PreparedCommand command)
-        {
-            // ReSharper disable once PossibleNullReferenceException
-            return (Delegate)typeof(IReaderStrategyRegistry)
-                .GetMethod(nameof(IReaderStrategyRegistry.Resolve), 1, new[] { typeof(PreparedCommand) })
-                .MakeGenericMethod(elementType)
-                .Invoke(configuration.ReaderStrategies, new object[] { command });
-        }
-
-        static IList CreateList(Type elementType)
-        {
-            var listType = typeof(List<>).MakeGenericType(elementType);
-            var list = (IList)Activator.CreateInstance(listType);
-            return list;
         }
     }
 }

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -199,8 +199,8 @@ namespace Nevermore.Advanced.Queryable
             expression = StripQuotes(expression);
             if (expression is LambdaExpression { Body: MemberExpression { NodeType: ExpressionType.MemberAccess } memberExpression })
             {
-                var (selectColumns, _) = GetSelectFieldReferenceAndType(memberExpression);
-                sqlBuilder.Select(selectColumns);
+                var selectColumn = GetSelectFieldReference(memberExpression);
+                sqlBuilder.Select(selectColumn);
                 return;
             }
 
@@ -208,7 +208,7 @@ namespace Nevermore.Advanced.Queryable
             {
                 foreach (var arg in newExpression.Arguments)
                 {
-                    var (selectColumn, _) = GetSelectFieldReferenceAndType(arg);
+                    var selectColumn = GetSelectFieldReference(arg);
                     sqlBuilder.Select(selectColumn);
                 }
             }
@@ -247,7 +247,7 @@ namespace Nevermore.Advanced.Queryable
 
             if (expression is MemberExpression { Member: { MemberType: MemberTypes.Property } and PropertyInfo propertyInfo } && propertyInfo.PropertyType == typeof(bool))
             {
-                var (fieldReference, _) = GetFieldReferenceAndType(expression);
+                var (fieldReference, _) = GetWhereFieldReferenceAndType(expression);
                 return sqlBuilder.CreateWhere(fieldReference, UnarySqlOperand.Equal, !invert);
             }
 
@@ -268,7 +268,7 @@ namespace Nevermore.Advanced.Queryable
 
                 if (left is MemberExpression { Member: PropertyInfo propertyInfo } memberExpressionL && memberExpressionL.IsBasedOff<ParameterExpression>())
                 {
-                    var (fieldReference, type) = GetFieldReferenceAndType(left);
+                    var (fieldReference, type) = GetWhereFieldReferenceAndType(left);
                     var value = GetValueFromExpression(right, type);
 
                     if (fieldReference is WhereFieldReference)
@@ -286,7 +286,7 @@ namespace Nevermore.Advanced.Queryable
                 else if (right is MemberExpression memberExpressionR && memberExpressionR.IsBasedOff<ParameterExpression>())
                 {
                     var values = (IEnumerable)GetValueFromExpression(left, typeof(IEnumerable));
-                    var (fieldReference, _) = GetFieldReferenceAndType(right);
+                    var (fieldReference, _) = GetWhereFieldReferenceAndType(right);
                     return sqlBuilder.CreateWhere(fieldReference, invert ? ArraySqlOperand.NotIn : ArraySqlOperand.In, values);
                 }
             }
@@ -296,7 +296,7 @@ namespace Nevermore.Advanced.Queryable
 
         IWhereClause CreateStringMethodWhere(MethodCallExpression expression, bool invert = false)
         {
-            var (fieldReference, _) = GetFieldReferenceAndType(expression.Object);
+            var (fieldReference, _) = GetWhereFieldReferenceAndType(expression.Object);
             var value = ((string)GetValueFromExpression(expression.Arguments[0], typeof(string))).EscapeForLikeComparison();
 
             if (expression.Method.Name == nameof(string.Contains))
@@ -344,7 +344,7 @@ namespace Nevermore.Advanced.Queryable
                 _ => throw new NotSupportedException()
             };
 
-            var (fieldReference, propertyType) = GetFieldReferenceAndType(expression.Left);
+            var (fieldReference, propertyType) = GetWhereFieldReferenceAndType(expression.Left);
             var value = GetValueFromExpression(expression.Right, propertyType);
 
             if (value == null && op is UnarySqlOperand.Equal or UnarySqlOperand.NotEqual)
@@ -377,42 +377,29 @@ namespace Nevermore.Advanced.Queryable
             return result;
         }
 
-        (ISelectColumns, Type) GetSelectFieldReferenceAndType(Expression expression)
+        ISelectColumns GetSelectFieldReference(Expression expression)
         {
-            if (expression is UnaryExpression unaryExpression)
-                expression = unaryExpression.Operand;
+            var (reference, type, isJson) = FindField(expression);
 
-            if (expression is MemberExpression { Member: PropertyInfo propertyInfo } memberExpression)
-            {
-                var documentMap = sqlBuilder.DocumentMap;
-                var parameterExpression = memberExpression.FindChildOfType<ParameterExpression>();
-                var childPropertyExpression = memberExpression.FindChildOfType<MemberExpression>();
-                if (childPropertyExpression == null && documentMap.Type.IsAssignableFrom(parameterExpression.Type))
-                {
-                    if (documentMap.IdColumn!.Property.Matches(propertyInfo))
-                    {
-                        return (new SelectColumn(documentMap.IdColumn.ColumnName), documentMap.IdColumn.Type);
-                    }
-
-                    var column = documentMap.Columns.Where(c => c.Property is not null).FirstOrDefault(c => c.Property.Matches(propertyInfo));
-                    if (column is not null)
-                    {
-                        return (new SelectColumn(column.ColumnName), propertyInfo.PropertyType);
-                    }
-                }
-
-                if (documentMap.HasJsonColumn())
-                {
-                    var jsonPath = GetJsonPath(memberExpression);
-                    var fieldReference = new SelectJsonValue(jsonPath, propertyInfo.PropertyType);
-                    return (fieldReference, propertyInfo.PropertyType);
-                }
-            }
-
-            throw new NotSupportedException();
+            return isJson ? new SelectJsonValue(reference, type) : new SelectColumn(reference);
         }
 
-        (IWhereFieldReference, Type) GetFieldReferenceAndType(Expression expression)
+        (IWhereFieldReference, Type) GetWhereFieldReferenceAndType(Expression expression)
+        {
+            var (reference, type, isJson) = FindField(expression);
+
+            if (!isJson)
+            {
+                return (new WhereFieldReference(reference), type);
+            }
+
+            IWhereFieldReference fieldReference = type.IsScalar()
+                ? new JsonValueFieldReference(reference)
+                : new JsonQueryFieldReference(reference);
+            return (fieldReference, type);
+        }
+
+        (string, Type, bool) FindField(Expression expression)
         {
             if (expression is UnaryExpression unaryExpression)
                 expression = unaryExpression.Operand;
@@ -426,23 +413,20 @@ namespace Nevermore.Advanced.Queryable
                 {
                     if (documentMap.IdColumn!.Property.Matches(propertyInfo))
                     {
-                        return (new WhereFieldReference(documentMap.IdColumn.ColumnName), documentMap.IdColumn.Type);
+                        return (documentMap.IdColumn.ColumnName, documentMap.IdColumn.Type, false);
                     }
 
                     var column = documentMap.Columns.Where(c => c.Property is not null).FirstOrDefault(c => c.Property.Matches(propertyInfo));
                     if (column is not null)
                     {
-                        return (new WhereFieldReference(column.ColumnName), propertyInfo.PropertyType);
+                        return (column.ColumnName, propertyInfo.PropertyType, false);
                     }
                 }
 
                 if (documentMap.HasJsonColumn())
                 {
                     var jsonPath = GetJsonPath(memberExpression);
-                    IWhereFieldReference fieldReference = propertyInfo.IsScalar()
-                        ? new JsonValueFieldReference(jsonPath)
-                        : new JsonQueryFieldReference(jsonPath);
-                    return (fieldReference, propertyInfo.PropertyType);
+                    return (jsonPath, propertyInfo.PropertyType, true);
                 }
             }
 

--- a/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
+++ b/source/Nevermore/Advanced/Queryable/QueryTranslator.cs
@@ -211,6 +211,8 @@ namespace Nevermore.Advanced.Queryable
                     var selectColumn = GetSelectFieldReference(arg);
                     sqlBuilder.Select(selectColumn);
                 }
+
+                return;
             }
 
             throw new NotSupportedException();

--- a/source/Nevermore/Advanced/Queryable/TypeExtensions.cs
+++ b/source/Nevermore/Advanced/Queryable/TypeExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Nevermore.Advanced.Queryable
+{
+    public static class TypeExtensions
+    {
+        static readonly HashSet<Type> KnownScalarTypes = new()
+        {
+            typeof(DateTimeOffset)
+        };
+
+
+        public static bool IsScalar(this Type type)
+        {
+            // there are some types that can be consider scalars but have a TypeCode of Object
+            if (KnownScalarTypes.Contains(type))
+            {
+                return true;
+            }
+
+            return Type.GetTypeCode(type) switch
+            {
+                TypeCode.Object => false,
+                _ => true
+            };
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderContext.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    public class AnonymousTypeReaderContext
+    {
+        public int Column = -1;
+    }
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderFunc.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderFunc.cs
@@ -1,0 +1,6 @@
+﻿using System.Data.Common;
+
+namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    internal delegate TRecord AnonymousTypeReaderFunc<TRecord>(DbDataReader reader, AnonymousTypeReaderContext context);
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/AnonymousTypes/AnonymousTypeReaderStrategy.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Nevermore.Advanced.ReaderStrategies.Compilation;
+
+namespace Nevermore.Advanced.ReaderStrategies.AnonymousTypes
+{
+    public class AnonymousTypeReaderStrategy : IReaderStrategy
+    {
+        readonly RelationalStoreConfiguration configuration;
+
+        public AnonymousTypeReaderStrategy(RelationalStoreConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public bool CanRead(Type type)
+        {
+            return type.IsGenericType &&
+                   type.Namespace == null &&
+                   type.IsSealed &&
+                   type.BaseType == typeof(object) &&
+                   !type.IsPublic &&
+                   type.GetCustomAttribute<CompilerGeneratedAttribute>() != null &&
+                   type.Name.Contains("AnonymousType");
+        }
+
+        public Func<PreparedCommand, Func<DbDataReader, (TRecord, bool)>> CreateReader<TRecord>()
+        {
+            return command =>
+            {
+                CompiledExpression<AnonymousTypeReaderFunc<TRecord>> compiled = null;
+                var rowNumber = 0;
+                var context = new AnonymousTypeReaderContext();
+
+                return reader =>
+                {
+                    rowNumber++;
+
+                    if (compiled == null)
+                    {
+                        compiled = Compile<TRecord>(reader);
+                    }
+
+                    try
+                    {
+                        var instance = compiled.Execute(reader, context);
+                        return (instance, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new ReaderException(rowNumber, context.Column, compiled.ExpressionSource, ex);
+                    }
+                };
+            };
+        }
+
+        CompiledExpression<AnonymousTypeReaderFunc<TRecord>> Compile<TRecord>(IDataRecord record)
+        {
+            var constructor = typeof(TRecord).GetConstructors().Single();
+            var constructorParams = constructor.GetParameters();
+
+            var readerArg = Expression.Parameter(typeof(DbDataReader), "reader");
+            var contextArg = Expression.Parameter(typeof(AnonymousTypeReaderContext), "context");
+
+            var locals = new List<ParameterExpression>();
+            var body = new List<Expression>();
+
+            var expectedFieldCount = record.FieldCount;
+            for (var i = 0; i < expectedFieldCount; i++)
+            {
+                var param = constructorParams[i];
+                var paramLocal = Expression.Variable(param.ParameterType, $"p{i}");
+                locals.Add(paramLocal);
+                body.Add(Expression.Assign(Expression.Field(contextArg, nameof(AnonymousTypeReaderContext.Column)), Expression.Constant(i)));
+                body.Add(Expression.Assign(paramLocal, ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), param.ParameterType, configuration.TypeHandlers)));
+            }
+
+            body.Add(Expression.New(constructor, locals));
+
+            var block = Expression.Block(locals, body);
+
+            var lambda = Expression.Lambda<AnonymousTypeReaderFunc<TRecord>>(block, readerArg, contextArg);
+
+            return ExpressionCompiler.Compile(lambda);
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ReaderStrategies/ArbitraryClasses/ArbitraryClassReaderStrategy.cs
+++ b/source/Nevermore/Advanced/ReaderStrategies/ArbitraryClasses/ArbitraryClassReaderStrategy.cs
@@ -14,7 +14,7 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
     /// This strategy is used for "POCO", or "Plain-Old-CLR-Objects" classes (those that don't have a document map).
     /// They will be read from the reader automatically. Our requirements are:
     /// 
-    ///  - The class must provide a constructor (declared or not) with no parameters.
+    ///  - The class must provide a constructor (declared or not) with no parameters, or a list of parameters that exactly matches the fields on the reader by type
     ///  - We only bind public, settable properties
     ///  - Column names must match property names, but the casing does not need to match
     ///  - If a column exists in the results, a property must exist on the class
@@ -31,10 +31,7 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
         
         public bool CanRead(Type type)
         {
-            return 
-                type.IsClass 
-                && type.GetConstructors().Any(c => c.IsPublic && c.GetParameters().Length == 0)
-                && !configuration.DocumentMaps.ResolveOptional(type, out _);
+            return type.IsClass && !configuration.DocumentMaps.ResolveOptional(type, out _);
         }
         
         public Func<PreparedCommand, Func<DbDataReader, (TRecord, bool)>> CreateReader<TRecord>()
@@ -81,18 +78,31 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
         //         result.LastName = reader.GetString(1);
         //         return result;
         //     }
+        //
+        //   -- OR --
+        //
+        //     (DbDataReader reader, ArbitraryClassReaderContext context) =>
+        //     {
+        //         var result = new Person(reader.GetString(0), reader.GetString(1));
+        //         return result;
+        //     }
         CompiledExpression<ArbitraryClassReaderFunc<TRecord>> Compile<TRecord>(IDataRecord record)
         {
             // To make it fast - as fast as if we wrote it by hand - we generate and compile C# expression trees for
             // each property on the class, and one to call the constructor.
-            
-            // Find the parameter-less constructor
+
             var constructors = typeof(TRecord).GetConstructors();
-            var defaultConstructor = constructors.FirstOrDefault(p => p.GetParameters().Length == 0) ?? throw new InvalidOperationException("When reading query results to a class, the class must provide a default constructor with no parameters.");
-            
-            // Create fast setters for all properties on the type
-            var properties = typeof(TRecord).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty);
-            
+            // Find the parameter-less constructor
+            var defaultConstructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            // Find a parameterized constructor that matches the data reader
+            var parameterizedConstructor = (from ctor in constructors
+                let parameters = ctor.GetParameters()
+                where parameters.Length == record.FieldCount && MatchesTypes(parameters, record)
+                select ctor).FirstOrDefault();
+            var selectedConstructor = parameterizedConstructor
+                                      ?? defaultConstructor
+                                      ?? throw new InvalidOperationException("No default constructor or constructor that exactly matches the number and types of the reader fields was found.");
+
             var readerArg = Expression.Parameter(typeof(DbDataReader), "reader");
             var contextArg = Expression.Parameter(typeof(ArbitraryClassReaderContext), "context");
 
@@ -101,18 +111,46 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
             
             var resultLocalVariable = Expression.Variable(typeof(TRecord), "result");
             locals.Add(resultLocalVariable);
-            body.Add(Expression.Assign(resultLocalVariable, Expression.New(defaultConstructor)));
-                        
+
+            if (selectedConstructor.GetParameters().Any())
+            {
+                BuildParameterizedConstructorExpression(selectedConstructor, readerArg, body, resultLocalVariable);
+            }
+            else
+            {
+                BuildParameterlessConstructorExpression<TRecord>(record, body, resultLocalVariable, selectedConstructor, contextArg, readerArg);
+            }
+
+            // Return it
+            body.Add(resultLocalVariable);
+
+            var block = Expression.Block(
+                locals,
+                body
+            );
+
+            var lambda = Expression.Lambda<ArbitraryClassReaderFunc<TRecord>>(block, readerArg, contextArg);
+
+            return ExpressionCompiler.Compile(lambda);
+        }
+
+        void BuildParameterlessConstructorExpression<TRecord>(IDataRecord record, List<Expression> body, ParameterExpression resultLocalVariable, ConstructorInfo selectedConstructor, ParameterExpression contextArg, ParameterExpression readerArg)
+        {
+            // Create fast setters for all properties on the type
+            var properties = typeof(TRecord).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty);
+
+            body.Add(Expression.Assign(resultLocalVariable, Expression.New(selectedConstructor)));
+
             var expectedFieldCount = record.FieldCount;
             for (var i = 0; i < expectedFieldCount; i++)
             {
                 var name = record.GetName(i);
-                
+
                 var property = properties.FirstOrDefault(p => p.Name == name);
                 if (property != null)
                 {
                     body.Add(Expression.Assign(Expression.Field(contextArg, nameof(ArbitraryClassReaderContext.Column)), Expression.Constant(i)));
-                    
+
                     body.Add(Expression.Assign(
                         Expression.Property(resultLocalVariable, property),
                         ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), property.PropertyType, configuration.TypeHandlers)));
@@ -122,18 +160,19 @@ namespace Nevermore.Advanced.ReaderStrategies.ArbitraryClasses
                     throw new Exception($"The query returned a column named '{name}' but no property by that name exists on the target type '{typeof(TRecord).Name}'. When reading to an arbitrary type, all columns must have a matching settable property.");
                 }
             }
+        }
 
-            // Return it
-            body.Add(resultLocalVariable);
-                        
-            var block = Expression.Block(
-                locals,
-                body
-            );
+        void BuildParameterizedConstructorExpression(ConstructorInfo selectedConstructor, ParameterExpression readerArg, List<Expression> body, ParameterExpression resultLocalVariable)
+        {
+            var arguments = selectedConstructor
+                .GetParameters()
+                .Select((p, i) => ExpressionHelper.GetValueFromReaderAsType(readerArg, Expression.Constant(i), p.ParameterType, configuration.TypeHandlers));
+            body.Add(Expression.Assign(resultLocalVariable, Expression.New(selectedConstructor, arguments)));
+        }
 
-            var lambda = Expression.Lambda<ArbitraryClassReaderFunc<TRecord>>(block, readerArg, contextArg);
-            
-            return ExpressionCompiler.Compile(lambda);
+        static bool MatchesTypes(IEnumerable<ParameterInfo> parameters, IDataRecord record)
+        {
+            return !parameters.Where((t, i) => t.ParameterType != record.GetFieldType(i)).Any();
         }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -4,6 +4,7 @@ using Nevermore.Advanced;
 using Nevermore.Advanced.Hooks;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.Advanced.ReaderStrategies;
+using Nevermore.Advanced.ReaderStrategies.AnonymousTypes;
 using Nevermore.Advanced.ReaderStrategies.ArbitraryClasses;
 using Nevermore.Advanced.ReaderStrategies.Documents;
 using Nevermore.Advanced.ReaderStrategies.Primitives;
@@ -39,6 +40,7 @@ namespace Nevermore
             ReaderStrategies.Register(new ValueTupleReaderStrategy(this));
             ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
             ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
+            ReaderStrategies.Register(new AnonymousTypeReaderStrategy(this));
 
             Hooks = new HookRegistry();
 

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -38,9 +38,9 @@ namespace Nevermore
             ReaderStrategies = new ReaderStrategyRegistry();
             ReaderStrategies.Register(new DocumentReaderStrategy(this));
             ReaderStrategies.Register(new ValueTupleReaderStrategy(this));
-            ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
-            ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
             ReaderStrategies.Register(new AnonymousTypeReaderStrategy(this));
+            ReaderStrategies.Register(new PrimitiveReaderStrategy(this));
+            ReaderStrategies.Register(new ArbitraryClassReaderStrategy(this));
 
             Hooks = new HookRegistry();
 

--- a/source/Nevermore/Util/TypeExtensions.cs
+++ b/source/Nevermore/Util/TypeExtensions.cs
@@ -22,5 +22,12 @@ namespace Nevermore.Util
 
             return enumerableType.GetGenericArguments().Single();
         }
+
+        public static object GetDefaultValue(this Type type)
+        {
+            return type.IsValueType
+                ? Activator.CreateInstance(type)
+                : null;
+        }
     }
 }


### PR DESCRIPTION
# Background

Add basic support for projection in IQueryable queries.

## Project a single column

```cs
transaction.Queryable<Document>().Select(d => d.Id);
```

## Project a set of properties as an anonymous type

```cs
transaction.Queryable<Document>().Select(d => new { d.Id, d.Name });
```