### PR TITLE
Move `OPTIONS` to end in `ToListWithCountAsyncCte`

### DIFF
--- a/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
+++ b/source/Nevermore.Tests/QueryBuilderFixture/QueryBuilderFixture.cs
@@ -1783,6 +1783,7 @@ ORDER BY [RowNum]");
             await CreateQueryBuilder<object>("Orders")
                 .OrderByDescending("LastModified")
                 .Where("Id", UnarySqlOperand.Equal, "1")
+                .Option("RECOMPILE")
                 .ToListWithCountAsync(10, 20);
 
                 query.Should().BeEquivalentTo(@"With ALIAS_GENERATED_1 as (
@@ -1806,7 +1807,8 @@ CROSS JOIN (
     SELECT COUNT(*) AS [CrossJoinCount]
     FROM [ALIAS_GENERATED_1]
 ) ALIAS_GENERATED_4
-ORDER BY ALIAS_GENERATED_3.[RowNum]");
+ORDER BY ALIAS_GENERATED_3.[RowNum]
+OPTION (RECOMPILE)");
 
             parameterValues.Should().HaveCount(3);
             parameterValues["id"].Should().BeEquivalentTo("1");

--- a/source/Nevermore/Advanced/QueryBuilder.cs
+++ b/source/Nevermore/Advanced/QueryBuilder.cs
@@ -461,7 +461,6 @@ namespace Nevermore.Advanced
                 subQueryBuilder.AddDefaultColumnSelection();
                 subQueryBuilder.AddWhere(new UnaryWhereParameter(rowNumberColumnName, UnarySqlOperand.GreaterThanOrEqual, minRowParameter));
                 subQueryBuilder.AddWhere(new UnaryWhereParameter(rowNumberColumnName, UnarySqlOperand.LessThanOrEqual, maxRowParameter));
-                subQueryBuilder.AddOptions(optionClauses);
                 var subQuery = subQueryBuilder.GenerateSelectWithoutDefaultOrderBy();
                 return new SubquerySource(subQuery, tableAliasGenerator.GenerateTableAlias());
             }
@@ -481,6 +480,7 @@ namespace Nevermore.Advanced
                 combinedQueryWithCount.AddDefaultColumnSelection();
                 combinedQueryWithCount.AddColumnSelection(new TableColumn(new Column(totalCountColumnName), innerCountSubQuery.Alias));
                 combinedQueryWithCount.AddOrder(rowNumberColumnName, false);
+                combinedQueryWithCount.AddOptions(optionClauses);
                 return combinedQueryWithCount;
             }
 


### PR DESCRIPTION
When including query hints these cannot be part of a nested query as produced by `ToListWithCountAsyncCte`. This change moves any options set on the query to the end of the generated query.

Previously, the syntax generated was invalid.

An existing unit test for `ToListWithCountAsyncCte` has been updated to include a query hint.