### PR TITLE
Ensure the SQL connection is always closed when disposing

### DIFF
--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -905,22 +905,27 @@ namespace Nevermore.Advanced
 
         public void Dispose()
         {
-            // ReSharper disable ConstantConditionalAccessQualifier
-            if (OwnsSqlTransaction)
+            try
             {
-                Transaction?.Dispose();
+                // ReSharper disable ConstantConditionalAccessQualifier
+                if (OwnsSqlTransaction)
+                {
+                    Transaction?.Dispose();
+                }
+
+                TransactionTimer?.Dispose();
+                DeadlockAwareLock?.Dispose();
             }
-
-            TransactionTimer?.Dispose();
-            DeadlockAwareLock?.Dispose();
-
-            if (OwnsSqlTransaction)
+            finally
             {
-                connection?.Dispose();
-            }
+                if (OwnsSqlTransaction)
+                {
+                    connection?.Dispose();
+                }
 
-            // ReSharper restore ConstantConditionalAccessQualifier
-            registry.Remove(this);
+                // ReSharper restore ConstantConditionalAccessQualifier
+                registry.Remove(this);
+            }
         }
     }
 }

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -918,13 +918,13 @@ namespace Nevermore.Advanced
             }
             finally
             {
+                // ReSharper restore ConstantConditionalAccessQualifier
+                registry.Remove(this);
+
                 if (OwnsSqlTransaction)
                 {
                     connection?.Dispose();
                 }
-
-                // ReSharper restore ConstantConditionalAccessQualifier
-                registry.Remove(this);
             }
         }
     }


### PR DESCRIPTION
[sc-80865]

Updates `ReadTransaction.Dispose()` to ensure that the SQL connection is disposed, even if the other dispose methods throw an exception.

Addressed https://github.com/OctopusDeploy/Issues/issues/8841