### PR TITLE
Pin FluentAssertions to v7

### DIFF
--- a/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
+++ b/source/Nevermore.Analyzers.Tests/Nevermore.Analyzers.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
     </ItemGroup>
 

--- a/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
+++ b/source/Nevermore.IntegrationTests/Nevermore.IntegrationTests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/source/Nevermore.Tests/Nevermore.Tests.csproj
+++ b/source/Nevermore.Tests/Nevermore.Tests.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
     <PackageReference Include="Assent" Version="1.8.2" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
[sc-101162]

FluentAssertions v8 changes to a non-open-source license; Commercial Use requires a paid subscription at $129 USD per developer per year.

This PR pins the version of FluentAssertions to 7.1.0.