### PR TITLE
Fix AddTable using the wrong source for the PrimaryKeyHandler

### DIFF
--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -739,7 +739,7 @@ namespace Nevermore.Advanced
             var schema = configuration.GetSchemaNameOrDefault(mapping);
             var columnNames = GetColumnNames(schema, mapping.TableName);
             var param = new CommandParameterValues();
-            param.AddTable("criteriaTable", idList.ToList(), configuration);
+            param.AddTable("criteriaTable", idList.ToList(), mapping.IdColumn.PrimaryKeyHandler);
             var statement = $"SELECT s.{string.Join(',', columnNames)} FROM [{schema}].[{mapping.TableName}] s INNER JOIN @criteriaTable t on t.[ParameterValue] = s.[{mapping.IdColumn.ColumnName}] order by s.[{mapping.IdColumn.ColumnName}]";
             return new PreparedCommand(statement, param, RetriableOperation.Select, mapping, commandBehavior: CommandBehavior.SingleResult | CommandBehavior.SequentialAccess);
         }

--- a/source/Nevermore/CommandParameterValues.cs
+++ b/source/Nevermore/CommandParameterValues.cs
@@ -56,12 +56,8 @@ namespace Nevermore
 
         public CommandType CommandType { get; set; }
 
-        public void AddTable<T>(string name, IReadOnlyCollection<T> ids, IRelationalStoreConfiguration configuration)
+        public void AddTable<T>(string name, IReadOnlyCollection<T> ids, IPrimaryKeyHandler primaryKeyHandler)
         {
-            var primaryKeyHandler = configuration.PrimaryKeyHandlers.Resolve(typeof(T));
-            if (primaryKeyHandler is null)
-                throw new InvalidOperationException($"Unable to locate primary key handler for type {typeof(T).Name}");
-
             var idColumnMetadata = primaryKeyHandler.GetSqlMetaData("ParameterValue");
 
             var dataRecords = ids.Where(v => v != null).Select(v =>


### PR DESCRIPTION
## Background

There are two ways to assign primary key handlers to documents. One is to register the handler with the `PrimaryKeyHandlers` collection in the configuration, the other is to assign a `PrimaryKeyHandler` to the `IdColumn` in the document map. The end result of both is the same, because when the document map is built, if there is no deliberately assigned `PrimaryKeyHandler`, then it will set the appropriate value from the `PrimaryKeyHandlers` in the configuration.

As a result, the correct way to access the `PrimaryKeyHandler` when you need it for a document type is _always_ to look it up via the document map. If you look it up via the configuration, you will end up using the wrong primary key handler (or failing to find one altogether) if the consumer has assigned a custom `PrimaryKeyHandler` to their document map. This PR fixes that bug by fixing the one place that was looking at the configuration when it should have been looking at the one on the document map.

## Breaking changes

The API for `CommandParameterValues` has changed. What was previously

```csharp
public void AddTable<T>(string name, IReadOnlyCollection<T> ids, IRelationalStoreConfiguration configuration);
```

is now

```csharp
public void AddTable<T>(string name, IReadOnlyCollection<T> ids, IPrimaryKeyHandler primaryKeyHandler);
```