### PR TITLE
Add support for a custom table name provider

### DIFF
--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -81,5 +81,10 @@ namespace Nevermore
         /// This is a temporary feature switch, we will always be using table valued parameters once we're satisfied with the stability
         /// </summary>
         public bool SupportLargeNumberOfRelatedDocuments { get; set; }
+        
+        /// <summary>
+        /// Used to get the table name for a document type. By default, the table name is retrieved from the document map.
+        /// </summary>
+        ITableNameResolver TableNameResolver { get; set; }
     }
 }

--- a/source/Nevermore/Mapping/ITableNameProvider.cs
+++ b/source/Nevermore/Mapping/ITableNameProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Nevermore.Mapping
+{
+    public interface ITableNameResolver
+    {
+        string GetTableNameFor(Type documentType);
+    }
+}

--- a/source/Nevermore/Mapping/TableNameProvider.cs
+++ b/source/Nevermore/Mapping/TableNameProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Nevermore.Mapping
+{
+    public class TableNameResolver : ITableNameResolver
+    {
+        readonly IDocumentMapRegistry mappings;
+
+        public TableNameResolver(IDocumentMapRegistry mappings)
+        {
+            this.mappings = mappings;
+        }
+
+        public string GetTableNameFor(Type documentType) => mappings.Resolve(documentType).TableName;
+    }
+}

--- a/source/Nevermore/Mapping/TableNameResolver.cs
+++ b/source/Nevermore/Mapping/TableNameResolver.cs
@@ -2,7 +2,7 @@
 
 namespace Nevermore.Mapping
 {
-    public class TableNameResolver : ITableNameResolver
+    internal class TableNameResolver : ITableNameResolver
     {
         readonly IDocumentMapRegistry mappings;
 

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -23,11 +23,11 @@ namespace Nevermore
         readonly Lazy<string> connectionString;
 
 #nullable enable
-        public RelationalStoreConfiguration(string connectionString, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null) : this(() => connectionString, customPrimaryKeyHandlerRegistry)
+        public RelationalStoreConfiguration(string connectionString, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null, ITableNameResolver? tableNameResolver = null) : this(() => connectionString, customPrimaryKeyHandlerRegistry, tableNameResolver)
         {
         }
 
-        public RelationalStoreConfiguration(Func<string> connectionStringFunc, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null)
+        public RelationalStoreConfiguration(Func<string> connectionStringFunc, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null, ITableNameResolver? tableNameResolver = null)
         {
             CommandFactory = new SqlCommandFactory();
             KeyBlockSize = NevermoreDefaults.DefaultKeyBlockSize;
@@ -52,6 +52,7 @@ namespace Nevermore
             PrimaryKeyHandlers = customPrimaryKeyHandlerRegistry ?? new PrimaryKeyHandlerRegistry();
 
             DocumentMaps = new DocumentMapRegistry(PrimaryKeyHandlers);
+            TableNameResolver = tableNameResolver ?? new TableNameResolver(DocumentMaps);
 
             TableColumnNameResolver = _ => new SelectAllColumnsTableResolver();
 
@@ -113,6 +114,8 @@ namespace Nevermore
         public ISqlCommandFactory CommandFactory { get; set; }
 
         public Func<IKeyAllocator> KeyAllocatorFactory { get; set; }
+        
+        public ITableNameResolver TableNameResolver { get; set; }
 
         string InitializeConnectionString(string sqlConnectionString)
         {

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -23,11 +23,11 @@ namespace Nevermore
         readonly Lazy<string> connectionString;
 
 #nullable enable
-        public RelationalStoreConfiguration(string connectionString, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null, ITableNameResolver? tableNameResolver = null) : this(() => connectionString, customPrimaryKeyHandlerRegistry, tableNameResolver)
+        public RelationalStoreConfiguration(string connectionString, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null) : this(() => connectionString, customPrimaryKeyHandlerRegistry)
         {
         }
 
-        public RelationalStoreConfiguration(Func<string> connectionStringFunc, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null, ITableNameResolver? tableNameResolver = null)
+        public RelationalStoreConfiguration(Func<string> connectionStringFunc, IPrimaryKeyHandlerRegistry? customPrimaryKeyHandlerRegistry = null)
         {
             CommandFactory = new SqlCommandFactory();
             KeyBlockSize = NevermoreDefaults.DefaultKeyBlockSize;
@@ -52,7 +52,7 @@ namespace Nevermore
             PrimaryKeyHandlers = customPrimaryKeyHandlerRegistry ?? new PrimaryKeyHandlerRegistry();
 
             DocumentMaps = new DocumentMapRegistry(PrimaryKeyHandlers);
-            TableNameResolver = tableNameResolver ?? new TableNameResolver(DocumentMaps);
+            TableNameResolver = new TableNameResolver(DocumentMaps);
 
             TableColumnNameResolver = _ => new SelectAllColumnsTableResolver();
 

--- a/source/Nevermore/Util/DataModificationQueryBuilder.cs
+++ b/source/Nevermore/Util/DataModificationQueryBuilder.cs
@@ -27,6 +27,7 @@ namespace Nevermore.Util
         readonly IDocumentSerializer serializer;
         readonly IRelationalStoreConfiguration configuration;
         readonly Func<DocumentMap, object> keyAllocator;
+        readonly ITableNameResolver tableNameResolver;
 
         public DataModificationQueryBuilder(IRelationalStoreConfiguration configuration, Func<DocumentMap, object> keyAllocator)
         {
@@ -34,6 +35,7 @@ namespace Nevermore.Util
             this.serializer = configuration.DocumentSerializer;
             this.configuration = configuration;
             this.keyAllocator = keyAllocator;
+            tableNameResolver = configuration.TableNameResolver;
         }
 
         public CommandParameterValues GetParametersForDocuments(IReadOnlyList<object> documents, InsertOptions options = null)
@@ -569,7 +571,7 @@ namespace Nevermore.Util
                     from m in g
                     from i in documentAndIds
                     from relId in (m.Handler.Read(i.document) as IEnumerable<(string id, Type type)>) ?? new (string id, Type type)[0]
-                    let relatedTableName = mappings.Resolve(relId.type).TableName
+                    let relatedTableName = tableNameResolver.GetTableNameFor(relId.type)
                     select (parentIdVariable: i.idVariable, parentId: i.parentId, relatedDocumentId: relId.id, relatedTableName)
                 ).Distinct().ToArray()
                 select new RelatedDocumentTableData


### PR DESCRIPTION
This PR introduces the `ITableNameResolver` interface and a default implementation. This default implementation attempts to get the table name from the registered document maps. This is consistent with how they're currently retrieved in `DataModificationQueryBuilder`.

`ITableNameResolver` is currently **only** used in the `RelatedDocument`s feature.