### PR TITLE
Add option to disable concurrency protection

### DIFF
--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -88,5 +88,13 @@ namespace Nevermore
         /// Used to get the table name for a document type. By default, the table name is retrieved from the document map.
         /// </summary>
         ITableNameResolver TableNameResolver { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether concurrent execution of queries is handled by Nevermore. When <value>true</value>, Nevermore will attempt
+        /// to sequence queries issued concurrently.
+        /// 
+        /// The default is <value>true</value>.
+        /// </summary>
+        bool SupportConcurrentExecution { get; set; }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -57,6 +57,7 @@ namespace Nevermore
             TableColumnNameResolver = _ => new SelectAllColumnsTableResolver();
 
             AllowSynchronousOperations = true;
+            SupportConcurrentExecution = true;
 
             QueryLogger = new DefaultQueryLogger();
             TransactionLogger = new DefaultTransactionLogger();
@@ -118,6 +119,8 @@ namespace Nevermore
         public Func<IKeyAllocator> KeyAllocatorFactory { get; set; }
         
         public ITableNameResolver TableNameResolver { get; set; }
+
+        public bool SupportConcurrentExecution { get; set; }
 
         string InitializeConnectionString(string sqlConnectionString)
         {


### PR DESCRIPTION
## Background

[sc-69597]

Nevermore has a feature which allows concurrent queries to be issued to a transaction without the need for MARS to be enabled within SQL Server. It does this by blocking the execution of queries on a semaphore which causes them to be issued to the database server one-at-a-time.

This feature can cause issues in some situations where one query is executed which depends on a previously issued query, creating a deadlock. Nevermore attempts to detect this situation and throw an exception, but cannot always do so reliably.

Currently this feature is on by default, with no option to disable it.

## Result

Add a configuration option `SupportConcurrentExecution` to turn this feature on or off as desired. The default will be on for compatibility.