### PR TITLE
Add concurrency warning option for transactions

### DIFF
--- a/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
+++ b/source/Nevermore.Tests/DeadlockAwareLockFixture.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Nevermore.Advanced;
-using Nito.AsyncEx;
 using NUnit.Framework;
 
 namespace Nevermore.Tests
@@ -28,7 +27,7 @@ namespace Nevermore.Tests
         [Test]
         public void MultipleCallsToWait_ShouldThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             deadlockAwareLock.Wait();
 
@@ -42,7 +41,7 @@ namespace Nevermore.Tests
             Task.Run(() =>
                 {
                     // ReSharper disable AccessToDisposedClosure
-                    using var deadlockAwareLock = new DeadlockAwareLock();
+                    using var deadlockAwareLock = new DeadlockAwareLock(false);
 
                     deadlockAwareLock.Wait();
 
@@ -57,7 +56,7 @@ namespace Nevermore.Tests
         [Test]
         public void AcquiringThenReleasingThenAcquiring_ShouldNotThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             deadlockAwareLock.Wait();
             deadlockAwareLock.Release();
@@ -70,7 +69,7 @@ namespace Nevermore.Tests
             Task.Run(() =>
                 {
                     // ReSharper disable AccessToDisposedClosure
-                    using var deadlockAwareLock = new DeadlockAwareLock();
+                    using var deadlockAwareLock = new DeadlockAwareLock(false);
 
                     deadlockAwareLock.Wait();
                     deadlockAwareLock.Release();
@@ -84,7 +83,7 @@ namespace Nevermore.Tests
         [Test]
         public async Task MultipleCallsToWaitAsync_ShouldThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             await deadlockAwareLock.WaitAsync(cancellationToken);
 
@@ -95,7 +94,7 @@ namespace Nevermore.Tests
         [Test]
         public async Task AcquiringAsyncThenReleasingThenAcquiringAsync_ShouldNotThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             await deadlockAwareLock.WaitAsync(cancellationToken);
             deadlockAwareLock.Release();
@@ -106,7 +105,7 @@ namespace Nevermore.Tests
         public async Task MultipleTasksContending_ShouldNotThrow()
         {
             // ReSharper disable AccessToDisposedClosure
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             // Loop so that we increase the probability that two different tasks are scheduled onto
             // the same worker thread. This helps us guarantee that we're not accidentally relying
@@ -136,7 +135,7 @@ namespace Nevermore.Tests
         [Test]
         public void UsingSyncExtensionMethods_AndReleasingLocksCorrectly_ShouldNotThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             using (var _ = deadlockAwareLock.Lock())
             {
@@ -150,7 +149,7 @@ namespace Nevermore.Tests
         [Test]
         public async Task UsingAsyncExtensionMethods_AndReleasingLocksCorrectly_ShouldNotThrow()
         {
-            using var deadlockAwareLock = new DeadlockAwareLock();
+            using var deadlockAwareLock = new DeadlockAwareLock(false);
 
             using (var _ = await deadlockAwareLock.LockAsync(cancellationToken))
             {

--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -23,18 +23,18 @@ namespace Nevermore.Advanced
         int? taskWhichHasAcquiredLock;
         int? threadWhichHasAcquiredLock;
 
-        readonly bool logOnConcurrentExecution;
+        readonly bool logConcurrentExecution;
 
-        public DeadlockAwareLock(bool logOnConcurrentExecution)
+        public DeadlockAwareLock(bool logConcurrentExecution)
         {
-            this.logOnConcurrentExecution = logOnConcurrentExecution;
+            this.logConcurrentExecution = logConcurrentExecution;
         }
 
         public void Wait()
         {
             AssertNoDeadlock();
 
-            if (logOnConcurrentExecution && semaphore.CurrentCount == 0)
+            if (logConcurrentExecution && semaphore.CurrentCount == 0)
             {
                 Log.Warn("Concurrent query execution detected while waiting for lock");
             }
@@ -47,7 +47,7 @@ namespace Nevermore.Advanced
         {
             AssertNoDeadlock();
             
-            if (logOnConcurrentExecution && semaphore.CurrentCount == 0)
+            if (logConcurrentExecution && semaphore.CurrentCount == 0)
             {
                 Log.Warn("Concurrent query execution detected while waiting for lock");
             }

--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -55,7 +55,7 @@ namespace Nevermore.Advanced
             }
             
             await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            RecordLockAcquisition();
+            await RecordLockAcquisitionAsync().ConfigureAwait(false);
         }
 
         public void Release()
@@ -91,6 +91,14 @@ namespace Nevermore.Advanced
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void RecordLockAcquisition()
         {
+            threadWhichHasAcquiredLock = Thread.CurrentThread.ManagedThreadId;
+            taskWhichHasAcquiredLock = Task.CurrentId;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        async Task RecordLockAcquisitionAsync()
+        {
+            await Task.Yield();
             threadWhichHasAcquiredLock = Thread.CurrentThread.ManagedThreadId;
             taskWhichHasAcquiredLock = Task.CurrentId;
         }

--- a/source/Nevermore/Advanced/DeadlockAwareLock.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLock.cs
@@ -34,6 +34,7 @@ namespace Nevermore.Advanced
         {
             AssertNoDeadlock();
 
+            // `SemaphoreSlim` counts down, so if it's 0 then there's a concurrent execution happening.
             if (logConcurrentExecution && semaphore.CurrentCount == 0)
             {
                 Log.Warn("Concurrent query execution detected while waiting for lock");
@@ -47,6 +48,7 @@ namespace Nevermore.Advanced
         {
             AssertNoDeadlock();
             
+            // `SemaphoreSlim` counts down, so if it's 0 then there's a concurrent execution happening.
             if (logConcurrentExecution && semaphore.CurrentCount == 0)
             {
                 Log.Warn("Concurrent query execution detected while waiting for lock");

--- a/source/Nevermore/Advanced/DeadlockAwareLockExtensions.cs
+++ b/source/Nevermore/Advanced/DeadlockAwareLockExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nito.AsyncEx;
+using Nito.Disposables;
+
+namespace Nevermore.Advanced
+{
+    public static class DeadlockAwareLockExtensions
+    {
+        public static IDisposable Lock(this DeadlockAwareLock deadlockAwareLock)
+        {
+            deadlockAwareLock.Wait();
+            return new Disposable(deadlockAwareLock.Release);
+        }
+        
+        static async Task<IDisposable> DoLockAsync(
+            this DeadlockAwareLock deadlockAwareLock,
+            CancellationToken cancellationToken)
+        {
+            await deadlockAwareLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return Disposable.Create(deadlockAwareLock.Release);
+        }
+        
+        public static AwaitableDisposable<IDisposable> LockAsync(
+            this DeadlockAwareLock deadlockAwareLock,
+            CancellationToken cancellationToken)
+        {
+            return new AwaitableDisposable<IDisposable>(DoLockAsync(deadlockAwareLock, cancellationToken));
+        }
+    }
+}

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -19,7 +19,6 @@ using Nevermore.Diagnostics;
 using Nevermore.Querying.AST;
 using Nevermore.TableColumnNameResolvers;
 using Nevermore.Transient;
-using Nito.AsyncEx;
 using Nito.Disposables;
 
 namespace Nevermore.Advanced
@@ -44,7 +43,7 @@ namespace Nevermore.Advanced
         DbConnection? connection;
 
         protected IUniqueParameterNameGenerator ParameterNameGenerator { get; } = new UniqueParameterNameGenerator();
-        protected DeadlockAwareLock DeadlockAwareLock { get; } = new();
+        protected DeadlockAwareLock DeadlockAwareLock { get; }
 
         // To help track deadlocks
         readonly List<string> commandTrace;
@@ -104,6 +103,8 @@ namespace Nevermore.Advanced
             this.configuration = configuration;
             this.customCommandTrace = customCommandTrace;
             commandTrace = new List<string>();
+
+            DeadlockAwareLock = new DeadlockAwareLock(configuration.LogOnConcurrentExecution);
 
             var transactionName = name ?? Thread.CurrentThread.Name;
 

--- a/source/Nevermore/Advanced/ReadTransaction.cs
+++ b/source/Nevermore/Advanced/ReadTransaction.cs
@@ -104,7 +104,7 @@ namespace Nevermore.Advanced
             this.customCommandTrace = customCommandTrace;
             commandTrace = new List<string>();
 
-            DeadlockAwareLock = new DeadlockAwareLock(configuration.LogOnConcurrentExecution);
+            DeadlockAwareLock = new DeadlockAwareLock(configuration.LogConcurrentExecution);
 
             var transactionName = name ?? Thread.CurrentThread.Name;
 

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -103,6 +103,6 @@ namespace Nevermore
         ///
         /// The default is <c>false</c>.
         /// </summary>
-        public bool LogOnConcurrentExecution { get; set; }
+        public bool LogConcurrentExecution { get; set; }
     }
 }

--- a/source/Nevermore/IRelationalStoreConfiguration.cs
+++ b/source/Nevermore/IRelationalStoreConfiguration.cs
@@ -90,11 +90,19 @@ namespace Nevermore
         ITableNameResolver TableNameResolver { get; set; }
 
         /// <summary>
-        /// Gets or sets whether concurrent execution of queries is handled by Nevermore. When <value>true</value>, Nevermore will attempt
+        /// Gets or sets whether concurrent execution of queries is handled by Nevermore. When <c>true</c>, Nevermore will attempt
         /// to sequence queries issued concurrently.
         /// 
-        /// The default is <value>true</value>.
+        /// The default is <c>true</c>.
         /// </summary>
         bool SupportConcurrentExecution { get; set; }
+        
+        /// <summary>
+        /// Gets or sets whether a warning log should be emitted when concurrent execution is detected. Does not function unless
+        /// <see cref="SupportConcurrentExecution"/> is set to <c>true</c>
+        ///
+        /// The default is <c>false</c>.
+        /// </summary>
+        public bool LogOnConcurrentExecution { get; set; }
     }
 }

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -121,6 +121,8 @@ namespace Nevermore
         public ITableNameResolver TableNameResolver { get; set; }
 
         public bool SupportConcurrentExecution { get; set; }
+        
+        public bool LogOnConcurrentExecution { get; set; }
 
         string InitializeConnectionString(string sqlConnectionString)
         {

--- a/source/Nevermore/RelationalStoreConfiguration.cs
+++ b/source/Nevermore/RelationalStoreConfiguration.cs
@@ -122,7 +122,7 @@ namespace Nevermore
 
         public bool SupportConcurrentExecution { get; set; }
         
-        public bool LogOnConcurrentExecution { get; set; }
+        public bool LogConcurrentExecution { get; set; }
 
         string InitializeConnectionString(string sqlConnectionString)
         {


### PR DESCRIPTION
Currently, there is no clear way to determine if a transaction is attempting to run multiple queries "concurrently".

This PR adds a new `LogOnConcurrentExecution` parameter to the `RelationalStoreConfiguration`, which log warnings when multiple concurrent queries are run in a `ReadTransaction` or `WriteTransaction`.

This PR also removes the `SemaphoreSlim` inheritance of `DeadlockAwareLock`, as it hid the fact that `SemaphoreSlim` extension methods were calling the base implementations instead of the overridden ones.