### PR TITLE
Make RelationalTransactionRegistry extensible

### DIFF
--- a/source/Nevermore.Tests/RelationalStore/ReadTransactionFixture.cs
+++ b/source/Nevermore.Tests/RelationalStore/ReadTransactionFixture.cs
@@ -29,7 +29,7 @@ namespace Nevermore.Tests.RelationalStore
         [SetUp]
         public void SetUp() // NUnit doesn't create a new instance of the fixture for each test
         {
-            registry = new(new SqlConnectionStringBuilder(FakeConnectionString));
+            registry = new(new SqlConnectionStringBuilder(FakeConnectionString).MaxPoolSize);
             createdConnections.Clear();
         }
 

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using Nevermore.Advanced;
 using Nevermore.Advanced.Hooks;
 using Nevermore.Advanced.InstanceTypeResolvers;
 using Nevermore.Advanced.ReaderStrategies;
@@ -39,6 +40,7 @@ namespace Nevermore
         IRelatedDocumentStore RelatedDocumentStore { get; set; }
         IQueryLogger QueryLogger { get; set; }
         ITransactionLogger TransactionLogger { get; set; }
+        IRelationalTransactionRegistry RelationalTransactionRegistry { get; set; }
 
         /// <summary>
         /// Hooks can be used to apply general logic when documents are inserted, updated or deleted.

--- a/source/Nevermore/RelationalStore.cs
+++ b/source/Nevermore/RelationalStore.cs
@@ -23,8 +23,14 @@ namespace Nevermore
         public RelationalStore(IRelationalStoreConfiguration configuration)
         {
             Configuration = configuration;
-            registry = new Lazy<IRelationalTransactionRegistry>(() => new RelationalTransactionRegistry(new SqlConnectionStringBuilder(configuration.ConnectionString)));
-            keyAllocator = new Lazy<IKeyAllocator>(configuration.KeyAllocatorFactory is not null ? () => configuration.KeyAllocatorFactory() : () => new KeyAllocator(this, configuration.KeyBlockSize));
+            registry = new Lazy<IRelationalTransactionRegistry>(
+                configuration.RelationalTransactionRegistry is not null
+                    ? () => configuration.RelationalTransactionRegistry
+                    : () => new RelationalTransactionRegistry(new SqlConnectionStringBuilder(configuration.ConnectionString).MaxPoolSize));
+            keyAllocator = new Lazy<IKeyAllocator>(
+                configuration.KeyAllocatorFactory is not null
+                    ? () => configuration.KeyAllocatorFactory()
+                    : () => new KeyAllocator(this, configuration.KeyBlockSize));
         }
 
         public void WriteCurrentTransactions(StringBuilder output) => registry.Value.WriteCurrentTransactions(output);

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -89,6 +89,8 @@ namespace Nevermore
 
         public ITransactionLogger TransactionLogger { get; set; }
 
+        public IRelationalTransactionRegistry RelationalTransactionRegistry { get; set; }
+
         public IHookRegistry Hooks { get; }
         public int KeyBlockSize { get; set; }
 


### PR DESCRIPTION
This PR makes it possible to specify a custom `IRelationalTransactionRegistry` via `RelationalStoreConfiguration`.

This PR also makes `RelationalTransactionRegistry.WriteCurrentTransactions` virtual so that you can override Nevermore's implementation to include other useful information.

### Breaking changes

`ConnectionString` and `MaxPoolSize` are no longer exposed by `RelationalTransactionRegistry` as they're duplicates of information already available via `RelationalStoreConfiguration`.

`RelationalTransactionRegistry` now accepts the max SQL connection pool size via its constructor rather than the entire connection string, as that's all it actually needs.